### PR TITLE
fix(brand): I agree with @osher lightweight isn't a huge selling point any longer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yargs",
   "version": "4.5.0",
-  "description": "Light-weight option parsing with an argv hash. No optstrings attached.",
+  "description": "yargs the modern, pirate-themed, successor to optimist.",
   "main": "./index.js",
   "files": [
     "index.js",


### PR DESCRIPTION
yargs is great because it's:

* full-featured.
* a slick API.
* pirate-themed.

Lightweight, it's not so much anymore. I suggest we change the description in `package.json` to match the repo.

CC: @nexdrew, @osher 

fixes: #468