### PR TITLE
Remove unneeded dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.2.6",
   "description": "Light-weight option parsing with an argv hash. No optstrings attached.",
   "main": "./index.js",
-  "dependencies": {
-    "minimist": "^0.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "hashish": "*",
     "mocha": "*",


### PR DESCRIPTION
The dependency on `minimist` is not used anywhere in the code (we bundle our own version).
