### PR TITLE
Disable process.exit calls using .exitProcess(false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,11 @@ yargs.showHelp();
 
 Later on, ```argv``` can be retrived with ```yargs.argv```
 
+.exitProcess(enable)
+----------------------------------
+
+By default, yargs exits the process when the user passes a help flag, uses the `.version` functionality or when validation fails. Calling `.exitProcess(false)` disables this behavior, enabling further actions after yargs have been validated.
+
 .parse(args)
 ------------
 

--- a/index.js
+++ b/index.js
@@ -186,7 +186,11 @@ function Argv (processArgs, cwd) {
                 }
                 console.error(failMessage);
             }
-            process.exit(1);
+            if (exitProcess){
+                process.exit(1);
+            }else{
+              throw new Error(msg);
+            }
         }
     }
     
@@ -306,7 +310,15 @@ function Argv (processArgs, cwd) {
         showHelpOnFail = enabled;
         return self;
     };
-
+    
+    var exitProcess = true;
+    self.exitProcess = function (enabled) {
+        if (typeof enabled !== 'boolean') {
+            enabled = true;
+        }
+        exitProcess = enabled;
+        return self;
+    };
 
     self.help = function () {
         if (arguments.length > 0) {
@@ -459,11 +471,15 @@ function Argv (processArgs, cwd) {
         Object.keys(argv).forEach(function(key) {
             if (key === helpOpt) {
                 self.showHelp(console.log);
-                process.exit(0);
+                if (exitProcess){
+                    process.exit(0);
+                }
             }
             else if (key === versionOpt) {
                 process.stdout.write(version);
-                process.exit(0);
+                if (exitProcess){
+                    process.exit(0);
+                }
             }
         });
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -723,6 +723,28 @@ describe('usage', function () {
             ]);
         });
     });
+    
+    describe('exitProcess', function () {
+        it('should not call process.exit on error if disabled', function () {
+            var opts = {
+                foo: { desc: 'foo option', alias: 'f' },
+            };
+
+            var r = checkUsage(function () {
+                return yargs(['--foo'])
+                    .exitProcess(false)
+                    .usage('Usage: $0 [options]')
+                    .options(opts)
+                    .demand(['foo'])
+                    .argv;
+            });
+            r.should.have.property('result');
+            r.result.should.have.property('_').with.length(0);
+            r.should.have.property('errors');
+            r.should.have.property('logs').with.length(0);
+            r.should.have.property('exit').and.be.false;
+        });
+    });
 
     it('should succeed when rebase', function () {
         yargs.rebase('/home/chevex', '/home/chevex/foo/bar/baz').should.equal('./foo/bar/baz');


### PR DESCRIPTION
I'm writing a CLI that can also be `require()`'d as a node module. I also handle errors generically thru a callback. 
The `process.exit` calls were proving problematic, so here's how I solved it.  
Includes:
-`README.md` entry
-Test Coverage

Let me know if there's any semantic changes you'd like - I've tried to follow your conventions as best possible. 
Also - feel free to toss this if it's something you'd rather not have in yargs core :-)
