### PR TITLE
feat(configuration): Add .configObject() method to pass configuration objects to yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,28 @@ var argv = require('yargs')
   .argv
 ```
 
+.configObject(obj)
+------------------
+
+Similar to [`config()`](#config), it receives an explicit configuration object.
+
+`obj` will be parsed and its properties will be set as arguments.
+
+```js
+var argv = require('yargs')
+  .configObject({foo: 1, bar: 2})
+  .argv
+console.log(argv)  
+```
+
+```
+$ node test.js
+{ _: [],
+  foo: 1,
+  bar: 2,
+  '$0': 'test.js' }
+```
+
 <a name="count"></a>.count(key)
 ------------
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -684,6 +684,17 @@ describe('yargs dsl tests', function () {
     })
   })
 
+  describe('configObject', function () {
+    it('allows a configuration object', function () {
+      var argv = yargs
+          .configObject({foo: 1, bar: 2})
+          .argv
+
+      argv.foo.should.equal(1)
+      argv.bar.should.equal(2)
+    })
+  })
+
   describe('normalize', function () {
     it('normalizes paths passed as arguments', function () {
       var argv = yargs('--path /foo/bar//baz/asdf/quux/..')

--- a/yargs.js
+++ b/yargs.js
@@ -188,6 +188,14 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
+  // Add 'obj' to options.configObjects
+  self.configObject = function (obj) {
+    if (typeof obj === 'object') {
+      options.configObjects = (options.configObjects || []).concat(obj)
+    }
+    return self
+  }
+
   self.example = function (cmd, description) {
     usage.example(cmd, description)
     return self


### PR DESCRIPTION
Similar to .config(), but it receives an explicit configuration object instead of setting a key for a file path to a JSON configuration object.

Closes #423