### PR TITLE
Fix demand() when second argument is an array

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -300,6 +300,18 @@ describe('usage tests', function () {
           'pork chop sandwiches'
         ])
       })
+
+      it("shouldn't interpret the second argument as a max when it is an array", function () {
+        var r = checkUsage(function () {
+          return yargs(['koala', 'wombat', '--1'])
+              .usage('Usage: foo')
+              .demand(1, ['1'])
+              .wrap(null)
+              .argv
+        })
+
+        r.errors.length.should.equal(0)
+      })
     })
   })
 

--- a/yargs.js
+++ b/yargs.js
@@ -234,6 +234,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       max.forEach(function (key) {
         self.demand(key, msg)
       })
+      max = Infinity
     } else if (typeof max !== 'number') {
       msg = max
       max = Infinity


### PR DESCRIPTION
Specifying a command count and required arguments at the same time causes the required arguments to be set as the 'max' of argv._

For example, calling `.demand(1, ['foo', 'bar'])` causes this to be set in options.demanded: `_: { count: 1, msg: undefined, max: [ 'foo', 'bar' ] } }`

This doesn't really fails because, when doing the validation, comparing a number to an array returns true most of the time on Javascript. But we shouldn't be relying on undocumented behavior if possible.

There is actually an edge case that fails: When calling `.demand(1, ['1'])`, it will fail is the user provides more than one command. I added a test for that.
