### PR TITLE
Fix bash completion when COMP_WORDS has a null word

### DIFF
--- a/completion.sh.hbs
+++ b/completion.sh.hbs
@@ -10,10 +10,10 @@ _yargs_completions()
     local cur_word args type_list
 
     cur_word="${COMP_WORDS[COMP_CWORD]}"
-    args=$(printf "%s " "${COMP_WORDS[@]}")
+    args=("${COMP_WORDS[@]}")
 
     # ask yargs to generate completions.
-    type_list=`{{app_path}} --get-yargs-completions $args`
+    type_list=$({{app_path}} --get-yargs-completions "${args[@]}")
 
     COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )
 


### PR DESCRIPTION
A little background: When executing a completion function, Bash sets the `COMP_WORDS` array containing the individual words in the command line. If the cursor is at the end of the line (after the last word and separated by a blank), an **additional null word** is added to `COMP_WORDS`. That way the completion function can tell if the user is trying to complete the last word, or a new word after it.

The issue here is that we aren't sending the last null word to yargs because bash's word splitting removes unquoted nulls.

This PR should fix it. It uses the **“${name[@]}”** form to send the words, which preserves them all.