### PR TITLE
Avoid repeating options in completion

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -14,6 +14,7 @@ module.exports = function (yargs, usage, command) {
     var current = process.argv[process.argv.length - 1]
     var previous = process.argv.slice(process.argv.indexOf('--' + self.completionKey) + 1)
     var argv = yargs.parse(previous)
+    var aliases = yargs.parsed.aliases
 
     // a custom completion function can be provided
     // to completion().
@@ -57,7 +58,14 @@ module.exports = function (yargs, usage, command) {
 
     if (current.match(/^-/)) {
       Object.keys(yargs.getOptions().key).forEach(function (key) {
-        completions.push('--' + key)
+        // If the key and its aliases aren't in 'previous', add the key to 'completions'
+        var keyAndAliases = [key].concat(aliases[key] || [])
+        var notInPrevious = keyAndAliases.every(function (val) {
+          return previous.indexOf('--' + val) === -1
+        })
+        if (notInPrevious) {
+          completions.push('--' + key)
+        }
       })
     }
 

--- a/test/completion.js
+++ b/test/completion.js
@@ -38,6 +38,36 @@ describe('Completion', function () {
       r.logs.should.not.include('apple')
     })
 
+    it('avoids repeating already included options', function () {
+      var r = checkUsage(function () {
+        return yargs(['--get-yargs-completions'])
+          .options({
+            foo: {describe: 'foo option'},
+            bar: {describe: 'bar option'}
+          })
+          .completion()
+          .argv
+      }, ['./completion', '--get-yargs-completions', './completion', '--foo', '--'])
+
+      r.logs.should.include('--bar')
+      r.logs.should.not.include('--foo')
+    })
+
+    it('avoids repeating options whose aliases are already included', function () {
+      var r = checkUsage(function () {
+        return yargs(['--get-yargs-completions'])
+            .options({
+              foo: {describe: 'foo option', alias: 'f'},
+              bar: {describe: 'bar option'}
+            })
+            .completion()
+            .argv
+      }, ['./completion', '--get-yargs-completions', './completion', '--f', '--'])
+
+      r.logs.should.include('--bar')
+      r.logs.should.not.include('--foo')
+    })
+
     it('completes options for a command', function () {
       var r = checkUsage(function () {
         return yargs(['--get-yargs-completions'])

--- a/test/integration.js
+++ b/test/integration.js
@@ -44,7 +44,7 @@ describe('integration tests', function () {
 
   // see #177
   it('allows --help to be completed without returning help message', function (done) {
-    testCmd('./bin.js', [ '--get-yargs-completions', '--help' ], function (code, stdout) {
+    testCmd('./bin.js', [ '--get-yargs-completions', '--h' ], function (code, stdout) {
       if (code) {
         done(new Error('cmd exited with code ' + code))
         return


### PR DESCRIPTION
This makes sure that an option won't be suggested for completion if the option, or any of its aliases, is already in the provided arguments.

Pretty much the same thing that was done for command completion in https://github.com/yargs/yargs/pull/183

I figure this is a good start, but it only checks options in **long form**. Checking for short form depends on whether 'short-option-groups' is enabled or not, and would need to duplicate parts of the parser logic, so it is a bit tricky.

I also had to modify slightly the integration test that checks that the completion for '--help' works. Now it won't complete if the current word is '--help', so I made it try to complete '--h'