### PR TITLE
Remove duplicated option keys from arrayOptions

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -85,7 +85,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     var arrayOptions = [
       'array', 'boolean', 'string', 'requiresArg',
-      'count', 'requiresArg', 'count', 'normalize', 'number'
+      'count', 'normalize', 'number'
     ]
 
     var objectOptions = [


### PR DESCRIPTION
It wasn't causing any issue, but this should save a few iterations in `arrayOptions.forEach`