### PR TITLE
Update Node versions in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ after_success: npm run coverage
 env:
   - NODE_VERSION="0.10"
   - NODE_VERSION="0.12"
-  - NODE_VERSION="iojs"
   - NODE_VERSION="4"
+  - NODE_VERSION="node"


### PR DESCRIPTION
Replace iojs with latest Node version.

For now, this will increase the range to Node 5 while preserving support back to Node 0.10.

This should help future-proof our testing a bit when new Node versions are released.