### PR TITLE
version output will not print extra newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,7 +457,7 @@ function Argv (processArgs, cwd) {
                 process.exit(0);
             }
             else if (key === versionOpt) {
-                console.log(version);
+                process.stdout.write(version);
                 process.exit(0);
             }
         });

--- a/test/usage.js
+++ b/test/usage.js
@@ -714,10 +714,12 @@ describe('usage', function () {
         process._exit = process.exit;
         process._env = process.env;
         process._argv = process.argv;
+        process.stdout._write = process.stdout.write;
 
         process.exit = function () { exit = true };
         process.env = Hash.merge(process.env, { _ : 'node' });
         process.argv = [ './usage' ];
+        process.stdout.write = function (msg) { logs.push(msg) };
 
         var errors = [];
         var logs = [];
@@ -732,6 +734,7 @@ describe('usage', function () {
         process.exit = process._exit;
         process.env = process._env;
         process.argv = process._argv;
+        process.stdout.write = process.stdout._write;
 
         console.error = console._error;
         console.log = console._log;


### PR DESCRIPTION
This is fussy of me, but the version output may be easier to programmatically consume if `process.stdout.write()` was used instead of `console.log()`, which will throw an extra newline at the end.
