### PR TITLE
Correcting an example in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ demand_count.js:
 ````javascript
 #!/usr/bin/env node
 var argv = require('yargs')
-    .demandCount(2)
+    .demand(2)
     .argv;
 console.dir(argv)
 ````


### PR DESCRIPTION
The function `demandCount` doesn't exist. It shoud be `demand`.
