### PR TITLE
docs(default): Document deprecated alias of default()

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,12 @@ Interpret `key` as a boolean flag, but set its parsed value to the number of
 flag occurrences rather than `true` or `false`. Default value is thus `0`.
 
 <a name="default"></a>.default(key, value, [description])
---------------------
+---------------------------------------------------------
+.defaults(key, value, [description])
+------------------------------------
+
+**Note:** The `.defaults()` alias is deprecated. It will be 
+removed in the next major version.
 
 Set `argv[key]` to `value` if no option was specified in `process.argv`.
 

--- a/yargs.js
+++ b/yargs.js
@@ -203,7 +203,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.default = function (key, value, defaultDescription) {
+  // The 'defaults' alias is deprecated. It will be removed in the next major version.
+  self.default = self.defaults = function (key, value, defaultDescription) {
     if (typeof key === 'object') {
       Object.keys(key).forEach(function (k) {
         self.default(k, key[k])
@@ -310,8 +311,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     validation.check(f)
     return self
   }
-
-  self.defaults = self.default
 
   self.describe = function (key, desc) {
     options.key[key] = true


### PR DESCRIPTION
Continues from #469