### PR TITLE
feat: apply .env() globally

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -547,6 +547,23 @@ describe('Command', function () {
     })
   })
 
+  // see: https://github.com/yargs/yargs/pull/553
+  it('preserves top-level envPrefix', function () {
+    process.env.FUN_DIP_STICK = 'yummy'
+    process.env.FUN_DIP_POWDER = 'true'
+    yargs('eat')
+      .env('FUN_DIP')
+      .global('stick') // this does not actually need to be global
+      .command('eat', 'Adult supervision recommended', function (yargs) {
+        return yargs.boolean('powder').exitProcess(false)
+      }, function (argv) {
+        argv.should.have.property('powder').and.be.true
+        argv.should.have.property('stick').and.equal('yummy')
+      })
+      .exitProcess(false)
+      .argv
+  })
+
   // addresses https://github.com/yargs/yargs/issues/514.
   it('respects order of positional arguments when matching commands', function () {
     var output = []

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -226,7 +226,7 @@ describe('yargs dsl tests', function () {
         normalize: [],
         number: [],
         config: {},
-        envPrefix: undefined,
+        envPrefix: 'YARGS', // preserved as global
         global: ['help'],
         demanded: {}
       }

--- a/yargs.js
+++ b/yargs.js
@@ -113,7 +113,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       })
     })
 
-    tmpOptions.envPrefix = undefined
+    tmpOptions.envPrefix = options.envPrefix
     options = tmpOptions
 
     // if this is the first time being executed, create


### PR DESCRIPTION
Fixes #486.

This means that a configured `envPrefix` will not be reset for nested commands.

This could potentially be considered a breaking change since env vars that used to be ignored for the execution of command handlers may no longer be ignored. 😮 Otherwise, this could be considered a fix. 😕 