### PR TITLE
Added .strict() method, to report error if unknown arguments are given

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,12 @@ is loaded and parsed, and its properties are set as arguments.
 
 Format usage output to wrap at `columns` many columns.
 
+.strict()
+---------
+
+Any command-line argument given that is not demanded, or does not have a
+corresponding description, will be reported as an error.
+
 .help()
 -------
 

--- a/example/strict.js
+++ b/example/strict.js
@@ -1,0 +1,19 @@
+var yargs = require('yargs');
+
+var argv = yargs.usage('This is my awesome program', {
+  'about': {
+    description: 'Provide some details about the author of this program',
+    boolean: true,
+    short: 'a',
+  },
+  'info': {
+    description: 'Provide some information about this program',
+    boolean: true,
+    short: 'i'
+  }
+}).strict().argv;
+
+yargs.showHelp();
+
+console.log('\n\nInspecting options');
+console.dir(argv);

--- a/index.js
+++ b/index.js
@@ -235,6 +235,12 @@ function Argv (processArgs, cwd) {
         wrap = cols;
         return self;
     };
+
+    var strict = false;
+    self.strict = function () {
+        strict = true;
+        return self;
+    };
     
     self.showHelp = function (fn) {
         if (!fn) fn = console.error.bind(console);
@@ -406,7 +412,35 @@ function Argv (processArgs, cwd) {
 
             fail('Missing required arguments: ' + Object.keys(missing).join(', ') + customMsg);
         }
-        
+
+        if (strict) {
+            var unknown = [];
+
+            var aliases = {};
+
+            Object.keys(options.alias).forEach(function (key) {
+                options.alias[key].forEach(function (alias) {
+                    aliases[alias] = key;
+                });
+            });
+
+            Object.keys(argv).forEach(function (key) {
+                if (key !== "$0" && key !== "_" &&
+                    !descriptions.hasOwnProperty(key) &&
+                    !demanded.hasOwnProperty(key) &&
+                    !aliases.hasOwnProperty(key)) {
+                    unknown.push(key);
+                }
+            });
+
+            if (unknown.length == 1) {
+                fail("Unknown argument: " + unknown[0]);
+            }
+            else if (unknown.length > 1) {
+                fail("Unknown arguments: " + unknown.join(", "));
+            }
+        }
+
         checks.forEach(function (f) {
             try {
                 var result = f(argv, aliases);

--- a/test/usage.js
+++ b/test/usage.js
@@ -290,6 +290,127 @@ describe('usage', function () {
         r.result.should.have.property('quux', 30);
     });
 
+    context("with strict() option set", function () {
+        it('should fail given an option argument that is not demanded', function () {
+            var r = checkUsage(function () {
+                opts = {
+                    foo: { demand: 'foo option', alias: 'f' },
+                    bar: { demand: 'bar option', alias: 'b' }
+                };
+
+                return yargs('-f 10 --bar 20 --baz 30'.split(' '))
+                    .usage('Usage: $0 [options]', opts)
+                    .strict()
+                    .argv;
+            });
+
+            r.should.have.property('result');
+            r.result.should.have.property('_').with.length(0);
+            r.result.should.have.property('f', 10);
+            r.result.should.have.property('foo', 10);
+            r.result.should.have.property('b', 20);
+            r.result.should.have.property('bar', 20);
+            r.result.should.have.property('baz', 30);
+            r.should.have.property('errors');
+            r.errors.join('\n').split(/\n+/).should.deep.equal([
+                'Usage: ./usage [options]',
+                'Options:',
+                '  --foo, -f  [required]',
+                '  --bar, -b  [required]',
+                'Unknown argument: baz',
+            ]);
+            r.should.have.property('logs').with.length(0);
+            r.should.have.property('exit').and.be.ok;
+        });
+
+        it('should fail given an option argument without a corresponding description', function () {
+            var r = checkUsage(function () {
+                opts = {
+                    foo: { description: 'foo option', alias: 'f' },
+                    bar: { description: 'bar option', alias: 'b' }
+                };
+
+                return yargs('-f 10 --bar 20 --baz 30'.split(' '))
+                    .usage('Usage: $0 [options]', opts)
+                    .strict()
+                    .argv;
+            });
+
+            r.should.have.property('result');
+            r.result.should.have.property('_').with.length(0);
+            r.result.should.have.property('f', 10);
+            r.result.should.have.property('foo', 10);
+            r.result.should.have.property('b', 20);
+            r.result.should.have.property('bar', 20);
+            r.result.should.have.property('baz', 30);
+            r.should.have.property('errors');
+            r.errors.join('\n').split(/\n+/).should.deep.equal([
+                'Usage: ./usage [options]',
+                'Options:',
+                '  --foo, -f  foo option',
+                '  --bar, -b  bar option',
+                'Unknown argument: baz',
+            ]);
+            r.should.have.property('logs').with.length(0);
+            r.should.have.property('exit').and.be.ok;
+        });
+
+        it('should fail given multiple option arguments without corresponding descriptions', function () {
+            var r = checkUsage(function () {
+                opts = {
+                    foo: { description: 'foo option', alias: 'f' },
+                    bar: { description: 'bar option', alias: 'b' }
+                };
+
+                return yargs('-f 10 --bar 20 --baz 30 -q 40'.split(' '))
+                    .usage('Usage: $0 [options]', opts)
+                    .strict()
+                    .argv;
+            });
+
+            r.should.have.property('result');
+            r.result.should.have.property('_').with.length(0);
+            r.result.should.have.property('f', 10);
+            r.result.should.have.property('foo', 10);
+            r.result.should.have.property('b', 20);
+            r.result.should.have.property('bar', 20);
+            r.result.should.have.property('baz', 30);
+            r.result.should.have.property('q', 40);
+            r.should.have.property('errors');
+            r.errors.join('\n').split(/\n+/).should.deep.equal([
+                'Usage: ./usage [options]',
+                'Options:',
+                '  --foo, -f  foo option',
+                '  --bar, -b  bar option',
+                'Unknown arguments: baz, q',
+            ]);
+            r.should.have.property('logs').with.length(0);
+            r.should.have.property('exit').and.be.ok;
+        });
+
+        it('should pass given option arguments with corresponding descriptions', function () {
+            var r = checkUsage(function () {
+                opts = {
+                    foo: { description: 'foo option' },
+                    bar: { description: 'bar option' }
+                };
+
+                return yargs('--foo 10 --bar 20'.split(' '))
+                    .usage('Usage: $0 [options]', opts)
+                    .strict()
+                    .argv;
+            });
+
+            r.should.have.property('result');
+            r.result.should.have.property('foo', 10);
+            r.result.should.have.property('bar', 20)
+            r.result.should.have.property('_').with.length(0);
+            r.should.have.property('errors').with.length(0);
+            r.should.have.property('logs').with.length(0);
+            r.should.have.property('exit', false);
+        });
+    });
+
     it('should display example on fail', function () {
         var r = checkUsage(function () {
             return yargs('')


### PR DESCRIPTION
This adds a new method,`.strict()`, which causes yargs to report an error if any unknown command line option arguments are given (i.e., any options not defined with `.describe()` or `.demand()`).
