### PR TITLE
chore: use const as a semantic tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 // classic singleton yargs API, to use yargs
 // without running as a singleton do:
 // require('yargs/yargs')(process.argv.slice(2))
-var yargs = require('./yargs')
+const yargs = require('./yargs')
 
 Argv(process.argv.slice(2))
 
 module.exports = Argv
 
 function Argv (processArgs, cwd) {
-  var argv = yargs(processArgs, cwd, require)
+  const argv = yargs(processArgs, cwd, require)
   singletonify(argv)
   return argv
 }

--- a/lib/command.js
+++ b/lib/command.js
@@ -2,7 +2,7 @@
 // and populating argv with said positional
 // arguments.
 module.exports = function (yargs, usage, validation) {
-  var self = {}
+  const self = {}
 
   var handlers = {}
   self.addHandler = function (cmd, description, builder, handler) {

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -1,20 +1,20 @@
-var fs = require('fs')
-var path = require('path')
+const fs = require('fs')
+const path = require('path')
 
 // add bash completions to your
 //  yargs-powered applications.
 module.exports = function (yargs, usage, command) {
-  var self = {
+  const self = {
     completionKey: 'get-yargs-completions'
   }
 
   // get a list of completion commands.
   // 'args' is the array of strings from the line to be completed
   self.getCompletion = function (args, done) {
-    var completions = []
-    var current = args.length ? args[args.length - 1] : ''
-    var argv = yargs.parse(args, true)
-    var aliases = yargs.parsed.aliases
+    const completions = []
+    const current = args.length ? args[args.length - 1] : ''
+    const argv = yargs.parse(args, true)
+    const aliases = yargs.parsed.aliases
 
     // a custom completion function can be provided
     // to completion().

--- a/lib/obj-filter.js
+++ b/lib/obj-filter.js
@@ -1,5 +1,5 @@
 module.exports = function (original, filter) {
-  var obj = {}
+  const obj = {}
   filter = filter || function (k, v) { return true }
   Object.keys(original || {}).forEach(function (key) {
     if (filter(key, original[key])) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,14 +1,14 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-var cliui = require('cliui')
-var decamelize = require('decamelize')
-var stringWidth = require('string-width')
-var wsize = require('window-size')
-var objFilter = require('./obj-filter')
+const cliui = require('cliui')
+const decamelize = require('decamelize')
+const stringWidth = require('string-width')
+const wsize = require('window-size')
+const objFilter = require('./obj-filter')
 
 module.exports = function (yargs, y18n) {
-  var __ = y18n.__
-  var self = {}
+  const __ = y18n.__
+  const self = {}
 
   // methods for ouputting/building failure message.
   var fails = []

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,17 +1,17 @@
-var objFilter = require('./obj-filter')
+const objFilter = require('./obj-filter')
 
 // validation-type-stuff, missing params,
 // bad implications, custom checks.
 module.exports = function (yargs, usage, y18n) {
-  var __ = y18n.__
-  var __n = y18n.__n
-  var self = {}
+  const __ = y18n.__
+  const __n = y18n.__n
+  const self = {}
 
   // validate appropriate # of non-option
   // arguments were provided, i.e., '_'.
   self.nonOptionCount = function (argv) {
-    var demanded = yargs.getDemanded()
-    var _s = argv._.length
+    const demanded = yargs.getDemanded()
+    const _s = argv._.length
 
     if (demanded._ && (_s < demanded._.count || _s > demanded._.max)) {
       if (demanded._.msg !== undefined) {
@@ -41,14 +41,14 @@ module.exports = function (yargs, usage, y18n) {
   // make sure that any args that require an
   // value (--foo=bar), have a value.
   self.missingArgumentValue = function (argv) {
-    var defaultValues = [true, false, '']
-    var options = yargs.getOptions()
+    const defaultValues = [true, false, '']
+    const options = yargs.getOptions()
 
     if (options.requiresArg.length > 0) {
-      var missingRequiredArgs = []
+      const missingRequiredArgs = []
 
       options.requiresArg.forEach(function (key) {
-        var value = argv[key]
+        const value = argv[key]
 
         // if a value is explicitly requested,
         // flag argument as missing if it does not
@@ -72,7 +72,7 @@ module.exports = function (yargs, usage, y18n) {
 
   // make sure all the required arguments are present.
   self.requiredArguments = function (argv) {
-    var demanded = yargs.getDemanded()
+    const demanded = yargs.getDemanded()
     var missing = null
 
     Object.keys(demanded).forEach(function (key) {
@@ -83,15 +83,15 @@ module.exports = function (yargs, usage, y18n) {
     })
 
     if (missing) {
-      var customMsgs = []
+      const customMsgs = []
       Object.keys(missing).forEach(function (key) {
-        var msg = missing[key].msg
+        const msg = missing[key].msg
         if (msg && customMsgs.indexOf(msg) < 0) {
           customMsgs.push(msg)
         }
       })
 
-      var customMsg = customMsgs.length ? '\n' + customMsgs.join('\n') : ''
+      const customMsg = customMsgs.length ? '\n' + customMsgs.join('\n') : ''
 
       usage.fail(__n(
         'Missing required argument: %s',
@@ -104,12 +104,12 @@ module.exports = function (yargs, usage, y18n) {
 
   // check for unknown arguments (strict-mode).
   self.unknownArguments = function (argv, aliases) {
-    var aliasLookup = {}
-    var descriptions = usage.getDescriptions()
-    var demanded = yargs.getDemanded()
-    var commandKeys = yargs.getCommandInstance().getCommands()
-    var unknown = []
-    var currentContext = yargs.getContext()
+    const aliasLookup = {}
+    const descriptions = usage.getDescriptions()
+    const demanded = yargs.getDemanded()
+    const commandKeys = yargs.getCommandInstance().getCommands()
+    const unknown = []
+    const currentContext = yargs.getContext()
 
     Object.keys(aliases).forEach(function (key) {
       aliases[key].forEach(function (alias) {
@@ -146,8 +146,8 @@ module.exports = function (yargs, usage, y18n) {
 
   // validate arguments limited to enumerated choices
   self.limitedChoices = function (argv) {
-    var options = yargs.getOptions()
-    var invalid = {}
+    const options = yargs.getOptions()
+    const invalid = {}
 
     if (!Object.keys(options.choices).length) return
 
@@ -163,7 +163,7 @@ module.exports = function (yargs, usage, y18n) {
       }
     })
 
-    var invalidKeys = Object.keys(invalid)
+    const invalidKeys = Object.keys(invalid)
 
     if (!invalidKeys.length) return
 
@@ -188,7 +188,7 @@ module.exports = function (yargs, usage, y18n) {
   self.customChecks = function (argv, aliases) {
     checks.forEach(function (f) {
       try {
-        var result = f(argv, aliases)
+        const result = f(argv, aliases)
         if (!result) {
           usage.fail(__('Argument check failed: %s', f.toString()))
         } else if (typeof result === 'string') {
@@ -216,11 +216,11 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   self.implications = function (argv) {
-    var implyFail = []
+    const implyFail = []
 
     Object.keys(implied).forEach(function (key) {
       var num
-      var origKey = key
+      const origKey = key
       var value = implied[key]
 
       // convert string '1' to number 1

--- a/yargs.js
+++ b/yargs.js
@@ -1,29 +1,29 @@
-var assert = require('assert')
-var assign = require('lodash.assign')
-var Command = require('./lib/command')
-var Completion = require('./lib/completion')
-var Parser = require('yargs-parser')
-var path = require('path')
-var Usage = require('./lib/usage')
-var Validation = require('./lib/validation')
-var Y18n = require('y18n')
-var readPkgUp = require('read-pkg-up')
-var pkgConf = require('pkg-conf')
-var requireMainFilename = require('require-main-filename')
-var objFilter = require('./lib/obj-filter')
+const assert = require('assert')
+const assign = require('lodash.assign')
+const Command = require('./lib/command')
+const Completion = require('./lib/completion')
+const Parser = require('yargs-parser')
+const path = require('path')
+const Usage = require('./lib/usage')
+const Validation = require('./lib/validation')
+const Y18n = require('y18n')
+const readPkgUp = require('read-pkg-up')
+const pkgConf = require('pkg-conf')
+const requireMainFilename = require('require-main-filename')
+const objFilter = require('./lib/obj-filter')
 
 var exports = module.exports = Yargs
 function Yargs (processArgs, cwd, parentRequire) {
   processArgs = processArgs || [] // handle calling yargs().
 
-  var self = {}
+  const self = {}
   var command = null
   var completion = null
   var groups = {}
   var preservedGroups = {}
   var usage = null
   var validation = null
-  var y18n = Y18n({
+  const y18n = Y18n({
     directory: path.resolve(__dirname, './locales'),
     updateFiles: false
   })
@@ -49,7 +49,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  var context = { resets: -1, commands: [] }
+  const context = { resets: -1, commands: [] }
   self.getContext = function () {
     return context
   }
@@ -621,8 +621,8 @@ function Yargs (processArgs, cwd, parentRequire) {
       defaults: {},
       cwd: requireMainFilename(require)
     })
-    var parsed = Parser.detailed(args, options)
-    var argv = parsed.argv
+    const parsed = Parser.detailed(args, options)
+    const argv = parsed.argv
     var aliases = parsed.aliases
 
     argv.$0 = self.$0
@@ -726,7 +726,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (!detectLocale) return
 
     try {
-      var osLocale = require('os-locale')
+      const osLocale = require('os-locale')
       self.locale(osLocale.sync({ spawn: false }))
     } catch (err) {
       // if we explode looking up locale just noop


### PR DESCRIPTION
Philosophy behind this: http://womack.io/2016/01/05/Const-ant-Craving/
tldr;
* `const` has been supported in Node.js since at least 0.4
* `const` makes code more readable—it's clear a value won't change
* standard helps w/ this by pointing out when `const` is misused