### PR TITLE
fix(default): Remove undocumented alias of default()

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -311,8 +311,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.defaults = self.default
-
   self.describe = function (key, desc) {
     options.key[key] = true
     usage.describe(key, desc)


### PR DESCRIPTION
Remove an alias of the `default()` method, called 'defaults', that was added to avoid usage of
a reserved word (https://github.com/yargs/yargs/commit/1bd4375e11327ba1687d4bb6e5e9f3c30c1be2af)

This isn't actually needed because a method name is a fair use of reserved keywords in Javascript.