### PR TITLE
feat(configuration): Allow to directly pass a configuration object to .config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,9 @@ var argv = require('yargs')
 ```
 
 <a name="config"></a>.config([key], [description], [parseFn])
-------------
+-------------------------------------------------------------
+.config(object)
+---------------
 
 Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
@@ -672,6 +674,24 @@ var argv = require('yargs')
     return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
   })
   .argv
+```
+
+You can also pass an explicit configuration `object`, it will be parsed 
+and its properties will be set as arguments.
+             
+```js
+var argv = require('yargs')
+  .config({foo: 1, bar: 2})
+  .argv
+console.log(argv)
+```
+ 
+```
+$ node test.js
+{ _: [],
+  foo: 1,
+  bar: 2,
+  '$0': 'test.js' }
 ```
 
 <a name="count"></a>.count(key)

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -682,6 +682,15 @@ describe('yargs dsl tests', function () {
 
       argv.foo.should.equal('baz')
     })
+
+    it('allows to pass a configuration object', function () {
+      var argv = yargs
+          .config({foo: 1, bar: 2})
+          .argv
+
+      argv.foo.should.equal(1)
+      argv.bar.should.equal(2)
+    })
   })
 
   describe('normalize', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -175,6 +175,13 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self.config = function (key, msg, parseFn) {
+    // allow to pass a configuration object
+    if (typeof key === 'object') {
+      options.configObjects = (options.configObjects || []).concat(key)
+      return self
+    }
+
+    // allow to provide a parsing function
     if (typeof msg === 'function') {
       parseFn = msg
       msg = null


### PR DESCRIPTION
Continues from #479