### PR TITLE
feat: provide suggestions if unknown command is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,12 @@ as a configuration object.
 `cwd` can optionally be provided, the package.json will be read
 from this location.
 
+.recommendCommands(boolean)
+---------------------------
+
+If this feature is turned on, yargs will provide suggestions for similiar commands if a command is called
+that wasn't defined in your configuration. By default, this feature is disabled.
+
 .require(key, [msg | boolean])
 ------------------------------
 .required(key, [msg | boolean])

--- a/README.md
+++ b/README.md
@@ -1352,6 +1352,7 @@ from this location.
 
 If this feature is turned on, yargs will provide suggestions for similiar commands if a command is called
 that wasn't defined in your configuration. By default, this feature is disabled.
+Alternatively, you can also pass no argument to enable this feature.
 
 .require(key, [msg | boolean])
 ------------------------------

--- a/locales/de.json
+++ b/locales/de.json
@@ -34,5 +34,5 @@
   "Path to JSON config file": "Pfad zur JSON-Config Datei",
   "Show help": "Hilfe anzeigen",
   "Show version number": "Version anzeigen",
-  "Did you mean %s?": "Meinten Sie %s?"
+  "Did you mean %s?": "Meintest du %s?"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -33,5 +33,6 @@
   "Invalid JSON config file: %s": "Fehlerhafte JSON-Config Datei: %s",
   "Path to JSON config file": "Pfad zur JSON-Config Datei",
   "Show help": "Hilfe anzeigen",
-  "Show version number": "Version anzeigen"
+  "Show version number": "Version anzeigen",
+  "Did you mean %s?": "Meinten Sie %s?"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -33,5 +33,6 @@
   "Invalid JSON config file: %s": "Invalid JSON config file: %s",
   "Path to JSON config file": "Path to JSON config file",
   "Show help": "Show help",
-  "Show version number": "Show version number"
+  "Show version number": "Show version number",
+  "Did you mean %s?": "Did you mean %s?"
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
+    "didyoumean": "^1.2.1",
     "get-caller-file": "^1.0.1",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -270,6 +270,17 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
