### PR TITLE
Parser bug testcase

### DIFF
--- a/test/fixtures/opt-assignment-and-positional-command-arg.js
+++ b/test/fixtures/opt-assignment-and-positional-command-arg.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+require('../../index')
+  .option('foo', {
+    nargs: 1,
+  })
+  .command(
+    'bar <baz>',
+    'example',
+    function (yargs) { return yargs },
+    function (argv) {
+      console.log(JSON.stringify({ _: argv._, foo: argv.foo, baz: argv.baz }))
+    }
+  )
+  .argv

--- a/test/integration.js
+++ b/test/integration.js
@@ -11,42 +11,47 @@ require('chai').should()
 
 describe('integration tests', function () {
   it('should run as a shell script with no arguments', function (done) {
-    testCmd('./bin.js', [], done)
+    testArgs('./bin.js', [], done)
   })
 
   it('should run as a shell script with arguments', function (done) {
-    testCmd('./bin.js', [ 'a', 'b', 'c' ], done)
+    testArgs('./bin.js', [ 'a', 'b', 'c' ], done)
   })
 
   it('should run as a node script with no arguments', function (done) {
-    testCmd('node bin.js', [], done)
+    testArgs('node bin.js', [], done)
   })
 
   it('should run as a node script with arguments', function (done) {
-    testCmd('node bin.js', [ 'x', 'y', 'z' ], done)
+    testArgs('node bin.js', [ 'x', 'y', 'z' ], done)
   })
 
   describe('path returned by "which"', function () {
     it('should match the actual path to the script file', function (done) {
       which('node', function (err, path) {
         if (err) return done(err)
-        testCmd(path.replace('Program Files', 'Progra~1') + ' bin.js', [], done)
+        testArgs(path.replace('Program Files', 'Progra~1') + ' bin.js', [], done)
       })
     })
 
     it('should match the actual path to the script file, with arguments', function (done) {
       which('node', function (err, path) {
         if (err) return done(err)
-        testCmd(path.replace('Program Files', 'Progra~1') + ' bin.js', [ 'q', 'r' ], done)
+        testArgs(path.replace('Program Files', 'Progra~1') + ' bin.js', [ 'q', 'r' ], done)
       })
     })
   })
 
   // see #177
   it('allows --help to be completed without returning help message', function (done) {
-    testCmd('./bin.js', [ '--get-yargs-completions', '--help' ], function (buf) {
-      buf.should.not.match(/generate bash completion script/)
-      buf.should.match(/--help/)
+    testCmd('./bin.js', [ '--get-yargs-completions', '--help' ], function (code, stdout) {
+      if (code) {
+        done(new Error('cmd exited with code ' + code))
+        return
+      }
+
+      stdout.should.not.match(/generate bash completion script/)
+      stdout.should.match(/--help/)
       return done()
     })
   })
@@ -68,15 +73,23 @@ describe('integration tests', function () {
 
       describe('version #', function () {
         it('defaults to appropriate version # when yargs is installed normally', function (done) {
-          testCmd('./normal-bin.js', [ '--version' ], function (buf) {
-            buf.should.match(/9\.9\.9/)
+          testCmd('./normal-bin.js', [ '--version' ], function (code, stdout) {
+            if (code) {
+              return done(new Error('cmd exited with code ' + code))
+            }
+
+            stdout.should.match(/9\.9\.9/)
             return done()
           })
         })
 
         it('defaults to appropriate version # when yargs is symlinked', function (done) {
-          testCmd('./symlink-bin.js', [ '--version' ], function (buf) {
-            buf.should.match(/9\.9\.9/)
+          testCmd('./symlink-bin.js', [ '--version' ], function (code, stdout) {
+            if (code) {
+              return done(new Error('cmd exited with code ' + code))
+            }
+
+            stdout.should.match(/9\.9\.9/)
             return done()
           })
         })
@@ -84,15 +97,23 @@ describe('integration tests', function () {
 
       describe('parser settings', function (done) {
         it('reads parser config settings when yargs is installed normally', function (done) {
-          testCmd('./normal-bin.js', [ '--foo.bar' ], function (buf) {
-            buf.should.match(/foo\.bar/)
+          testCmd('./normal-bin.js', [ '--foo.bar' ], function (code, stdout) {
+            if (code) {
+              return done(new Error('cmd exited with code ' + code))
+            }
+
+            stdout.should.match(/foo\.bar/)
             return done()
           })
         })
 
         it('reads parser config settings when yargs is installed as a symlink', function (done) {
-          testCmd('./symlink-bin.js', [ '--foo.bar' ], function (buf) {
-            buf.should.match(/foo\.bar/)
+          testCmd('./symlink-bin.js', [ '--foo.bar' ], function (code, stdout) {
+            if (code) {
+              return done(new Error('cmd exited with code ' + code))
+            }
+
+            stdout.should.match(/foo\.bar/)
             return done()
           })
         })
@@ -106,7 +127,7 @@ describe('integration tests', function () {
   }
 })
 
-function testCmd (cmd, args, done) {
+function testCmd (cmd, args, cb) {
   var oldDir = process.cwd()
   process.chdir(path.join(__dirname, '/fixtures'))
 
@@ -115,15 +136,23 @@ function testCmd (cmd, args, done) {
   var bin = spawn(cmds[0], cmds.slice(1).concat(args.map(String)))
   process.chdir(oldDir)
 
-  bin.stderr.on('data', done)
+  var stdout = ''
+  bin.stdout.setEncoding('utf8')
+  bin.stdout.on('data', function (str) { stdout += str })
 
-  bin.stdout.on('data', function (buf) {
-    // hack to allow us to assert against completion suggestions.
-    if (~args.indexOf('--get-yargs-completions') ||
-      ~args.indexOf('--version') ||
-      ~args.indexOf('--foo.bar')) return done(buf.toString())
+  bin.on('exit', function (code) {
+    cb(code, stdout)
+  })
+}
 
-    var _ = JSON.parse(buf.toString())
+function testArgs (cmd, args, done) {
+  testCmd(cmd, args, function (code, stdout) {
+    if (code) {
+      done(new Error('cmd exited with code ' + code))
+      return
+    }
+
+    var _ = JSON.parse(stdout)
     _.map(String).should.deep.equal(args.map(String))
     done()
   })

--- a/test/integration.js
+++ b/test/integration.js
@@ -56,6 +56,36 @@ describe('integration tests', function () {
     })
   })
 
+  it('correctly fills positional command args with preceding option', function (done) {
+    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo', 'fOo', 'bar', 'bAz'], function (code, stdout) {
+      if (code) {
+        done(new Error('cmd exited with code ' + code))
+        return
+      }
+
+      var argv = JSON.parse(stdout)
+      argv._.should.deep.equal(['bar'])
+      argv.foo.should.equal('fOo')
+      argv.baz.should.equal('bAz')
+      return done()
+    })
+  })
+
+  it('correctly fills positional command args with = assignment in preceding option', function (done) {
+    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo=fOo', 'bar', 'bAz'], function (code, stdout) {
+      if (code) {
+        done(new Error('cmd exited with code ' + code))
+        return
+      }
+
+      var argv = JSON.parse(stdout)
+      argv._.should.deep.equal(['bar'])
+      argv.foo.should.equal('fOo')
+      argv.baz.should.equal('bAz')
+      return done()
+    })
+  })
+
   if (process.platform !== 'win32') {
     describe('load root package.json', function () {
       before(function (done) {


### PR DESCRIPTION
Test case for #396. Notice that the case with `'--foo=fOo'` fails, but the case with `'--foo', 'fOo'` passes.