### PR TITLE
Fix unintentional command execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -616,7 +616,7 @@ function Argv (processArgs, cwd) {
 
     // if there's a handler associated with a
     // command defer processing to it.
-    var handlerKeys = command.getCommands()
+    var handlerKeys = command.getCommandsWithHandlers()
     for (var i = 0, cmd; (cmd = handlerKeys[i]) !== undefined; i++) {
       if (~argv._.indexOf(cmd) && cmd !== completionCommand) {
         setPlaceholderKeys(argv)

--- a/index.js
+++ b/index.js
@@ -616,11 +616,12 @@ function Argv (processArgs, cwd) {
 
     // if there's a handler associated with a
     // command defer processing to it.
-    var handlerKeys = command.getCommandsWithHandlers()
+    var handlerKeys = command.getCommands()
     for (var i = 0, cmd; (cmd = handlerKeys[i]) !== undefined; i++) {
       if (~argv._.indexOf(cmd) && cmd !== completionCommand) {
         setPlaceholderKeys(argv)
-        return command.runCommand(cmd, self, parsed)
+        command.runCommand(cmd, self, parsed)
+        if (command.hasHandlerFunction(cmd)) return
       }
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -48,10 +48,12 @@ module.exports = function (yargs, usage, validation) {
     return Object.keys(handlers)
   }
 
-  self.getCommandsWithHandlers = function () {
-    return Object.keys(handlers).filter(function (value) {
-      return handlers[value].handler
-    })
+  self.hasHandlerFunction = function (cmd) {
+    if (typeof handlers[cmd] !== 'undefined') {
+      return !!handlers[cmd].handler
+    } else {
+      return false
+    }
   }
 
   self.getCommandHandlers = function () {

--- a/lib/command.js
+++ b/lib/command.js
@@ -48,6 +48,12 @@ module.exports = function (yargs, usage, validation) {
     return Object.keys(handlers)
   }
 
+  self.getCommandsWithHandlers = function () {
+    return Object.keys(handlers).filter(function (value) {
+      return handlers[value].handler
+    })
+  }
+
   self.getCommandHandlers = function () {
     return handlers
   }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -269,6 +269,22 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
+    it('only runs commands if handler is defined', function () {
+      var r = checkOutput(function () {
+        yargs(['get', '--browser', 'Internet Explorer'])
+          .command('get')
+          .string('browser')
+          .check(function (argv) {
+            // This check is only run if the command handler is not run
+            return argv.browser !== 'Internet Explorer'
+          })
+          .exitProcess()
+          .argv
+      })
+
+      expect(r.exit).to.equal(true)
+    })
+
     it("skips executing top-level command if builder's help is executed", function () {
       var r = checkOutput(function () {
         yargs(['blerg', '-h'])


### PR DESCRIPTION
This PR aims at fixing yargs unintentionally running commands that do not have associated handlers, and thus skipping, for example, custom checks, as raised in #403.

Originally, in v3, yargs only executed command functions if available, which means code like this would work:
```javascript
var argv = yargs(['command', '--option', 'lol'])
  .command('command')
  .string('option')
  .check(argv => argv.option !== 'lol')
  .argv
```
^ this should output an error that custom checks weren't met.

However, as v4 introduced a major overhaul of the command API and changed things a bit, that code does not work anymore in said version.

The problem is that yargs attempts to execute handlers of commands that don't exist, because it thinks they do. This, however, does not cause an error, as `command.js`'s if-behaviour does not throw if no handler is available. As a result, yargs finally does not do things like custom checks anymore.

__This PR doesn't actually yet fix things, but is meant to show the problem, and a potential approach to fix it.__