### PR TITLE
fix(pkgConf): fix aliases issues in .pkgConf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,8 +1155,8 @@ Parse `args` instead of `process.argv`. Returns the `argv` object.
 .pkgConf(key, [cwd])
 ------------
 
-Similar to [`config()`](#config), indicates that yargs should read
-default argument values from the specified key in package.json.
+Similar to [`config()`](#config), indicates that yargs should interpret the object from the specified key in package.json
+as a configuration object.
 
 `cwd` can optionally be provided, the package.json will be read
 from this location.

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -848,14 +848,14 @@ describe('yargs dsl tests', function () {
   })
 
   describe('pkgConf', function () {
-    it('uses values from package.json as defaults', function () {
+    it('uses values from package.json', function () {
       var argv = yargs('--foo a').pkgConf('repository').argv
 
       argv.foo.should.equal('a')
       argv.type.should.equal('git')
     })
 
-    it('combines yargs defaults with package.json defaults', function () {
+    it('combines yargs defaults with package.json values', function () {
       var argv = yargs('--foo a')
         .default('b', 99)
         .pkgConf('repository')
@@ -864,6 +864,31 @@ describe('yargs dsl tests', function () {
       argv.b.should.equal(99)
       argv.foo.should.equal('a')
       argv.type.should.equal('git')
+    })
+
+    it('should use value from package.json, if argv value is using default value', function () {
+      var argv = yargs('--foo a')
+        .default('b', 99)
+        .pkgConf('repository')
+        .default('type', 'default')
+        .argv
+
+      argv.b.should.equal(99)
+      argv.foo.should.equal('a')
+      argv.type.should.equal('git')
+    })
+
+    it('should apply value from config object to all aliases', function () {
+      var argv = yargs('--foo a')
+        .pkgConf('repository')
+        .alias('type', 't')
+        .alias('t', 'u')
+        .argv
+
+      argv.foo.should.equal('a')
+      argv.type.should.equal('git')
+      argv.t.should.equal('git')
+      argv.u.should.equal('git')
     })
 
     it('is cool with a key not existing', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -331,11 +331,10 @@ function Yargs (processArgs, cwd, parentRequire) {
       cwd: path || requireMainFilename(parentRequire || require)
     })
 
+    // If an object exists in the key, add it to options.configObjects
     if (obj.pkg && obj.pkg[key] && typeof obj.pkg[key] === 'object') {
       conf = obj.pkg[key]
-      Object.keys(conf).forEach(function (k) {
-        self.default(k, conf[k])
-      })
+      options.configObjects = (options.configObjects || []).concat(conf)
     }
 
     return self


### PR DESCRIPTION
Update `.pkgConf()` to use the new `configObjects` option from yargs-parser, this way the aliases issues are solved.

Change wording of `.pkgConf()` tests and description as it no longer works by setting defaults, and add some further tests.