### PR TITLE
Fix dashes-to-camelCase for options with no aliases

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -26,16 +26,19 @@ module.exports = function (args, opts) {
         flags.configs[key] = true;
     });
 
+    function toCamelCase(str) {
+        return str.split('-').map(function(word, i) {
+            return (i ? word[0].toUpperCase() + word.slice(1) : word);
+        }).join('');
+    }
+
     var aliases = {};
     Object.keys(opts.alias || {}).forEach(function (key) {
         aliases[key] = [].concat(opts.alias[key]);
         // For "--option-name", also set argv.optionName
         aliases[key].concat(key).forEach(function (x) {
             if (/-/.test(x)) {
-                aliases[key].push(
-                    x.split('-').map(function(word, i) {
-                        return (i ? word[0].toUpperCase() + word.slice(1) : word);
-                    }).join(''));
+                aliases[key].push(toCamelCase(x));
             }
         });
         aliases[key].forEach(function (x) {
@@ -60,6 +63,10 @@ module.exports = function (args, opts) {
     }
 
     function setArg (key, val) {
+        if (/-/.test(key) && !(aliases[key] && aliases[key].length)) {
+            aliases[key] = [toCamelCase(key)];
+        }
+
         var value = !flags.strings[key] && isNumber(val) ? Number(val) : val;
 
         if (flags.counts[key] || flags.counts[aliases[key]]) {

--- a/test/parse_camelCase.js
+++ b/test/parse_camelCase.js
@@ -7,6 +7,24 @@ describe('parse', function () {
 
         it('should provide options with dashes as camelCase properties', function () {
             var result = yargs()
+                .parse([ '--some-option' ]);
+
+            result.should.have.property('someOption').that.is.a('boolean').and.is.true;
+        });
+
+        it('should provide count options with dashes as camelCase properties', function () {
+            var result = yargs()
+                .option('some-option', {
+                    describe : 'some option',
+                    type     : 'count'
+                })
+                .parse([ '--some-option', '--some-option', '--some-option' ]);
+
+            result.should.have.property('someOption', 3);
+        });
+
+        it('should provide options with dashes and aliases as camelCase properties', function () {
+            var result = yargs()
                 .option('some-option', {
                     alias    : 'o',
                     describe : 'some option'


### PR DESCRIPTION
Found a bug in the new feature I added in #6.  Before this change, setting `argv.someOption` from `--some-option` only worked if that option had some aliases.
