### PR TITLE
fix tests that use .command() improperly

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -86,9 +86,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs('wombat -w 10 -m 10')
             .usage('Usage: $0 -w NUM -m NUM')
-            .command('wombat', 'wombat handlers', function (yargs, argv) {
-              return argv
-            })
+            .command('wombat', 'wombat handlers')
             .demand(1, ['w', 'm'])
             .strict()
             .wrap(null)
@@ -175,9 +173,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs('wombat -w 10 -m 10')
             .usage('Usage: $0 -w NUM -m NUM')
-            .command('wombat', 'wombat handlers', function (yargs, argv) {
-              return argv
-            })
+            .command('wombat', 'wombat handlers')
             .require(1, ['w', 'm'])
             .strict()
             .wrap(null)

--- a/test/validation.js
+++ b/test/validation.js
@@ -72,12 +72,8 @@ describe('validation tests', function () {
 
     it('fails with invalid command', function (done) {
       yargs(['koala'])
-        .command('wombat', 'wombat burrows', function (yargs, argv) {
-          return argv
-        })
-        .command('kangaroo', 'kangaroo handlers', function (yargs, argv) {
-          return argv
-        })
+        .command('wombat', 'wombat burrows')
+        .command('kangaroo', 'kangaroo handlers')
         .demand(1)
         .strict()
         .fail(function (msg) {


### PR DESCRIPTION
I left these to provide only `cmd` and `desc`, as they are only testing `fail` outputs in `validation` and `usage`.

closes #429 