### PR TITLE
fix: cache pkg lookups by path to avoid returning the wrong one

### DIFF
--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,5 +1,8 @@
 {
   "version": "9.9.9",
+  "repository": {
+    "type": "svn"
+  },
   "yargs": {
     "dot-notation": false
   }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -934,7 +934,7 @@ describe('yargs dsl tests', function () {
 
       argv.b.should.equal(99)
       argv.foo.should.equal('a')
-      expect(argv.git).to.equal(undefined)
+      expect(argv.type).to.equal(undefined)
     })
 
     it('allows an alternative cwd to be specified', function () {
@@ -944,6 +944,22 @@ describe('yargs dsl tests', function () {
 
       argv.foo.should.equal('a')
       argv.dotNotation.should.equal(false)
+    })
+
+    it('doesn\'t mess up other pkg lookups when cwd is specified', function () {
+      var r = checkOutput(function () {
+        return yargs('--version')
+          .pkgConf('repository', './test/fixtures')
+          .version()
+          .argv
+      })
+      const options = yargs.getOptions()
+
+      // assert pkgConf lookup (test/fixtures/package.json)
+      options.configObjects.should.deep.equal([{ type: 'svn' }])
+      // assert parseArgs and guessVersion lookup (package.json)
+      expect(options.configuration['dot-notation']).to.be.undefined
+      r.logs[0].should.not.equal('9.9.9') // breaks when yargs gets to this version
     })
 
     // see https://github.com/yargs/yargs/issues/485

--- a/yargs.js
+++ b/yargs.js
@@ -355,9 +355,10 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  var pkg = null
+  var pkgs = {}
   function pkgUp (path) {
-    if (pkg && !path) return pkg
+    var npath = path || '*'
+    if (pkgs[npath]) return pkgs[npath]
     const readPkgUp = require('read-pkg-up')
 
     var obj = {}
@@ -367,8 +368,8 @@ function Yargs (processArgs, cwd, parentRequire) {
       })
     } catch (noop) {}
 
-    if (obj.pkg) pkg = obj.pkg
-    return pkg || {}
+    pkgs[npath] = obj.pkg || {}
+    return pkgs[npath]
   }
 
   self.parse = function (args, shortCircuit) {


### PR DESCRIPTION
Fixes the small bug mentioned here: https://github.com/yargs/yargs/pull/544/files#r70469421

Includes test 😎 