### PR TITLE
feat(validation): Add .skipValidation() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ Valid `opt` keys include:
 - `normalize`: boolean, apply `path.normalize()` to the option, see [`normalize()`](#normalize)
 - `number`: boolean, interpret option as a number, [`number()`](#number)
 - `requiresArg`: boolean, require the option be specified with a value, see [`requiresArg()`](#requiresArg)
+- `skipValidation`: boolean, skips validation if the option is present, see [`skipValidation()`](#skipValidation)
 - `string`: boolean, interpret option as a string, see [`string()`](#string)
 - `type`: one of the following strings
     - `'array'`: synonymous for `array: true`, see [`array()`](#array)
@@ -1272,6 +1273,12 @@ Missing argument value: f
 
 Specify --help for available options
 ```
+
+<a name="skipValidation"></a>.skipValidation(key)
+-----------------
+
+Specifies either a single option key (string), or an array of options.
+If any of the options is present, yargs validation is skipped.
 
 .strict()
 ---------

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -232,6 +232,7 @@ describe('yargs dsl tests', function () {
         defaultDescription: {},
         choices: {},
         requiresArg: [],
+        skipValidation: [],
         count: [],
         normalize: [],
         number: [],
@@ -884,6 +885,43 @@ describe('yargs dsl tests', function () {
 
       argv.foo.should.equal('a')
       argv.dotNotation.should.equal(false)
+    })
+  })
+
+  describe('skipValidation', function () {
+    it('skips validation if an option with skipValidation is present', function () {
+      var argv = yargs(['--koala', '--skip'])
+          .demand(1)
+          .fail(function (msg) {
+            expect.fail()
+          })
+          .skipValidation(['skip', 'reallySkip'])
+          .argv
+      argv.koala.should.equal(true)
+    })
+
+    it('does not skip validation if no option with skipValidation is present', function (done) {
+      var argv = yargs(['--koala'])
+          .demand(1)
+          .fail(function (msg) {
+            return done()
+          })
+          .skipValidation(['skip', 'reallySkip'])
+          .argv
+      argv.koala.should.equal(true)
+    })
+
+    it('allows key to be specified with option shorthand', function () {
+      var argv = yargs(['--koala', '--skip'])
+          .demand(1)
+          .fail(function (msg) {
+            expect.fail()
+          })
+          .option('skip', {
+            skipValidation: true
+          })
+          .argv
+      argv.koala.should.equal(true)
     })
   })
 })


### PR DESCRIPTION
`.skipValidation()` takes a key. If the key is present, validation won't be performed.

Closes #453