### PR TITLE
introduce conventional-changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## Change Log
-
 ### v4.4.0 (2016/04/03 21:10 +07:00)
 
 - [#454](https://github.com/yargs/yargs/pull/454) fix demand() when second argument is an array (@elas7)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chalk": "^1.1.3",
+    "conventional-recommended-workflow": "^1.0.0",
     "coveralls": "^2.11.9",
     "cpr": "^1.0.0",
     "es6-promise": "^3.0.2",
@@ -42,7 +43,8 @@
   "scripts": {
     "pretest": "standard",
     "test": "nyc --cache mocha --require ./test/before.js --timeout=4000 --check-leaks",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "release": "conventional-recommended-workflow"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm sick of maintaining a hand-rolled artisanal changelog, switching to using the conventional-changelog angular format:

https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md