### PR TITLE
[WIP] New method to apply command modules matching glob pattern

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,3 +1,6 @@
+var globSync = require('glob').sync
+var path = require('path')
+
 // handles parsing positional arguments,
 // and populating argv with said positional
 // arguments.
@@ -56,6 +59,16 @@ module.exports = function (yargs, usage, validation) {
       else parsedCommand.demanded.push(cmd.replace(bregex, ''))
     })
     return parsedCommand
+  }
+
+  self.findModules = function (glob, req, cwd, opts) {
+    opts = opts || {}
+    opts.nodir = true
+    if (!opts.cwd) opts.cwd = cwd
+    if (typeof opts.matchBase === 'undefined') opts.matchBase = true
+    globSync(glob, opts).forEach(function (file) {
+      self.addHandler(req(path.resolve(opts.cwd, file)))
+    })
   }
 
   self.getCommands = function () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "camelcase": "^2.0.1",
     "cliui": "^3.1.1",
     "decamelize": "^1.1.1",
+    "glob": "^7.0.3",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",
     "pkg-conf": "^1.1.1",

--- a/yargs.js
+++ b/yargs.js
@@ -196,6 +196,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
+  self.commands = function (glob, opts) {
+    var req = parentRequire || require
+    command.findModules(glob, req, path.dirname(requireMainFilename(req)), opts)
+    return self
+  }
+
   self.string = function (strings) {
     options.string.push.apply(options.string, [].concat(strings))
     return self


### PR DESCRIPTION
(Sorry for another WIP pull, but I wanted to propose this to the team.)

My proposal is to add a new `.commands(glob, opts)` method that:

- finds command submodules matching the given glob pattern (via new dependency [`glob`](https://github.com/isaacs/node-glob)) relative to the bin module executing yargs (via existing use of `require-main-filename`)
- requires the found submodules (another "dynamic" use of require)
- applies the submodules as commands (via `command.addHandler()`)

For programs with many commands, this allows authors to modularize them into their own files and easily apply all of them to yargs with a single concise method, like so:

```js
require('yargs')
  .commands('cmd*') // finds all nested submodules
                    // like cmd-foo.js and lib/whatever/cmd-bar.js
  .help()
  .argv
```

They can even add new commands without changing the yargs configuration at all!

The initial logic in this branch works, but it needs tests.

I'm looking for feedback on the following:

1. What do you think about the method name `.commands()`?
2. Do you see any problems with adding `glob` as a dependency?
3. Any advice for writing tests that work outside the context of yargs?