### PR TITLE
showHelp getting the emission function itself

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -321,9 +321,8 @@ module.exports = function (yargs, y18n) {
 
   self.showHelp = function (level) {
     if (!level) level = 'error'
-    var emit = 'function' == typeof level ? level : console[ level ]
-    
-    if ('function' == typeof emit) emit(self.help());
+    var emit = typeof level === 'function' ? level : console[ level ]
+    emit(self.help())
   }
 
   self.functionDescription = function (fn) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -320,8 +320,10 @@ module.exports = function (yargs, y18n) {
   }
 
   self.showHelp = function (level) {
-    level = level || 'error'
-    console[level](self.help())
+    if (!level) level = 'error'
+    var emit = 'function' == typeof level ? level : console[ level ]
+    
+    if ('function' == typeof emit) emit(self.help());
   }
 
   self.functionDescription = function (fn) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1958,7 +1958,7 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should display 'type' string in help message if set for alias', function () {
+    it("should display 'type' string in help message if set for alias", function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
           .string('foo')

--- a/test/usage.js
+++ b/test/usage.js
@@ -2018,6 +2018,52 @@ describe('usage tests', function () {
         ''
       ])
     })
+    
+    it("when passed a string - should call the correct console.log method", function() {
+      var r = checkUsage(function () {
+        var y = yargs(['--foo'])
+          .options('foo', {
+            alias: 'f',
+            describe: 'foo option'
+          })
+          .wrap(null)
+
+        y.showHelp("log")
+      });
+
+      r.errors.length.should.eql(0);
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --foo, -f  foo option',
+        ''
+      ])
+    })
+    it("when passed a handler - should provide the help string to the handler", function() {
+      var testlogs = [];
+      var r = checkUsage(function () {
+        var y = yargs(['--foo'])
+          .options('foo', {
+            alias: 'f',
+            describe: 'foo option'
+          })
+          .wrap(null)
+
+        y.showHelp(testHandler)
+      });
+
+      r.errors.length.should.eql(0);
+      r.logs.length.should.eql(0);
+      
+      testlogs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --foo, -f  foo option',
+        ''
+      ])
+      
+      function testHandler(msg) {
+          testlogs.push(msg);
+      }
+    })
   })
 
   describe('$0', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -2018,7 +2018,7 @@ describe('usage tests', function () {
         ''
       ])
     })
-    
+
     it('when passed a string - should call the correct console.log method', function () {
       var r = checkUsage(function () {
         var y = yargs(['--foo'])
@@ -2028,7 +2028,7 @@ describe('usage tests', function () {
           })
           .wrap(null)
 
-        y.showHelp("log")
+        y.showHelp('log')
       })
 
       r.errors.length.should.eql(0)

--- a/test/usage.js
+++ b/test/usage.js
@@ -1977,7 +1977,7 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should display 'type' number in help message if set for alias', function () {
+    it("should display 'type' number in help message if set for alias", function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
           .string('foo')

--- a/test/usage.js
+++ b/test/usage.js
@@ -1958,7 +1958,7 @@ describe('usage tests', function () {
       ])
     })
 
-    it("should display 'type' string in help message if set for alias", function () {
+    it('should display 'type' string in help message if set for alias', function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
           .string('foo')
@@ -1977,7 +1977,7 @@ describe('usage tests', function () {
       ])
     })
 
-    it("should display 'type' number in help message if set for alias", function () {
+    it('should display 'type' number in help message if set for alias', function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
           .string('foo')
@@ -2019,7 +2019,7 @@ describe('usage tests', function () {
       ])
     })
     
-    it("when passed a string - should call the correct console.log method", function() {
+    it('when passed a string - should call the correct console.log method', function () {
       var r = checkUsage(function () {
         var y = yargs(['--foo'])
           .options('foo', {
@@ -2029,17 +2029,17 @@ describe('usage tests', function () {
           .wrap(null)
 
         y.showHelp("log")
-      });
+      })
 
-      r.errors.length.should.eql(0);
+      r.errors.length.should.eql(0)
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --foo, -f  foo option',
         ''
       ])
     })
-    it("when passed a handler - should provide the help string to the handler", function() {
-      var testlogs = [];
+    it('when passed a handler - should provide the help string to the handler', function () {
+      var testlogs = []
       var r = checkUsage(function () {
         var y = yargs(['--foo'])
           .options('foo', {
@@ -2049,19 +2049,19 @@ describe('usage tests', function () {
           .wrap(null)
 
         y.showHelp(testHandler)
-      });
+      })
 
-      r.errors.length.should.eql(0);
-      r.logs.length.should.eql(0);
-      
+      r.errors.length.should.eql(0)
+      r.logs.length.should.eql(0)
+
       testlogs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --foo, -f  foo option',
         ''
       ])
-      
-      function testHandler(msg) {
-          testlogs.push(msg);
+
+      function testHandler (msg) {
+        testlogs.push(msg)
       }
     })
   })


### PR DESCRIPTION
Motive: in tests I don't want yargs to print anything to the console. But I do want to catch it and see that it try.
So - when I pass it the handler itself - let it write to this handler.

Consider the following use-case scenario:

```
var yargs = require('yargs');
var options = { ... }; 
module.exports = function args(process, log)  {
   var args = yargs.usage("foo").help().options(options).parse(process.argv);

   if (!log) log = console.log; //injected in test time, defaults to console.log;

   if (args.help) {
        yargs.showHelp( log )
        process.exit();
        return;
   }

   return args
}

```


then, in tests

```
var sut = require('../lib/args')

describe("lib/args", function() {
   describe("when provided with help switch", function() {
        var logs = [];
        var mockProcess = { env: { ... }, argv: [ .... ], exit: function() { ... }  };
        var xUsage =  /^Usage:  ......  (whatever)    /
        before(function() {
             var args = sut( mockProcess, mockLog )
        })
        it("should call exit", function() { ... } );
        it("should output help message", function() { 
             logs.length.should.eql(1);
             logs[0].should.match(xUsage)
        });
        function mockLog(msg) {
             logs.push(msg);
        }
   })
})
```