### PR TITLE
Corrected interaction between .strict() and .check()

### DIFF
--- a/index.js
+++ b/index.js
@@ -610,14 +610,6 @@ function Argv (processArgs, cwd) {
         else if (unknown.length > 1) {
             fail("Unknown arguments: " + unknown.join(", "));
         }
-
-        Object.keys(argv).forEach(function (key) {
-            if (key !== "$0" && key !== "_" &&
-                !optionAliases.hasOwnProperty(key) &&
-                Array.isArray(argv[key])) {
-                fail("Repeated option: " + key);
-            }
-        });
     }
     
     function longest (xs) {


### PR DESCRIPTION
The handling of `.strict()` has an error where the `aliases` variable is overwritten, causing the arguments passed to any registered `.check()` functions to be different than previous versions. This change corrects the problem by extracting the strict handling code into a separate function.
