### PR TITLE
Fix tests

### DIFF
--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -1,13 +1,3 @@
-var optimist = require('../');
-var test = require('tap').test;
-
-test('whitespace should be whitespace' , function (t) {
-    t.plan(1);
-    var x = optimist.parse([ '-x', '\t' ]).x;
-    t.equal(x, '\t');
-});
-
-
 var should = require('chai').should(),
     yargs = require('../');
 


### PR DESCRIPTION
It looks like `test/whitespace.js` had some old code that still referred to the `tap` module.  After this fix, tests work correctly for me using mocha.
