### PR TITLE
fix: pull in @nexdrew's fixes to yargs-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "which-module": "^1.0.0",
     "window-size": "^0.2.0",
     "y18n": "^3.2.1",
-    "yargs-parser": "^2.4.0"
+    "yargs-parser": "^2.4.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",
     "chalk": "^1.1.3",
     "coveralls": "^2.11.11",
     "cpr": "^1.0.0",
-    "cross-spawn-async": "^2.2.1",
+    "cross-spawn": "^4.0.0",
     "es6-promise": "^3.0.2",
     "hashish": "0.0.4",
     "mocha": "^2.5.2",

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,6 +1,6 @@
 /* global describe, it, before, after */
 
-var spawn = require('cross-spawn-async')
+var spawn = require('cross-spawn')
 var path = require('path')
 var which = require('which')
 var rimraf = require('rimraf')


### PR DESCRIPTION
While we're at it, stop using the `cross-spawn-async` dependency which is deprecated.