### PR TITLE
Add missing features to README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,10 +982,12 @@ Locales currently supported:
 * **es:** Spanish.
 * **fr:** French.
 * **id:** Indonesian.
+* **it:** Italian.
 * **ja:** Japanese.
 * **ko:** Korean.
 * **nb:** Norwegian Bokmål.
 * **pirate:** American Pirate.
+* **pl:** Polish.
 * **pt:** Portuguese.
 * **pt_BR:** Brazilian Portuguese.
 * **tr:** Turkish.

--- a/README.md
+++ b/README.md
@@ -454,9 +454,11 @@ var argv = require('yargs')
 ```
 
 .command(cmd, desc, [builder], [handler])
--------------------
+-----------------------------------------
 .command(cmd, desc, [module])
--------------------
+-----------------------------
+.command(module)
+----------------
 
 Document the commands exposed by your application.
 
@@ -533,11 +535,17 @@ yargs.command('get <source> [proxy]', 'make a get HTTP request')
 For complicated commands you can pull the logic into a module. A module
 simply needs to export:
 
-* `exports.builder`: which describes the options that a command accepts.
+* `exports.command`: string that executes this command when given on the command line, may contain positional args
+* `exports.describe`: string used as the description for the command in help text, use `false` for a hidden command
+* `exports.builder`: object declaring the options the command accepts, or a function accepting and returning a yargs instance
 * `exports.handler`: a function which will be passed the parsed argv.
 
 ```js
 // my-module.js
+exports.command = 'get <source> [proxy]'
+
+exports.describe = 'make a get HTTP request'
+
 exports.builder = {
   banana: {
     default: 'cool'
@@ -553,6 +561,14 @@ exports.handler = function (argv) {
 ```
 
 You then register the module like so:
+
+```js
+yargs.command(require('my-module'))
+  .help()
+  .argv
+```
+
+Or if the module does not export `command` and `describe` (or if you just want to override them):
 
 ```js
 yargs.command('get <source> [proxy]', 'make a get HTTP request', require('my-module'))

--- a/README.md
+++ b/README.md
@@ -829,7 +829,19 @@ yargs have been validated.
 
 Method to execute when a failure occurs, rather than printing the failure message.
 
-`fn` is called with the failure message that would have been printed.
+`fn` is called with the failure message that would have been printed and the
+`Error` instance originally thrown, if any.
+
+```js
+var argv = require('yargs')
+  .fail(function (msg, err) {
+    if (err) throw err // preserve stack
+    console.error('You broke it!')
+    console.error(msg)
+    process.exit(1)
+  })
+  .argv
+```
 
 <a name="global"></a>.global(globals)
 ------------

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,7 @@
   "boolean": "boolean",
   "count": "count",
   "string": "string",
+  "number": "number",
   "array": "array",
   "required": "required",
   "default:": "default:",

--- a/locales/it.json
+++ b/locales/it.json
@@ -5,6 +5,7 @@
   "boolean": "booleano",
   "count": "contatore",
   "string": "stringa",
+  "number": "numero",
   "array": "vettore",
   "required": "richiesto",
   "default:": "predefinito:",


### PR DESCRIPTION
1. Include `command` and `describe` props for command modules (since #414)
2. Include `Error` instance as 2nd arg for fail handler (since #382)
3. Sync up locale list with locale files

Also added missing `"number"` string to American English and Italian locales. (I think my Italian translation is correct. :smiley:)