### PR TITLE
feat: adds recommendCommands() for command suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,6 +1362,12 @@ as a configuration object.
 `cwd` can optionally be provided, the package.json will be read
 from this location.
 
+.recommendCommands(boolean)
+---------------------------
+
+If this feature is turned on, yargs will provide suggestions for similiar commands if a command is called
+that wasn't defined in your configuration. By default, this feature is disabled.
+
 .require(key, [msg | boolean])
 ------------------------------
 .required(key, [msg | boolean])

--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,7 @@ from this location.
 
 If this feature is turned on, yargs will provide suggestions for similiar commands if a command is called
 that wasn't defined in your configuration. By default, this feature is disabled.
+Alternatively, you can also pass no argument to enable this feature.
 
 .require(key, [msg | boolean])
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -1362,12 +1362,11 @@ as a configuration object.
 `cwd` can optionally be provided, the package.json will be read
 from this location.
 
-.recommendCommands(boolean)
+.recommendCommands()
 ---------------------------
 
-If this feature is turned on, yargs will provide suggestions for similiar commands if a command is called
-that wasn't defined in your configuration. By default, this feature is disabled.
-Alternatively, you can also pass no argument to enable this feature.
+Should yargs provide suggestions regarding similar commands if no matching
+command is found?
 
 .require(key, [msg | boolean])
 ------------------------------

--- a/lib/levenshtein.js
+++ b/lib/levenshtein.js
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2011 Andrei Mackenzie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// levenshtein distance algorithm, pulled from Andrei Mackenzie's MIT licensed.
+// gist, which can be found here: https://gist.github.com/andrei-m/982927
+
+// Compute the edit distance between the two given strings
+module.exports = function (a, b) {
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  var matrix = []
+
+  // increment along the first column of each row
+  var i
+  for (i = 0; i <= b.length; i++) {
+    matrix[i] = [i]
+  }
+
+  // increment each column in the first row
+  var j
+  for (j = 0; j <= a.length; j++) {
+    matrix[0][j] = j
+  }
+
+  // Fill in the rest of the matrix
+  for (i = 1; i <= b.length; i++) {
+    for (j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1]
+      } else {
+        matrix[i][j] = Math.min(matrix[i - 1][j - 1] + 1, // substitution
+                                Math.min(matrix[i][j - 1] + 1, // insertion
+                                         matrix[i - 1][j] + 1)) // deletion
+      }
+    }
+  }
+
+  return matrix[b.length][a.length]
+}

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -273,6 +273,22 @@ module.exports = function (yargs, usage, y18n) {
     }
   }
 
