### PR TITLE
keys added to argv multiple times, when creating camel-case aliases

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -41,12 +41,8 @@ module.exports = function (args, opts) {
         aliases[key].concat(key).forEach(function (x) {
             if (/-/.test(x)) {
                 var c = toCamelCase(x);
-                // ensure we don't add the same alias multiple
-                // times while camel-casing.
-                if (opts.alias[x] || !opts.default[c]) {
-                  aliases[key].push(c);
-                  newAliases[c] = true;
-                }
+                aliases[key].push(c);
+                newAliases[c] = true;
             }
         });
         aliases[key].forEach(function (x) {
@@ -61,8 +57,12 @@ module.exports = function (args, opts) {
     Object.keys(defaults || {}).forEach(function (key) {
         if (/-/.test(key) && !opts.alias[key]) {
             var c = toCamelCase(key);
-            aliases[key] = (aliases[key] || []).concat(c);
-            newAliases[c] = true;
+            aliases[key] = aliases[key] || [];
+            // don't allow the same key to be added multiple times.
+            if (aliases[key].indexOf(c) === -1) {
+                aliases[key] = (aliases[key] || []).concat(c);
+                newAliases[c] = true;
+            }
         }
         (aliases[key] || []).forEach(function (alias) {
             defaults[alias] = defaults[key];

--- a/test/parse.js
+++ b/test/parse.js
@@ -353,23 +353,37 @@ describe('parse', function () {
     });
 
     // regression, see https://github.com/chevex/yargs/issues/63
-    it('should not add alias multiple times to argv, if argv is called multiple times', function() {
-      var yargs = require('../')(['--health-check=/banana', '--second-key', '/apple'])
+    it('should not add the same key to argv multiple times, when creating camel-case aliases', function() {
+      var yargs = require('../')(['--health-check=banana', '--second-key', 'apple', '-t=blarg'])
           .options('h', {
             alias: 'health-check',
             description: 'health check',
-            default: '/apple'
+            default: 'apple'
           })
           .options('second-key', {
             alias: 's',
             description: 'second key',
-            default: '/banana'
-          });
+            default: 'banana'
+          })
+          .options('third-key', {
+            alias: 't',
+            description: 'third key',
+            default: 'third'
+          })
 
-      yargs.argv;
+      // before this fix, yargs failed parsing
+      // one but not all forms of an arg.
+      yargs.argv.secondKey.should.eql('apple');
+      yargs.argv.s.should.eql('apple');
+      yargs.argv['second-key'].should.eql('apple');
 
-      yargs.argv.secondKey.should.eql('/apple');
-      yargs.argv.healthCheck.should.eql('/banana');
+      yargs.argv.healthCheck.should.eql('banana');
+      yargs.argv.h.should.eql('banana');
+      yargs.argv['health-check'].should.eql('banana');
+
+      yargs.argv.thirdKey.should.eql('blarg');
+      yargs.argv.t.should.eql('blarg');
+      yargs.argv['third-key'].should.eql('blarg');
     });
 
 });


### PR DESCRIPTION
Creating aliases that have the camel-case parsing logic applied to them results in an array of values being populated in `yargs.argv.camelCase` rather than a variable.

Fixes #63 
