### PR TITLE
fix: lazy-load package.json and cache. get rid of pkg-conf dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "decamelize": "^1.1.1",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",
-    "pkg-conf": "^1.1.2",
     "read-pkg-up": "^1.0.1",
     "require-directory": "^2.1.1",
     "require-main-filename": "^1.0.1",


### PR DESCRIPTION
we dug into some of the performance concerns with yargs in #521, and came up with an initial quick win.

In this pull request we:

* eliminate `pkg-conf` in favor of using `read-pkg-up` exclusively.
* we lazy-load `read-pkg-up` (the require time for modules was leading to some of yargs' bad performance benchmarks).
* we cache the `package.json` the first time we load it.

- [x] published this to `next` tag and made sure that `pkgConf` and yargs configuration continues working as expected.