### PR TITLE
fix: positional arguments were not being handled appropriately by parse()

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -491,4 +491,12 @@ describe('Command', function () {
     output.should.include('bar')
     output.should.not.include('foo')
   })
+
+  // addresses https://github.com/yargs/yargs/issues/558
+  it('handles positional arguments if command is invoked using .parse()', function () {
+    var y = yargs([])
+      .command('foo <second>', 'the foo command', {})
+    var argv = y.parse(['foo', 'bar'])
+    argv.second.should.equal('bar')
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -372,6 +372,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self.parse = function (args, shortCircuit) {
+    if (!shortCircuit) processArgs = args
     return parseArgs(args, shortCircuit)
   }
 


### PR DESCRIPTION
fixes #558