### PR TITLE
Add .commandDir(dir) to API to apply all command modules from a relative directory

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -9,11 +9,13 @@ module.exports = function (yargs, usage, validation) {
 
   var handlers = {}
   self.addHandler = function (cmd, description, builder, handler) {
-    // TODO allow objects that only define command and description
-    
-    // allow a module to define all properties
-    if (typeof cmd === 'object' && typeof cmd.command === 'string' && cmd.builder && typeof cmd.handler === 'function') {
-      self.addHandler(cmd.command, extractDesc(cmd), cmd.builder, cmd.handler)
+    // allow modules that define (a) all properties or (b) only command and description
+    if (typeof cmd === 'object' && typeof cmd.command === 'string') {
+      if (cmd.builder && typeof cmd.handler === 'function') {
+        self.addHandler(cmd.command, extractDesc(cmd), cmd.builder, cmd.handler)
+      } else {
+        self.addHandler(cmd.command, extractDesc(cmd))
+      }
       return
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var requireDirectory = require('require-directory')
 
 // handles parsing positional arguments,
@@ -39,12 +40,31 @@ module.exports = function (yargs, usage, validation) {
     }
   }
 
-  self.addDirectory = function (dir, req, mainFilename, opts) {
+  self.addDirectory = function (dir, context, req, mainFilename, opts) {
     opts = opts || {}
+    // dir should be relative to the command module
+    dir = path.join(context.dirs[context.commands.join('|')] || '', dir)
+    // disable recursion to support nested directories of subcommands
+    if (typeof opts.recurse !== 'boolean') opts.recurse = false
+    // exclude 'json', 'coffee' from require-directory defaults
+    if (!Array.isArray(opts.extensions)) opts.extensions = ['js']
+    // allow consumer to define their own visitor function
     var parentVisit = typeof opts.visit === 'function' ? opts.visit : function (o) { return o }
+    // call addHandler via visitor function
     opts.visit = function (obj, joined, filename) {
       var visited = parentVisit(obj, joined, filename)
-      if (visited) self.addHandler(visited)
+      // allow consumer to skip modules with their own visitor
+      if (visited) {
+        // check for cyclic reference
+        // each command file path should only be seen once per execution
+        if (~context.files.indexOf(joined)) return visited
+        // keep track of visited files in context.files
+        context.files.push(joined)
+        // map "command path" to the directory path it came from
+        // so that dir can be relative in the API
+        context.dirs[context.commands.concat(parseCommand(visited.command).cmd).join('|')] = dir
+        self.addHandler(visited)
+      }
       return visited
     }
     requireDirectory({ require: req, filename: mainFilename }, dir, opts)

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,3 +1,5 @@
+var requireDirectory = require('require-directory')
+
 // handles parsing positional arguments,
 // and populating argv with said positional
 // arguments.
@@ -6,6 +8,8 @@ module.exports = function (yargs, usage, validation) {
 
   var handlers = {}
   self.addHandler = function (cmd, description, builder, handler) {
+    // TODO allow objects that only define command and description
+    
     // allow a module to define all properties
     if (typeof cmd === 'object' && typeof cmd.command === 'string' && cmd.builder && typeof cmd.handler === 'function') {
       self.addHandler(cmd.command, extractDesc(cmd), cmd.builder, cmd.handler)
@@ -33,6 +37,17 @@ module.exports = function (yargs, usage, validation) {
       demanded: parsedCommand.demanded,
       optional: parsedCommand.optional
     }
+  }
+
+  self.addDirectory = function (dir, req, mainFilename, opts) {
+    opts = opts || {}
+    var parentVisit = typeof opts.visit === 'function' ? opts.visit : function (o) { return o }
+    opts.visit = function (obj, joined, filename) {
+      var visited = parentVisit(obj, joined, filename)
+      if (visited) self.addHandler(visited)
+      return visited
+    }
+    requireDirectory({ require: req, filename: mainFilename }, dir, opts)
   }
 
   function extractDesc (obj) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,5 @@
-var path = require('path')
-var requireDirectory = require('require-directory')
+const path = require('path')
+const requireDirectory = require('require-directory')
 
 // handles parsing positional arguments,
 // and populating argv with said positional
@@ -51,10 +51,10 @@ module.exports = function (yargs, usage, validation) {
     // exclude 'json', 'coffee' from require-directory defaults
     if (!Array.isArray(opts.extensions)) opts.extensions = ['js']
     // allow consumer to define their own visitor function
-    var parentVisit = typeof opts.visit === 'function' ? opts.visit : function (o) { return o }
+    const parentVisit = typeof opts.visit === 'function' ? opts.visit : function (o) { return o }
     // call addHandler via visitor function
     opts.visit = function (obj, joined, filename) {
-      var visited = parentVisit(obj, joined, filename)
+      const visited = parentVisit(obj, joined, filename)
       // allow consumer to skip modules with their own visitor
       if (visited) {
         // check for cyclic reference

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "os-locale": "^1.4.0",
     "pkg-conf": "^1.1.2",
     "read-pkg-up": "^1.0.1",
+    "require-directory": "^2.1.1",
     "require-main-filename": "^1.0.1",
     "set-blocking": "^2.0.0",
     "string-width": "^1.0.1",

--- a/test/fixtures/cmddir/deep/deeper/deeper_still/limbo.js
+++ b/test/fixtures/cmddir/deep/deeper/deeper_still/limbo.js
@@ -1,0 +1,28 @@
+exports.command = 'limbo [opts]'
+exports.desc = 'Get lost in pure subconscious'
+exports.builder = {
+  'with-self-exit': {
+    desc: 'Pretty much your only way out',
+    type: 'boolean'
+  },
+  'with-totem': {
+    desc: 'Take your totem with you',
+    type: 'boolean'
+  }
+}
+exports.handler = function (argv) {
+  var factor = 3
+  if (!argv.withSelfExit) throw new Error('You entered limbo without a way out!')
+  if (!argv.withTotem) factor -= 2
+  if (argv.extract) {
+    if (!chancesLevel4(factor)) throw new Error('You didn\'t have much chance anyway, you\'re stuck in limbo!')
+    if (!argv._msg) argv._msg = 'You have accomplished the impossible. Inception successful.'
+    return
+  }
+  if (!chancesLevel4(factor)) throw new Error('You rolled the dice and lost, you\'re stuck in limbo!')
+  if (!argv._msg) argv._msg = 'Can you ever be sure of what\'s real anymore?'
+}
+
+function chancesLevel4 (factor) {
+  return Math.floor(Math.random() * 10) < factor
+}

--- a/test/fixtures/cmddir/deep/deeper/inception.js
+++ b/test/fixtures/cmddir/deep/deeper/inception.js
@@ -1,0 +1,32 @@
+exports.command = 'inception [command] [opts]'
+exports.desc = 'Enter another dream, where inception is possible'
+exports.builder = function (yargs) {
+  return yargs
+    .commandDir('deeper_still')
+    .option('with-sedation', {
+      desc: 'Apply a sedative?',
+      type: 'boolean',
+      global: true
+    })
+    .option('with-timed-kick', {
+      desc: 'Plan an elaborate timed kick at each layer?',
+      type: 'boolean',
+      global: true
+    })
+}
+exports.handler = function (argv) {
+  var factor = 5
+  if (argv.extract) {
+    if (!argv.withSedation) factor -= 1
+    if (!argv.withTimedKick) factor -= 1
+    if (!chancesLevel3(factor)) throw new Error('Something went wrong at level 3! Check your options for increased chance of success.')
+    if (!argv._msg) argv._msg = 'You have narrowly escaped disaster. Inception successful.'
+    return
+  }
+  if (!chancesLevel3(factor)) throw new Error('You can no longer tell a dream from reality!')
+  if (!argv._msg) argv._msg = 'Be very careful, you\'re starting to lose grip on reality.'
+}
+
+function chancesLevel3 (factor) {
+  return Math.floor(Math.random() * 10) < factor
+}

--- a/test/fixtures/cmddir/deep/of-memory.json
+++ b/test/fixtures/cmddir/deep/of-memory.json
@@ -1,0 +1,4 @@
+{
+  "command": "of-memory <memory>",
+  "desc": "Dream about a specific memory"
+}

--- a/test/fixtures/cmddir/deep/within-a-dream.js
+++ b/test/fixtures/cmddir/deep/within-a-dream.js
@@ -1,0 +1,27 @@
+module.exports = {
+  command: 'within-a-dream [command] [opts]',
+  desc: 'Dream within a dream',
+  builder: function (yargs) {
+    return yargs
+      .commandDir('deeper')
+      .option('with-kick', {
+        desc: 'Plan a kick for controlled wake up?',
+        type: 'boolean',
+        global: true
+      })
+  },
+  handler: function (argv) {
+    var factor = 7
+    if (argv.extract) {
+      if (!argv.withKick) factor -= 2
+      if (!chancesLevel2(factor)) throw new Error('Something went wrong at level 2! Check your options for increased chance of success.')
+      if (!argv._msg) argv._msg = 'You got lucky this time. Extraction successful.'
+      return
+    }
+    if (!argv._msg) argv._msg = 'Let\'s not make a habit of this.'
+  }
+}
+
+function chancesLevel2 (factor) {
+  return Math.floor(Math.random() * 10) < factor
+}

--- a/test/fixtures/cmddir/dream.js
+++ b/test/fixtures/cmddir/dream.js
@@ -1,0 +1,31 @@
+exports.command = 'dream [command] [opts]'
+exports.desc = 'Go to sleep and dream'
+exports.builder = function (yargs) {
+  return yargs
+    .commandDir('deep', {
+      extensions: ['js', 'json']
+    })
+    .option('shared', {
+      desc: 'Is the dream shared with others?',
+      type: 'boolean',
+      global: true
+    })
+    .option('extract', {
+      desc: 'Attempt extraction?',
+      type: 'boolean',
+      global: true
+    })
+}
+exports.handler = function (argv) {
+  if (argv.extract) {
+    if (!argv.shared) throw new Error('Dream is not shared, there is no one to extract from!')
+    if (!chancesLevel1()) throw new Error('Extraction failed!')
+    if (!argv._msg) argv._msg = 'Extraction succesful'
+  }
+  if (argv._msg) console.log(argv._msg)
+  else console.log(argv.shared ? 'Training session over' : 'Well, that was a refreshing nap')
+}
+
+function chancesLevel1 () {
+  return Math.floor(Math.random() * 10) < 9
+}

--- a/test/fixtures/cmddir_cyclic/cyclic.js
+++ b/test/fixtures/cmddir_cyclic/cyclic.js
@@ -1,0 +1,6 @@
+exports.command = 'cyclic'
+exports.description = 'Attempts to (re)apply its own dir'
+exports.builder = function (yargs) {
+  return yargs.commandDir('../cmddir_cyclic')
+}
+exports.handler = function (argv) {}

--- a/yargs.js
+++ b/yargs.js
@@ -207,7 +207,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self.commandDir = function (dir, opts) {
-    var req = parentRequire || require
+    const req = parentRequire || require
     command.addDirectory(dir, self.getContext(), req, requireMainFilename(req), opts)
     return self
   }

--- a/yargs.js
+++ b/yargs.js
@@ -50,7 +50,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  const context = { resets: -1, commands: [] }
+  const context = { resets: -1, commands: [], dirs: {}, files: [] }
   self.getContext = function () {
     return context
   }
@@ -208,7 +208,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.commandDir = function (dir, opts) {
     var req = parentRequire || require
-    command.addDirectory(dir, req, requireMainFilename(req), opts)
+    command.addDirectory(dir, self.getContext(), req, requireMainFilename(req), opts)
     return self
   }
 

--- a/yargs.js
+++ b/yargs.js
@@ -206,6 +206,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
+  self.commandDir = function (dir, opts) {
+    var req = parentRequire || require
+    command.addDirectory(dir, req, requireMainFilename(req), opts)
+    return self
+  }
+
   self.string = function (strings) {
     options.string.push.apply(options.string, [].concat(strings))
     return self


### PR DESCRIPTION
This replaces #463, opting to require modules from a single directory at a time via `require-directory` (instead of supporting globs).

The implementation is slightly trickier than I originally thought, but it allows a consumer to do things like the following.

### Example setup

**directory structure**:

```
cli.js
commands/
  people.js
  places.js
  things.js
  common_cmds/
    details.js
    search.js
  people_cmds/
    call.js
  places_cmds/
    nav.js
```

**cli.js**:

```js
#!/usr/bin/env node
require('yargs')
  // apply people.js, places.js, things.js but not subdirectories
  .commandDir('commands')
  .help()
  .wrap(40)
  .argv
```

**commands/people.js**:

```js
exports.command = 'people <command>'
exports.desc = 'Work with people'
exports.builder = function (yargs) {
  // apply commands in subdirectories
  return yargs.commandDir('common_cmds').commandDir('people_cmds')
}
exports.handler = function (argv) {}
```

**commands/places.js**:

```js
exports.command = 'places <command>'
exports.desc = 'Work with places'
exports.builder = function (yargs) {
  // you can even share the same subcommands e.g. common_cmds
  return yargs.commandDir('common_cmds').commandDir('places_cmds')
}
exports.handler = function (argv) {}
```

**commands/things.js**:

```js
exports.command = 'things <command>'
exports.desc = 'Work with things'
exports.builder = function (yargs) {
  return yargs.commandDir('common_cmds')
}
exports.handler = function (argv) {}
```

**commands/common_cmds/details.js**:

```js
exports.command = 'details <name>'
exports.desc = 'Get details by name'
exports.builder = {}
exports.handler = function (argv) {
  // parent command accessible via argv._ as always
  console.log('getting %s details for name: %s', argv._[0], argv.name)
}
```

### Example CLI

```
$ ./cli.js --help
Commands:
  people <command>  Work with people
  places <command>  Work with places
  things <command>  Work with things

Options:
  --help  Show help            [boolean]
```

```
$ ./cli.js people --help
cli.js people <command>

Commands:
  details <name>  Get details by name
  search <query>  Search via query
  call <person>   Call someone

Options:
  --help  Show help            [boolean]
```

```
$ ./cli.js people details       
cli.js people details <name>

Options:
  --help  Show help            [boolean]

Not enough non-option arguments: got 0, need at least 1
```

```
$ ./cli.js people details Andrew
getting people details for name: Andrew
```

### API

This adds one method to the API: `.commandDir(dir, [opts])`

`dir` is a directory name which can/should be relative to the module calling the method.

`opts` is an options object that is passed to `require-directory`, allowing consumers to customize the behavior. In the initial implementation, the following opts are valid:

- `opts.recurse`: boolean, default `false`

    Should yargs require command modules from all nested directories? The default is `false` so subcommands can be nested instead of flattened.

- `opts.extensions`: array of strings, default `['js']`

    The types of files to include when requiring.

- `opts.visit`: function

    A synchronous function that is called for each command module encountered. Accepts `commandObject`, `pathToFile`, and `filename` as arguments. Returns `commandObject` to include the command; any falsey value to exclude/skip it.

- `opts.include`: RegExp or function

    Whitelist certain modules. See [require-directory whitelisting](https://www.npmjs.com/package/require-directory#whitelisting) for details.

- `opts.exclude`: RegExp or function

    Blacklist certain modules. See [require-directory blacklisting](https://www.npmjs.com/package/require-directory#blacklisting) for details.

### Notes

This also includes a change that allows a command module to only define `command` and `description`, which better supports requiring JSON modules (though I'm not sure why someone would want to do that) and fulfills (at least) a part of #492.

I considered adding support for using the filename of a command module as its `command` string if the module itself doesn't define `command`, but I think it'd be nice to support this for _all_ command modules (i.e. not just when using `.commandDir()`), so I'd like to tackle that separately/subsequently.

I don't have strong feelings about the method name `commandDir`. Would be happy to change it if folks like something else better. As always, feedback is welcomed!

### Still lacking

- [x] Tests!
- [x] README update