### PR TITLE
For "--option-name", also set argv.optionName

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -51,6 +51,15 @@ module.exports = function (args, opts) {
     }
 
     function setArg (key, val) {
+        if (/-/.test(key)) {
+            // For "--option-name", also set argv.optionName
+            setArg(
+                key.split('-').map(function(word, i) {
+                    return (i ? word[0].toUpperCase() + word.slice(1) : word);
+                }).join(''),
+                val);
+        }
+
         var value = !flags.strings[key] && isNumber(val) ? Number(val) : val;
 
         if (flags.counts[key] || flags.counts[aliases[key]]) {


### PR DESCRIPTION
I think `argv.optionName` is cleaner and more idiomatic than `argv['option-name']`.
