### PR TITLE
Introduce command execution context

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -70,6 +70,9 @@ module.exports = function (yargs, usage, validation) {
     var argv = parsed.argv
     var commandHandler = handlers[command]
     var innerArgv = argv
+    var currentContext = yargs.getContext()
+    var parentCommands = currentContext.commands.slice()
+    currentContext.commands.push(command)
     if (commandHandler.builder && typeof commandHandler.builder === 'function') {
       // a function can be provided, which interacts which builds
       // up a yargs chain and returns it.
@@ -79,30 +82,31 @@ module.exports = function (yargs, usage, validation) {
       // original command string as usage() for consistent behavior with
       // options object below
       if (yargs.parsed === false && typeof yargs.getUsageInstance().getUsage() === 'undefined') {
-        yargs.usage('$0 ' + commandHandler.original)
+        yargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
       }
       innerArgv = innerArgv ? innerArgv.argv : argv
     } else if (commandHandler.builder && typeof commandHandler.builder === 'object') {
       // as a short hand, an object can instead be provided, specifying
       // the options that a command takes.
       innerArgv = yargs.reset(parsed.aliases)
-      innerArgv.usage('$0 ' + commandHandler.original)
+      innerArgv.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
       Object.keys(commandHandler.builder).forEach(function (key) {
         innerArgv.option(key, commandHandler.builder[key])
       })
       innerArgv = innerArgv.argv
     }
 
-    populatePositional(commandHandler, innerArgv)
+    populatePositional(commandHandler, innerArgv, currentContext)
 
     if (commandHandler.handler) {
       commandHandler.handler(innerArgv)
     }
+    currentContext.commands.pop()
     return innerArgv
   }
 
-  function populatePositional (commandHandler, argv) {
-    var cmd = argv._.shift() // nuke the first argument (the current command)
+  function populatePositional (commandHandler, argv, context) {
+    argv._ = argv._.slice(context.commands.length) // nuke the current commands
     var demanded = commandHandler.demanded.slice(0)
     var optional = commandHandler.optional.slice(0)
 
@@ -120,7 +124,7 @@ module.exports = function (yargs, usage, validation) {
       argv[maybe] = argv._.shift()
     }
 
-    argv._.unshift(cmd)
+    argv._ = context.commands.concat(argv._)
   }
 
   self.reset = function () {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -109,6 +109,7 @@ module.exports = function (yargs, usage, y18n) {
     var demanded = yargs.getDemanded()
     var commandKeys = yargs.getCommandInstance().getCommands()
     var unknown = []
+    var currentContext = yargs.getContext()
 
     Object.keys(aliases).forEach(function (key) {
       aliases[key].forEach(function (alias) {
@@ -126,7 +127,7 @@ module.exports = function (yargs, usage, y18n) {
     })
 
     if (commandKeys.length > 0) {
-      argv._.forEach(function (key) {
+      argv._.slice(currentContext.commands.length).forEach(function (key) {
         if (commandKeys.indexOf(key) === -1) {
           unknown.push(key)
         }

--- a/test/command.js
+++ b/test/command.js
@@ -41,6 +41,23 @@ describe('Command', function () {
       argv.bar.should.equal('hello')
       argv.awesome.should.equal('world')
     })
+
+    it('populates subcommand\'s inner argv with positional arguments', function () {
+      yargs('foo bar hello world')
+        .command('foo', 'my awesome command', function (yargs) {
+          return yargs.command(
+            'bar <greeting> [recipient]',
+            'subcommands are cool',
+            function () {},
+            function (argv) {
+              argv._.should.deep.equal(['foo', 'bar'])
+              argv.greeting.should.equal('hello')
+              argv.recipient.should.equal('world')
+            }
+          )
+        })
+        .argv
+    })
   })
 
   describe('missing positional arguments', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1717,6 +1717,44 @@ describe('usage tests', function () {
         ''
       ])
     })
+
+    it('displays given command chain with positional args in default usage for subcommand with builder object', function () {
+      var r = checkUsage(function () {
+        return yargs('one two --help')
+          .command('one <sub>', 'level one, requires subcommand', function (yargs) {
+            return yargs.command('two [next]', 'level two', {}, function (argv) {})
+          }, function (argv) {})
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        './usage one two [next]',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('displays given command chain with positional args in default usage for subcommand with builder function', function () {
+      var r = checkUsage(function () {
+        return yargs('one two --help')
+          .command('one <sub>', 'level one, requires subcommand', function (yargs) {
+            return yargs.command('two [next]', 'level two', function (yargs) { return yargs }, function (argv) {})
+          }, function (argv) {})
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        './usage one two [next]',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
   })
 
   describe('epilogue', function () {

--- a/test/validation.js
+++ b/test/validation.js
@@ -315,4 +315,22 @@ describe('validation tests', function () {
         .parse([])
     })
   })
+
+  describe('strict mode', function () {
+    it('does not fail when command with subcommands called', function () {
+      yargs('one')
+        .command('one', 'level one', function (yargs) {
+          return yargs
+            .command('twoA', 'level two A')
+            .command('twoB', 'level two B')
+            .strict()
+            .fail(function (msg) {
+              expect.fail()
+            })
+        }, function (argv) {
+          argv._[0].should.equal('one')
+        })
+        .argv
+    })
+  })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -887,3 +887,43 @@ describe('yargs dsl tests', function () {
     })
   })
 })
+
+describe('yargs context', function () {
+  beforeEach(function () {
+    delete require.cache[require.resolve('../')]
+    yargs = require('../')
+  })
+
+  it('should begin with initial state', function () {
+    var context = yargs.getContext()
+    context.resets.should.equal(0)
+    context.commands.should.deep.equal([])
+  })
+
+  it('should track number of resets', function () {
+    var context = yargs.getContext()
+    yargs.reset()
+    context.resets.should.equal(1)
+    yargs.reset()
+    yargs.reset()
+    context.resets.should.equal(3)
+  })
+
+  it('should track commands being executed', function () {
+    var context
+    yargs('one two')
+      .command('one', 'level one', function (yargs) {
+        context = yargs.getContext()
+        context.commands.should.deep.equal(['one'])
+        return yargs.command('two', 'level two', function (yargs) {
+          context.commands.should.deep.equal(['one', 'two'])
+        }, function (argv) {
+          context.commands.should.deep.equal(['one', 'two'])
+        })
+      }, function (argv) {
+        context.commands.should.deep.equal(['one'])
+      })
+      .argv
+    context.commands.should.deep.equal([])
+  })
+})

--- a/yargs.js
+++ b/yargs.js
@@ -47,11 +47,19 @@ function Yargs (processArgs, cwd, parentRequire) {
     )
   }
 
+  // use context object to keep track of resets, subcommand execution, etc
+  // submodules should modify and check the state of context as necessary
+  var context = { resets: -1, commands: [] }
+  self.getContext = function () {
+    return context
+  }
+
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
   // by this action.
   var options
   self.resetOptions = self.reset = function (aliases) {
+    context.resets++
     aliases = aliases || {}
     options = options || {}
     // put yargs back into an initial state, this


### PR DESCRIPTION
This is something I've wanted to do for a while but never had a good grasp on how to implement it. (And, I arguably still don't. :grinning:)

However, issue #426 brought up a good first use-case for maintaining a context of command execution, in order to change the behavior of "unknown argument" validation (induced by `.strict()`) based on if it's running for a (possibly nested) command or not.

As is, this branch fixes that problem - without breaking any existing tests - but is still lacking tests for the scenarios it addresses.

The reason I'm opening this PR now is that I'd like some feedback on the approach/implementation before I put much more effort into it. Basically, I'm adding another piece of state (tied to the yargs singleton) that does **not** get reset for command execution, but rather keeps track of which commands are currently being executed. This `context` object is available to all submodule logic (via the `.getContext()` method), intended to be **modified** at state transitions and **read** for processing logic that is dependent on the current command context. I realize that exposing it in this way leaves it vulnerable to unexpected manipulation (even from user code), but it seems more useful/flexible this way and is consistent with other "internal" APIs as well.

Note that the `context` initially has two fields: a `commands` array representing the currently executing commands (supports nested subcommands) and a `resets` integer representing the total number of times a reset has occurred. I thought the number of resets would be useful, but I ended up not using it since, for command processing, I can rely on the length of the commands array instead. I fully expect additional fields to be added to the `context` in the future, if the need arises for additional state not currently represented.

Also note that this branch already uses the `context` in two different ways - once for validation logic and once for correcting the implicit usage string for subcommands. I also commented a way it might be useful for interpreting `.demand()` for a command, but I shied away from this b/c I honestly don't understand the intent/expectation of demanding a certain number of args within a (sub)command.

At any rate, please let me know your thoughts. I pushed the branch to the main repo so it is available for easy fetching/modification by yargs members.