### PR TITLE
Show better output on command handler error

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -163,7 +163,12 @@ module.exports = function (yargs, usage, validation) {
     populatePositional(commandHandler, innerArgv, currentContext)
 
     if (commandHandler.handler) {
-      commandHandler.handler(innerArgv)
+      try {
+        commandHandler.handler(innerArgv)
+      } catch (err) {
+        err._yargsErrorName = 'COMMAND_HANDLER_ERROR'
+        throw err
+      }
     }
     currentContext.commands.pop()
     return innerArgv

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -44,9 +44,16 @@ module.exports = function (yargs, y18n) {
       if (!failureOutput) {
         failureOutput = true
         if (showHelpOnFail) yargs.showHelp('error')
-        if (msg) console.error(msg)
+        var padFailMessage = false
+        if (err._yargsErrorName) {
+          console.error(err._yargsErrorName + ':', err.stack)
+          padFailMessage = true
+        } else if (msg) {
+          console.error(msg)
+          padFailMessage = true
+        }
         if (failMessage) {
-          if (msg) console.error('')
+          if (padFailMessage) console.error('')
           console.error(failMessage)
         }
       }


### PR DESCRIPTION
I had a similar issue to https://github.com/yargs/yargs/issues/373

My subcommands were throwing errors, and yargs was eating them and only printing the message (if any).  No stack trace, very sad.

This adds a field to errors resulting from `commandHandler.handler()` calls, `_yargsErrorName `.  The presence of this field causes usage to print the `_yargsErrorName` along with the original `err.stack`.

### Example:
Lets assume that the error I am throwing in my handler is `throw new Error('boop')` 

Old (not helpful):
``` bash
# Missing demand arg
$ my-command
<HELP TEXT>

# With demand arg, handler throws error
$ my-command --required-arg
<HELP TEXT>

boop
```

New (yes helpful):
``` bash
# Missing demand arg
$ my-command
<HELP TEXT>

# With demand arg, handler throws error
$ my-command --required-arg
<HELP TEXT>

COMMAND_HANDLER_ERROR: Error: boop
    at <STACK>
```