### PR TITLE
fix(commandDir): make dir relative to caller instead of require.main.filename

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -42,10 +42,8 @@ module.exports = function (yargs, usage, validation) {
     }
   }
 
-  self.addDirectory = function (dir, context, req, mainFilename, opts) {
+  self.addDirectory = function (dir, context, req, callerFile, opts) {
     opts = opts || {}
-    // dir should be relative to the command module
-    dir = path.join(context.dirs[context.commands.join('|')] || '', dir)
     // disable recursion to support nested directories of subcommands
     if (typeof opts.recurse !== 'boolean') opts.recurse = false
     // exclude 'json', 'coffee' from require-directory defaults
@@ -62,14 +60,11 @@ module.exports = function (yargs, usage, validation) {
         if (~context.files.indexOf(joined)) return visited
         // keep track of visited files in context.files
         context.files.push(joined)
-        // map "command path" to the directory path it came from
-        // so that dir can be relative in the API
-        context.dirs[context.commands.concat(parseCommand(visited.command || commandFromFilename(filename)).cmd).join('|')] = dir
         self.addHandler(visited)
       }
       return visited
     }
-    requireDirectory({ require: req, filename: mainFilename }, dir, opts)
+    requireDirectory({ require: req, filename: callerFile }, dir, opts)
   }
 
   // lookup module object from require()d command and derive name

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
+    "get-caller-file": "^1.0.1",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",
     "read-pkg-up": "^1.0.1",

--- a/test/command.js
+++ b/test/command.js
@@ -344,8 +344,7 @@ describe('Command', function () {
     it('supports relative dirs', function () {
       var r = checkOutput(function () {
         return yargs('--help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir')
+          .commandDir('fixtures/cmddir')
           .argv
       })
       r.should.have.property('exit').and.be.true
@@ -363,8 +362,7 @@ describe('Command', function () {
     it('supports nested subcommands', function () {
       var r = checkOutput(function () {
         return yargs('dream --help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir')
+          .commandDir('fixtures/cmddir')
           .argv
       }, [ './command' ])
       r.should.have.property('exit').and.be.true
@@ -386,8 +384,7 @@ describe('Command', function () {
     it('supports a "recurse" boolean option', function () {
       var r = checkOutput(function () {
         return yargs('--help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir', { recurse: true })
+          .commandDir('fixtures/cmddir', { recurse: true })
           .argv
       })
       r.should.have.property('exit').and.be.true
@@ -411,8 +408,7 @@ describe('Command', function () {
       var filename
       var r = checkOutput(function () {
         return yargs('--help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir', {
+          .commandDir('fixtures/cmddir', {
             visit: function (_commandObject, _pathToFile, _filename) {
               commandObject = _commandObject
               pathToFile = _pathToFile
@@ -441,8 +437,7 @@ describe('Command', function () {
     it('detects and ignores cyclic dir references', function () {
       var r = checkOutput(function () {
         return yargs('cyclic --help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir_cyclic')
+          .commandDir('fixtures/cmddir_cyclic')
           .argv
       }, [ './command' ])
       r.should.have.property('exit').and.be.true
@@ -459,8 +454,7 @@ describe('Command', function () {
     it('derives \'command\' string from filename when not exported', function () {
       var r = checkOutput(function () {
         return yargs('--help').help().wrap(null)
-          // assumes cwd is node_modules/mocha/bin
-          .commandDir('../../../test/fixtures/cmddir_noname')
+          .commandDir('fixtures/cmddir_noname')
           .argv
       })
       r.should.have.property('exit').and.be.true

--- a/yargs.js
+++ b/yargs.js
@@ -49,7 +49,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  const context = { resets: -1, commands: [], dirs: {}, files: [] }
+  const context = { resets: -1, commands: [], files: [] }
   self.getContext = function () {
     return context
   }
@@ -207,7 +207,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.commandDir = function (dir, opts) {
     const req = parentRequire || require
-    command.addDirectory(dir, self.getContext(), req, requireMainFilename(req), opts)
+    command.addDirectory(dir, self.getContext(), req, require('get-caller-file')(), opts)
     return self
   }
 


### PR DESCRIPTION
Pull in [`get-caller-file`](https://github.com/stefanpenner/get-caller-file) to always interpret the directory given to `.commandDir()` as relative to the caller. This actually helps simplify the logic a good bit since I no longer need to keep track of a command-to-dir mapping between calls.

The `require` is deliberately lazy, so we only load the dependency if `.commandDir()` is called.

There are a few different packages that provide the "get filename of caller" functionality, but I chose `get-caller-file` because it was the only one that already had passing tests for the range of Node we need and includes Windows tests ([`caller`](https://github.com/totherik/caller) seems to be popular but is lacking the fuller range of testing, and [`caller-path` seems to be broken on Node 4+](https://github.com/sindresorhus/caller-path/issues/1)). An added benefit is that `get-caller-file` also seems to be the smallest and only pulls in one dependency.

Fixes #529.