+  self.recommendCommands = function (cmd, potentialCommands) {
+    const distance = require('./levenshtein')
+    const threshold = 3 // if it takes more than three edits, let's move on.
+
+    var recommended = null
+    var bestDistance = Infinity
+    for (var i = 0, candidate; (candidate = potentialCommands[i]) !== undefined; i++) {
+      var d = distance(cmd, candidate)
+      if (d <= threshold && d < bestDistance) {
+        bestDistance = d
+        recommended = candidate
+      }
+    }
+    if (recommended) usage.fail(__('Did you mean %s?', recommended))
+  }
+
   self.reset = function (globalLookup) {
     implied = objFilter(implied, function (k, v) {
       return globalLookup[k]

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -276,6 +276,7 @@ module.exports = function (yargs, usage, y18n) {
   self.recommendCommands = function (cmd, potentialCommands) {
     const distance = require('./levenshtein')
     const threshold = 3 // if it takes more than three edits, let's move on.
+    potentialCommands = potentialCommands.sort(function (a, b) { return b.length - a.length })
 
     var recommended = null
     var bestDistance = Infinity

--- a/locales/de.json
+++ b/locales/de.json
@@ -34,5 +34,5 @@
   "Path to JSON config file": "Pfad zur JSON-Config Datei",
   "Show help": "Hilfe anzeigen",
   "Show version number": "Version anzeigen",
-  "Did you mean %s?": "Meinten Sie %s?"
+  "Did you mean %s?": "Meintest du %s?"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -33,5 +33,6 @@
   "Invalid JSON config file: %s": "Fehlerhafte JSON-Config Datei: %s",
   "Path to JSON config file": "Pfad zur JSON-Config Datei",
   "Show help": "Hilfe anzeigen",
-  "Show version number": "Version anzeigen"
+  "Show version number": "Version anzeigen",
+  "Did you mean %s?": "Meinten Sie %s?"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -33,5 +33,6 @@
   "Invalid JSON config file: %s": "Invalid JSON config file: %s",
   "Path to JSON config file": "Path to JSON config file",
   "Show help": "Show help",
-  "Show version number": "Show version number"
+  "Show version number": "Show version number",
+  "Did you mean %s?": "Did you mean %s?"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
-    "didyoumean": "^1.2.1",
     "get-caller-file": "^1.0.1",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
+    "didyoumean": "^1.2.1",
     "get-caller-file": "^1.0.1",
     "lodash.assign": "^4.0.3",
     "os-locale": "^1.4.0",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -281,6 +281,18 @@ describe('yargs dsl tests', function () {
       r.logs.should.be.empty
     })
 
+    it('recommends the longest match first', function () {
+      var r = checkOutput(function () {
+        yargs(['boat'])
+          .command('bot')
+          .command('goat')
+          .recommendCommands()
+          .argv
+      })
+
+      r.errors[1].should.match(/Did you mean goat/)
+    })
+
     it("skips executing top-level command if builder's help is executed", function () {
       var r = checkOutput(function () {
         yargs(['blerg', '-h'])

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -267,7 +267,7 @@ describe('yargs dsl tests', function () {
           .argv
       })
 
-      r.logs[0].should.match(/Did you mean 'goat'/)
+      r.logs[0].should.match(/Did you mean goat/)
     })
 
     it("skips executing top-level command if builder's help is executed", function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -267,18 +267,7 @@ describe('yargs dsl tests', function () {
           .argv
       })
 
-      r.logs[0].should.match(/Did you mean goat/)
-    })
-
-    it('does not recommend a similar command if a "false" is passed as a parameter', function () {
-      var r = checkOutput(function () {
-        yargs(['boat'])
-          .command('goat')
-          .recommendCommands(false)
-          .argv
-      })
-
-      r.logs.should.be.empty
+      r.errors[1].should.match(/Did you mean goat/)
     })
 
     it('does not recommend a similiar command if no similar command exists', function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -259,7 +259,7 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
-    it('recommends a similiar command if no command handler is found', function () {
+    it('recommends a similar command if no command handler is found', function () {
       var r = checkOutput(function () {
         yargs(['boat'])
           .command('goat')
@@ -268,6 +268,28 @@ describe('yargs dsl tests', function () {
       })
 
       r.logs[0].should.match(/Did you mean goat/)
+    })
+
+    it('does not recommend a similar command if a "false" is passed as a parameter', function () {
+      var r = checkOutput(function () {
+        yargs(['boat'])
+          .command('goat')
+          .recommendCommands(false)
+          .argv
+      })
+
+      r.logs.should.be.empty
+    })
+
+    it('does not recommend a similiar command if no similar command exists', function () {
+      var r = checkOutput(function () {
+        yargs(['foo'])
+          .command('nothingSimilar')
+          .recommendCommands()
+          .argv
+      })
+
+      r.logs.should.be.empty
     })
 
     it("skips executing top-level command if builder's help is executed", function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -259,6 +259,17 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
+    it('recommends a similiar command if no command handler is found', function () {
+      var r = checkOutput(function () {
+        yargs(['boat'])
+          .command('goat')
+          .recommendCommands(true)
+          .argv
+      })
+
+      r.logs[0].should.match(/Did you mean 'goat'/)
+    })
+
     it("skips executing top-level command if builder's help is executed", function () {
       var r = checkOutput(function () {
         yargs(['blerg', '-h'])

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -263,7 +263,7 @@ describe('yargs dsl tests', function () {
       var r = checkOutput(function () {
         yargs(['boat'])
           .command('goat')
-          .recommendCommands(true)
+          .recommendCommands()
           .argv
       })
 

--- a/yargs.js
+++ b/yargs.js
@@ -287,6 +287,25 @@ function Yargs (processArgs, cwd, parentRequire) {
     return options.demanded
   }
 
+  var recommendCommands
+  self.recommendCommands = function (value) {
+    if (value === undefined || !!value === true) {
+      recommendCommands = true
+    } else {
+      recommendCommands = false
+    }
+    return self
+  }
+
+  self.recommendCommand = function (cmd, handlerKeys) {
+    if (recommendCommands) {
+      const similarCommand = require('didyoumean')(cmd, handlerKeys)
+      if (similarCommand) {
+        console.log(__('Did you mean %s?', similarCommand))
+      }
+    }
+  }
+
   self.requiresArg = function (requiresArgs) {
     options.requiresArg.push.apply(options.requiresArg, [].concat(requiresArgs))
     return self
@@ -675,6 +694,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       return argv
     }
 
+<<<<<<< HEAD
     if (argv._.length) {
       // check for helpOpt in argv._ before running commands
       // assumes helpOpt must be valid if useHelpOptAsCommand is true
@@ -705,6 +725,17 @@ function Yargs (processArgs, cwd, parentRequire) {
           setPlaceholderKeys(argv)
           return command.runCommand(cmd, self, parsed)
         }
+=======
+    // if there's a handler associated with a
+    // command defer processing to it.
+    var handlerKeys = command.getCommands()
+    for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
+      if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
+        setPlaceholderKeys(argv)
+        return command.runCommand(cmd, self, parsed)
+      } else {
+        self.recommendCommand(cmd, handlerKeys)
+>>>>>>> update .recommendCommands() following @nexdrew's review
       }
 
       // generate a completion script for adding to ~/.bashrc.

--- a/yargs.js
+++ b/yargs.js
@@ -123,7 +123,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
-    exitProcess = true
     strict = false
     completionCommand = null
     self.parsed = false
@@ -299,7 +298,9 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.recommendCommand = function (cmd, handlerKeys) {
     if (recommendCommands) {
-      const similarCommand = require('didyoumean')(cmd, handlerKeys)
+      const didyoumean = require('didyoumean')
+      didyoumean.threshold = 0.7
+      const similarCommand = didyoumean(cmd, handlerKeys)
       if (similarCommand) {
         console.log(__('Did you mean %s?', similarCommand))
       }

--- a/yargs.js
+++ b/yargs.js
@@ -287,27 +287,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     return options.demanded
   }
 
-  var recommendCommands
-  self.recommendCommands = function (value) {
-    if (value === undefined || !!value === true) {
-      recommendCommands = true
-    } else {
-      recommendCommands = false
-    }
-    return self
-  }
-
-  self.recommendCommand = function (cmd, handlerKeys) {
-    if (recommendCommands) {
-      const didyoumean = require('didyoumean')
-      didyoumean.threshold = 0.7
-      const similarCommand = didyoumean(cmd, handlerKeys)
-      if (similarCommand) {
-        console.log(__('Did you mean %s?', similarCommand))
-      }
-    }
-  }
-
   self.requiresArg = function (requiresArgs) {
     options.requiresArg.push.apply(options.requiresArg, [].concat(requiresArgs))
     return self
@@ -646,6 +625,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     return detectLocale
   }
 
+  var recommendCommands
+  self.recommendCommands = function () {
+    recommendCommands = true
+    return self
+  }
+
   self.getUsageInstance = function () {
     return usage
   }
@@ -696,7 +681,6 @@ function Yargs (processArgs, cwd, parentRequire) {
       return argv
     }
 
-<<<<<<< HEAD
     if (argv._.length) {
       // check for helpOpt in argv._ before running commands
       // assumes helpOpt must be valid if useHelpOptAsCommand is true
@@ -727,18 +711,11 @@ function Yargs (processArgs, cwd, parentRequire) {
           setPlaceholderKeys(argv)
           return command.runCommand(cmd, self, parsed)
         }
-=======
-    // if there's a handler associated with a
-    // command defer processing to it.
-    var handlerKeys = command.getCommands()
-    for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
-      if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
-        setPlaceholderKeys(argv)
-        return command.runCommand(cmd, self, parsed)
-      } else {
-        self.recommendCommand(cmd, handlerKeys)
->>>>>>> update .recommendCommands() following @nexdrew's review
       }
+
+      // recommend a command if recommendCommands() has
+      // been enabled, and no commands were found to execute
+      if (recommendCommands && argv._.length) validation.recommendCommands(argv._[argv._.length - 1], handlerKeys)
 
       // generate a completion script for adding to ~/.bashrc.
       if (completionCommand && ~argv._.indexOf(completionCommand) && !argv[completion.completionKey]) {

--- a/yargs.js
+++ b/yargs.js
@@ -706,16 +706,23 @@ function Yargs (processArgs, cwd, parentRequire) {
       // if there's a handler associated with a
       // command defer processing to it.
       var handlerKeys = command.getCommands()
-      for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
-        if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
-          setPlaceholderKeys(argv)
-          return command.runCommand(cmd, self, parsed)
+      if (handlerKeys.length) {
+        var firstUnknownCommand
+        for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
+          if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
+            setPlaceholderKeys(argv)
+            return command.runCommand(cmd, self, parsed)
+          } else if (!firstUnknownCommand && cmd !== completionCommand) {
+            firstUnknownCommand = cmd
+          }
+        }
+
+        // recommend a command if recommendCommands() has
+        // been enabled, and no commands were found to execute
+        if (recommendCommands && firstUnknownCommand) {
+          validation.recommendCommands(firstUnknownCommand, handlerKeys)
         }
       }
-
-      // recommend a command if recommendCommands() has
-      // been enabled, and no commands were found to execute
-      if (recommendCommands && argv._.length) validation.recommendCommands(argv._[argv._.length - 1], handlerKeys)
 
       // generate a completion script for adding to ~/.bashrc.
       if (completionCommand && ~argv._.indexOf(completionCommand) && !argv[completion.completionKey]) {

--- a/yargs.js
+++ b/yargs.js
@@ -123,6 +123,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
+    exitProcess = true
     strict = false
     completionCommand = null
     self.parsed = false


### PR DESCRIPTION
working from @maxrimue's branch for `recommendCommands()`, and implementing @nexdrew's code-review.

This pull request gets us to `v1` of command recommendations (thanks @maxrimue for the hard work) addressing some of the nits in #562 (@maxrimue sorry for @nexdrew and I providing such a difficult review).

Here's a breakdown of some of the changes made:

* rather than pulling in another dependency, I simply added a helper module for calculating levenshtein distance: this is a fairly simple algorithm, and I could imagine us using it in other places -- might as well dance around adding another dependency to yargs.
* we now handle the edge-case that @nexdrew outlined with nested arguments significantly better, by avoiding making recommendations until after we've walked through all the command handlers.
* we now recommend commands using the validation module, this allows us to piggyback off existing functionality in `usage.js`, and `validation.js`.
* we now use the same method signature as `strict()` for `recommendCommands()` rather than trying to be overly fancy with argument overriding.

reviewers: @maxrimue @nexdrew I plan on stubbornly marching us towards `yargs@5.x` over the next week, appreciate your patience.