### PR TITLE
variadic positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,17 @@ yargs.command('get <source> [proxy]', 'make a get HTTP request')
   .argv
 ```
 
+#### Variadic Positional Arguments
+
+The last positional argument can optionally accept an array of
+values, by using the `..` operator:
+
+```js
+yargs.command('download <url> [files..]', 'download several files')
+  .help()
+  .argv
+```
+
 ### Providing a Command Module
 
 For complicated commands you can pull the logic into a module. A module

--- a/lib/command.js
+++ b/lib/command.js
@@ -45,15 +45,26 @@ module.exports = function (yargs, usage, validation) {
 
   function parseCommand (cmd) {
     var splitCommand = cmd.split(/\s/)
-    var bregex = /[\][<>]/g
+    var bregex = /\.*[\][<>]/g
     var parsedCommand = {
       cmd: (splitCommand.shift()).replace(bregex, ''),
       demanded: [],
       optional: []
     }
-    splitCommand.forEach(function (cmd) {
-      if (/^\[/.test(cmd)) parsedCommand.optional.push(cmd.replace(bregex, ''))
-      else parsedCommand.demanded.push(cmd.replace(bregex, ''))
+    splitCommand.forEach(function (cmd, i) {
+      var variadic = false
+      if (/\.+[\]>]/.test(cmd) && i === splitCommand.length - 1) variadic = true
+      if (/^\[/.test(cmd)) {
+        parsedCommand.optional.push({
+          cmd: cmd.replace(bregex, ''),
+          variadic: variadic
+        })
+      } else {
+        parsedCommand.demanded.push({
+          cmd: cmd.replace(bregex, ''),
+          variadic: variadic
+        })
+      }
     })
     return parsedCommand
   }
@@ -113,15 +124,19 @@ module.exports = function (yargs, usage, validation) {
     validation.positionalCount(demanded.length, argv._.length)
 
     while (demanded.length) {
-      if (!argv._.length) break
       var demand = demanded.shift()
-      argv[demand] = argv._.shift()
+      if (demand.variadic) argv[demand.cmd] = []
+      if (!argv._.length) break
+      if (demand.variadic) argv[demand.cmd] = argv._.splice(0)
+      else argv[demand.cmd] = argv._.shift()
     }
 
     while (optional.length) {
-      if (!argv._.length) break
       var maybe = optional.shift()
-      argv[maybe] = argv._.shift()
+      if (maybe.variadic) argv[maybe.cmd] = []
+      if (!argv._.length) break
+      if (maybe.variadic) argv[maybe.cmd] = argv._.splice(0)
+      else argv[maybe.cmd] = argv._.shift()
     }
 
     argv._ = context.commands.concat(argv._)


### PR DESCRIPTION
Introduces the concept of variadic commands arguments. I'm feeling like along with @nexdrew's work in https://github.com/yargs/yargs/pull/428 commands are getting pretty darn slick. You can now do: 

`./my-bin.js open file-1 file-2-file-3`

and get,

````js
{files: ['file-1', 'file-2', 'file-3']}
```