### PR TITLE
If invoking .config() without parameters, set a default option

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,12 +622,14 @@ var argv = require('yargs')
   .argv;
 ```
 
-<a name="config"></a>.config(key, [description], [parseFn])
+<a name="config"></a>.config([key], [description], [parseFn])
 ------------
 
 Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
 and parsed, and its properties are set as arguments.
+
+If invoked without parameters, `.config()` will make `--config` the option to pass the JSON config file.
 
 An optional `description` can be provided to customize the config (`key`) option
 in the usage string.

--- a/test/validation.js
+++ b/test/validation.js
@@ -240,6 +240,24 @@ describe('validation tests', function () {
       ])
     })
 
+    it('should be displayed in the help message with its default name', function () {
+      var checkUsage = require('./helpers/utils').checkOutput
+      var r = checkUsage(function () {
+        return yargs(['--help'])
+            .config()
+            .help('help')
+            .wrap(null)
+            .argv
+      })
+      r.should.have.property('logs').with.length(1)
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --config  Path to JSON config file',
+        '  --help    Show help  [boolean]',
+        ''
+      ])
+    })
+
     it('should allow help message to be overridden', function () {
       var checkUsage = require('./helpers/utils').checkOutput
       var r = checkUsage(function () {

--- a/yargs.js
+++ b/yargs.js
@@ -179,6 +179,8 @@ function Yargs (processArgs, cwd, parentRequire) {
       parseFn = msg
       msg = null
     }
+
+    key = key || 'config'
     self.describe(key, msg || usage.deferY18nLookup('Path to JSON config file'))
     ;(Array.isArray(key) ? key : [key]).forEach(function (k) {
       options.config[k] = parseFn || true


### PR DESCRIPTION
Before this, if you called `.config()` without parameters, an option named `'undefined'` is set to receive the config file. I propose to set the default name `'config'`.

This way it works just like `.help()` and `.completion()`.