+    it('recommends a similiar command if no command handler is found', function () {
+      var r = checkOutput(function () {
+        yargs(['boat'])
+          .command('goat')
+          .recommendCommands(true)
+          .argv
+      })
+
+      r.logs[0].should.match(/Did you mean 'goat'/)
+    })
+
     it("skips executing top-level command if builder's help is executed", function () {
       var r = checkOutput(function () {
         yargs(['blerg', '-h'])

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -270,7 +270,7 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
-    it('recommends a similiar command if no command handler is found', function () {
+    it('recommends a similar command if no command handler is found', function () {
       var r = checkOutput(function () {
         yargs(['boat'])
           .command('goat')
@@ -279,6 +279,28 @@ describe('yargs dsl tests', function () {
       })
 
       r.logs[0].should.match(/Did you mean goat/)
+    })
+
+    it('does not recommend a similar command if a "false" is passed as a parameter', function () {
+      var r = checkOutput(function () {
+        yargs(['boat'])
+          .command('goat')
+          .recommendCommands(false)
+          .argv
+      })
+
+      r.logs.should.be.empty
+    })
+
+    it('does not recommend a similiar command if no similar command exists', function () {
+      var r = checkOutput(function () {
+        yargs(['foo'])
+          .command('nothingSimilar')
+          .recommendCommands()
+          .argv
+      })
+
+      r.logs.should.be.empty
     })
 
     it("skips executing top-level command if builder's help is executed", function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -278,7 +278,7 @@ describe('yargs dsl tests', function () {
           .argv
       })
 
-      r.logs[0].should.match(/Did you mean 'goat'/)
+      r.logs[0].should.match(/Did you mean goat/)
     })
 
     it("skips executing top-level command if builder's help is executed", function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -274,7 +274,7 @@ describe('yargs dsl tests', function () {
       var r = checkOutput(function () {
         yargs(['boat'])
           .command('goat')
-          .recommendCommands(true)
+          .recommendCommands()
           .argv
       })
 

--- a/yargs.js
+++ b/yargs.js
@@ -10,6 +10,7 @@ const Y18n = require('y18n')
 const requireMainFilename = require('require-main-filename')
 const objFilter = require('./lib/obj-filter')
 const setBlocking = require('set-blocking')
+const didYouMean = require('didyoumean')
 
 var exports = module.exports = Yargs
 function Yargs (processArgs, cwd, parentRequire) {
@@ -125,6 +126,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     exitProcess = true
     strict = false
+    recommendCommands = false
     completionCommand = null
     self.parsed = false
 
@@ -285,6 +287,12 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.getDemanded = function () {
     return options.demanded
+  }
+
+  var recommendCommands
+  self.recommendCommands = function (value) {
+    recommendCommands = !!value
+    return self
   }
 
   self.requiresArg = function (requiresArgs) {
@@ -661,6 +669,11 @@ function Yargs (processArgs, cwd, parentRequire) {
       if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
         setPlaceholderKeys(argv)
         return command.runCommand(cmd, self, parsed)
+      } else {
+        if (recommendCommands) {
+          const similiarCommand = didYouMean(cmd, handlerKeys)
+          console.log('Did you mean \'' + similiarCommand + '\'?')
+        }
       }
     }
 

--- a/yargs.js
+++ b/yargs.js
@@ -125,7 +125,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
-    exitProcess = true
     strict = false
     recommendCommands = false
     completionCommand = null
@@ -302,7 +301,9 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.recommendCommand = function (cmd, handlerKeys) {
     if (recommendCommands) {
-      const similarCommand = require('didyoumean')(cmd, handlerKeys)
+      const didyoumean = require('didyoumean')
+      didyoumean.threshold = 0.7
+      const similarCommand = didyoumean(cmd, handlerKeys)
       if (similarCommand) {
         console.log(__('Did you mean %s?', similarCommand))
       }

--- a/yargs.js
+++ b/yargs.js
@@ -10,7 +10,6 @@ const Y18n = require('y18n')
 const requireMainFilename = require('require-main-filename')
 const objFilter = require('./lib/obj-filter')
 const setBlocking = require('set-blocking')
-const didYouMean = require('didyoumean')
 
 var exports = module.exports = Yargs
 function Yargs (processArgs, cwd, parentRequire) {
@@ -293,8 +292,21 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   var recommendCommands
   self.recommendCommands = function (value) {
-    recommendCommands = !!value
+    if (value === undefined || !!value === true) {
+      recommendCommands = true
+    } else {
+      recommendCommands = false
+    }
     return self
+  }
+
+  self.recommendCommand = function (cmd, handlerKeys) {
+    if (recommendCommands) {
+      const similarCommand = require('didyoumean')(cmd, handlerKeys)
+      if (similarCommand) {
+        console.log(__('Did you mean %s?', similarCommand))
+      }
+    }
   }
 
   self.requiresArg = function (requiresArgs) {
@@ -672,10 +684,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         setPlaceholderKeys(argv)
         return command.runCommand(cmd, self, parsed)
       } else {
-        if (recommendCommands) {
-          const similiarCommand = didYouMean(cmd, handlerKeys)
-          console.log(__('Did you mean %s?', similiarCommand))
-        }
+        self.recommendCommand(cmd, handlerKeys)
       }
     }
 

--- a/yargs.js
+++ b/yargs.js
@@ -125,8 +125,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
+    exitProcess = true
     strict = false
-    recommendCommands = false
     completionCommand = null
     self.parsed = false
 

--- a/yargs.js
+++ b/yargs.js
@@ -29,6 +29,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     updateFiles: false
   })
 
+  const __ = y18n.__
+
   if (!cwd) cwd = process.cwd()
 
   self.$0 = process.argv
@@ -672,7 +674,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       } else {
         if (recommendCommands) {
           const similiarCommand = didYouMean(cmd, handlerKeys)
-          console.log('Did you mean \'' + similiarCommand + '\'?')
+          console.log(__('Did you mean %s?', similiarCommand))
         }
       }
     }


### PR DESCRIPTION
This closes #496.

This PR adds a method `.recommendCommands()`, that, if turned on, will use a very small library called [didyoumean](https://www.npmjs.com/package/didyoumean) to determine and show similar named, registered commands, if a command gets called that is unknown to yargs.