### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,8 +336,8 @@ function Argv (processArgs, cwd) {
                     : null
                 ,
                 options.default[key] !== undefined
-                    ? '[default: ' + (typeof defaults[key] === 'string' ?
-                    JSON.stringify : String)(defaults[key]) + ']'
+                    ? '[default: ' + (typeof options.default[key] === 'string' ?
+                    JSON.stringify : String)(options.default[key]) + ']'
                     : null
             ].filter(Boolean).join('  ');
             


### PR DESCRIPTION
When check() fails a error occurs. It seems to be fixed with this small change. Unit tests would be good ...

ReferenceError: defaults is not defined
    at /Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:339:46
    at Array.forEach (native)
    at Object.Argv.self.help (/Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:302:14)
    at Object.Argv.self.showHelp (/Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:241:17)
    at fail (/Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:168:18)
    at /Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:420:17
    at Array.forEach (native)
    at parseArgs (/Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:410:16)
    at Object.Argv.Object.defineProperty.get [as argv](/Users/heideggermartin/IdeaProjects/mapslice/node_modules/yargs/index.js:368:36)
    at Object.<anonymous> (/Users/heideggermartin/IdeaProjects/mapslice/bin/mapslice:24:46)
