### PR TITLE
For "--some-option", also set argv.someOption

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -29,6 +29,15 @@ module.exports = function (args, opts) {
     var aliases = {};
     Object.keys(opts.alias || {}).forEach(function (key) {
         aliases[key] = [].concat(opts.alias[key]);
+        // For "--option-name", also set argv.optionName
+        aliases[key].concat(key).forEach(function (x) {
+            if (/-/.test(x)) {
+                aliases[key].push(
+                    x.split('-').map(function(word, i) {
+                        return (i ? word[0].toUpperCase() + word.slice(1) : word);
+                    }).join(''));
+            }
+        });
         aliases[key].forEach(function (x) {
             aliases[x] = [key].concat(aliases[key].filter(function (y) {
                 return x !== y;

--- a/test/parse_camelCase.js
+++ b/test/parse_camelCase.js
@@ -1,0 +1,31 @@
+var should = require('chai').should(),
+    yargs = require('../');
+
+describe('parse', function () {
+
+    describe('dashes and camelCase', function () {
+
+        it('should provide options with dashes as camelCase properties', function () {
+            var result = yargs()
+                .option('some-option', {
+                    alias    : 'o',
+                    describe : 'some option'
+                })
+                .parse([ '--some-option' ]);
+
+            result.should.have.property('someOption').that.is.a('boolean').and.is.true;
+        });
+
+        it('should provide aliases with dashes as camelCase properties', function() {
+            var result = yargs()
+                .option('o', {
+                    alias    : 'some-option',
+                    describe : 'some option'
+                })
+                .parse([ '--some-option', 'val' ]);
+
+            result.should.have.property('someOption').that.is.a('string').and.equals('val');
+        });
+    });
+
+});


### PR DESCRIPTION
I think `argv.someOption` is cleaner and more idiomatic than `argv['some-option']`.  Tests will pass if you merge #5.
