### PR TITLE
feat(command): builder function no longer needs to return the yargs instance

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -137,10 +137,14 @@ module.exports = function (yargs, usage, validation) {
       // and did not explicitly set a usage() string, then apply the
       // original command string as usage() for consistent behavior with
       // options object below
-      if (yargs.parsed === false && typeof yargs.getUsageInstance().getUsage() === 'undefined') {
-        yargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
+      if (yargs.parsed === false) {
+        if (typeof yargs.getUsageInstance().getUsage() === 'undefined') {
+          yargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
+        }
+        innerArgv = innerArgv ? innerArgv.argv : yargs.argv
+      } else {
+        innerArgv = yargs.parsed.argv
       }
-      innerArgv = innerArgv ? innerArgv.argv : yargs.argv
     } else if (commandHandler.builder && typeof commandHandler.builder === 'object') {
       // as a short hand, an object can instead be provided, specifying
       // the options that a command takes.

--- a/lib/command.js
+++ b/lib/command.js
@@ -130,8 +130,8 @@ module.exports = function (yargs, usage, validation) {
     var parentCommands = currentContext.commands.slice()
     currentContext.commands.push(command)
     if (commandHandler.builder && typeof commandHandler.builder === 'function') {
-      // a function can be provided, which interacts which builds
-      // up a yargs chain and returns it.
+      // a function can be provided, which builds
+      // up a yargs chain and possibly returns it.
       innerArgv = commandHandler.builder(yargs.reset(parsed.aliases))
       // if the builder function did not yet parse argv with reset yargs
       // and did not explicitly set a usage() string, then apply the
@@ -140,7 +140,7 @@ module.exports = function (yargs, usage, validation) {
       if (yargs.parsed === false && typeof yargs.getUsageInstance().getUsage() === 'undefined') {
         yargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
       }
-      innerArgv = innerArgv ? innerArgv.argv : argv
+      innerArgv = innerArgv ? innerArgv.argv : yargs.argv
     } else if (commandHandler.builder && typeof commandHandler.builder === 'object') {
       // as a short hand, an object can instead be provided, specifying
       // the options that a command takes.

--- a/test/command.js
+++ b/test/command.js
@@ -493,4 +493,14 @@ describe('Command', function () {
     var argv = y.parse(['foo', 'bar'])
     argv.second.should.equal('bar')
   })
+
+  // addresses https://github.com/yargs/yargs/issues/522
+  it('does not require builder function to return', function () {
+    var argv = yargs('yo')
+      .command('yo [someone]', 'Send someone a yo', function (yargs) {
+        yargs.default('someone', 'Pat')
+      })
+      .argv
+    argv.should.have.property('someone').and.equal('Pat')
+  })
 })

--- a/test/command.js
+++ b/test/command.js
@@ -499,8 +499,32 @@ describe('Command', function () {
     var argv = yargs('yo')
       .command('yo [someone]', 'Send someone a yo', function (yargs) {
         yargs.default('someone', 'Pat')
+      }, function (argv) {
+        argv.should.have.property('someone').and.equal('Pat')
       })
       .argv
     argv.should.have.property('someone').and.equal('Pat')
+  })
+
+  it('allows builder function to parse argv without returning', function () {
+    var argv = yargs('yo Jude')
+      .command('yo <someone>', 'Send someone a yo', function (yargs) {
+        yargs.argv
+      }, function (argv) {
+        argv.should.have.property('someone').and.equal('Jude')
+      })
+      .argv
+    argv.should.have.property('someone').and.equal('Jude')
+  })
+
+  it('allows builder function to return parsed argv', function () {
+    var argv = yargs('yo Leslie')
+      .command('yo <someone>', 'Send someone a yo', function (yargs) {
+        return yargs.argv
+      }, function (argv) {
+        argv.should.have.property('someone').and.equal('Leslie')
+      })
+      .argv
+    argv.should.have.property('someone').and.equal('Leslie')
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -40,7 +40,7 @@ describe('yargs dsl tests', function () {
     Object.keys(argv).should.include('cool')
   })
 
-  it('populates argv with placeholder keys when passed into command handler', function (done) {
+  it.skip('populates argv with placeholder keys when passed into command handler', function (done) {
     yargs(['blerg'])
       .option('cool', {})
       .command('blerg', 'handle blerg things', function () {}, function (argv) {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -40,17 +40,6 @@ describe('yargs dsl tests', function () {
     Object.keys(argv).should.include('cool')
   })
 
-  it.skip('populates argv with placeholder keys when passed into command handler', function (done) {
-    yargs(['blerg'])
-      .option('cool', {})
-      .command('blerg', 'handle blerg things', function () {}, function (argv) {
-        Object.keys(argv).should.include('cool')
-        return done()
-      })
-      .exitProcess(false) // defaults to true.
-      .argv
-  })
-
   it('accepts an object for implies', function () {
     var r = checkOutput(function () {
       return yargs(['--x=33'])


### PR DESCRIPTION
Fixes #522.

~~I'm not quite sure about the intentions of what should be allowed to be returned by the builder function. Returning the `yargs` instance or nothing should now work, but I wonder if we ever intended to allow it to return something like `yargs.argv`? If so, I think we will need a new issue for that.~~

Otherwise, this PR seems to work fine, but it could possibly result in unexpected behavior in user CLIs if they were previously not returning the `yargs` instance, either by mistake or not. For that reason, this change may be better suited for 5.x.

Note that I skipped the `populates argv with placeholder keys when passed into command handler` unit test because this change breaks it and it no longer seems to be valid (options must now be marked `global: true` in order to apply to the argv of a command handler, be it a placeholder or populated value). We should either remove it (if everyone agrees the test is no longer valid), or fix it by using `global: true` (which is tested elsewhere).

**UPDATE**: With commit 739a4f4, a builder function can also call `yargs.argv`, with or without returning. I think this is a good idea b/c I've seen a few folks [try to do this](https://github.com/yargs/yargs/issues/565) and it makes the API much less rigid. 😎 