### PR TITLE
fix: we now respect the order of _ when applying commands

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -455,4 +455,20 @@ describe('Command', function () {
       ])
     })
   })
+
+  // addresses https://github.com/yargs/yargs/issues/514.
+  it('respects order of positional arguments when matching commands', function () {
+    var output = []
+    yargs('bar foo')
+      .command('foo', 'foo command', function (yargs) {
+        output.push('foo')
+      })
+      .command('bar', 'bar command', function (yargs) {
+        output.push('bar')
+      })
+      .argv
+
+    output.should.include('bar')
+    output.should.not.include('foo')
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -647,8 +647,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     // if there's a handler associated with a
     // command defer processing to it.
     var handlerKeys = command.getCommands()
-    for (var i = 0, cmd; (cmd = handlerKeys[i]) !== undefined; i++) {
-      if (~argv._.indexOf(cmd) && cmd !== completionCommand) {
+    for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
+      if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
         setPlaceholderKeys(argv)
         return command.runCommand(cmd, self, parsed)
       }


### PR DESCRIPTION
We were applying commands in the order that handlers were defined, rather than the order of `_`, fixes #514 