### PR TITLE
feat: use readme from latest published version instead of master

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,13 @@
 
   <!-- Initializer -->
   <script>
-    Flatdoc.run({
-      fetcher: Flatdoc.github('bcoe/yargs')
-    });
+    // use https://jsonp.afeld.me/ to wrap registry json in jsonp
+    $.get('https://jsonp.afeld.me/?url=https://registry.npmjs.org/yargs', function (data) {
+      var version = data['dist-tags'] && data['dist-tags'].latest
+      Flatdoc.run({
+        fetcher: Flatdoc.file('https://raw.githubusercontent.com/yargs/yargs/v' + version + '/README.md')
+      })
+    }, 'jsonp')
   </script>
 </head>
 <body role='flatdoc' class='no-literate'>


### PR DESCRIPTION
Instead of having Flatdoc render the README from master, let's query the registry for the `latest` published version of yargs and tell Flatdoc to use the corresponding tag in GitHub.

This should fix the [problem where ](https://github.com/yargs/yargs/issues/529#issuecomment-226997791) [our docs are out-of-sync ](https://github.com/yargs/yargs/issues/529#issuecomment-228461862) [with what's actually published](https://github.com/yargs/yargs/issues/529#issuecomment-229407166).

Note that this introduces a dependency on an external service (https://jsonp.afeld.me/) in order to wrap the JSON from the public npm registry in a JSONP response, to get around the lack of CORS support in the registry. We could use [YQL](https://developer.yahoo.com/yql/) as a "more stable" alternative, but that would require [attribution](https://developer.yahoo.com/attribution/) and I would prefer to support the [awesome open source](https://github.com/afeld/jsonp) service by @afeld instead. (If you agree, please go star the repo!)