### PR TITLE
Check for commands before validating argv._ in strict mode

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -125,11 +125,13 @@ module.exports = function (yargs, usage, y18n) {
       }
     })
 
-    argv._.forEach(function (key) {
-      if (!commandKeys.hasOwnProperty(key)) {
-        unknown.push(key)
-      }
-    })
+    if (commandKeys.length > 0) {
+      argv._.forEach(function (key) {
+        if (commandKeys.indexOf(key) === -1) {
+          unknown.push(key)
+        }
+      })
+    }
 
     if (unknown.length > 0) {
       usage.fail(__n(

--- a/test/validation.js
+++ b/test/validation.js
@@ -70,7 +70,7 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with invalid command', function (done) {
+    it('fails in strict mode with invalid command', function (done) {
       yargs(['koala'])
         .command('wombat', 'wombat burrows')
         .command('kangaroo', 'kangaroo handlers')
@@ -81,6 +81,17 @@ describe('validation tests', function () {
           return done()
         })
         .argv
+    })
+
+    it('does not fail in strict mode when no commands configured', function () {
+      var argv = yargs('koala')
+        .demand(1)
+        .strict()
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+      argv._[0].should.equal('koala')
     })
 
     it('fails when a required argument is missing', function (done) {


### PR DESCRIPTION
Fixes #444

Note that `commandKeys` is an array, not an object, so I replaced the use of `hasOwnProperty()` with `indexOf()` to account for inherent Array properties like `length`.