### PR TITLE
Improve $0 in Windows

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -2112,7 +2112,7 @@ describe('usage tests', function () {
 
       it('is not resolved to the relative path if it is larger, using Windows paths', function () {
         mockProcessArgv(['node', 'C:\\script.js'], function () {
-          yargs([], 'C:\\very\\long\\current\\directory\\').$0.should.equal('\\script.js')
+          yargs([], 'C:\\very\\long\\current\\directory\\').$0.should.equal('C:\\script.js')
         })
       })
     }

--- a/test/usage.js
+++ b/test/usage.js
@@ -2076,6 +2076,46 @@ describe('usage tests', function () {
         yargs([]).$0.should.equal('/code/iojs/script.js')
       })
     })
+
+    it('is detected correctly when argv contains "node.exe"', function () {
+      mockProcessArgv(['node.exe', 'script.js'], function () {
+        yargs([]).$0.should.equal('script.js')
+      })
+    })
+
+    it('is detected correctly when argv contains "iojs.exe"', function () {
+      mockProcessArgv(['iojs.exe', 'script.js'], function () {
+        yargs([]).$0.should.equal('script.js')
+      })
+    })
+
+    if (process.platform !== 'win32') {
+      it('is resolved to the relative path if it is shorter', function () {
+        mockProcessArgv(['node', '/code/node/script.js'], function () {
+          yargs([], '/code/python/').$0.should.equal('../node/script.js')
+        })
+      })
+
+      it('is not resolved to the relative path if it is larger', function () {
+        mockProcessArgv(['node', '/script.js'], function () {
+          yargs([], '/very/long/current/directory/').$0.should.equal('/script.js')
+        })
+      })
+    }
+
+    if (process.platform === 'win32') {
+      it('is resolved to the relative path if it is shorter, using Windows paths', function () {
+        mockProcessArgv(['node.exe', 'C:\\code\\node\\script.js'], function () {
+          yargs([], 'C:\\code\\python\\').$0.should.equal('..\\node\\script.js')
+        })
+      })
+
+      it('is not resolved to the relative path if it is larger, using Windows paths', function () {
+        mockProcessArgv(['node', 'C:\\script.js'], function () {
+          yargs([], 'C:\\very\\long\\current\\directory\\').$0.should.equal('\\script.js')
+        })
+      })
+    }
   })
 
   describe('choices', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -37,7 +37,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       // bin file with #!/usr/bin/env node
       if (i === 0 && /\b(node|iojs)(\.exe)?$/.test(x)) return
       var b = rebase(cwd, x)
-      return x.match(/^(\/|\\)/) && b.length < x.length ? b : x
+      return x.match(/^(\/|([a-zA-Z]:)?\\)/) && b.length < x.length ? b : x
     })
     .join(' ').trim()
 

--- a/yargs.js
+++ b/yargs.js
@@ -35,9 +35,9 @@ function Yargs (processArgs, cwd, parentRequire) {
     .map(function (x, i) {
       // ignore the node bin, specify this in your
       // bin file with #!/usr/bin/env node
-      if (i === 0 && /\b(node|iojs)$/.test(x)) return
+      if (i === 0 && /\b(node|iojs)(\.exe)?$/.test(x)) return
       var b = rebase(cwd, x)
-      return x.match(/^\//) && b.length < x.length ? b : x
+      return x.match(/^(\/|\\)/) && b.length < x.length ? b : x
     })
     .join(' ').trim()
 


### PR DESCRIPTION
I made some changes to the way the `$0` variable is created, so that the Windows version matches the Linux one:
  - It ignores `argv[0]` if it ends in "node.exe" or "iojs.exe"
  - It allows to use the rebased version of `argv[1]` if it uses Windows style paths

Now, the tricky part is that I had to make platform dependent tests, because the behavior of `node.path.relative` changes depending on platform, and there's not a straightforward way to mock it. Let me know what you think.
