### PR TITLE
feat: interpret demand() numbers as relative to executing command

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -11,18 +11,19 @@ module.exports = function (yargs, usage, y18n) {
   // arguments were provided, i.e., '_'.
   self.nonOptionCount = function (argv) {
     const demanded = yargs.getDemanded()
-    const _s = argv._.length
+    // don't count currently executing commands
+    const _s = argv._.length - yargs.getContext().commands.length
 
     if (demanded._ && (_s < demanded._.count || _s > demanded._.max)) {
       if (demanded._.msg !== undefined) {
         usage.fail(demanded._.msg)
       } else if (_s < demanded._.count) {
         usage.fail(
-          __('Not enough non-option arguments: got %s, need at least %s', argv._.length, demanded._.count)
+          __('Not enough non-option arguments: got %s, need at least %s', _s, demanded._.count)
         )
       } else {
         usage.fail(
-          __('Too many non-option arguments: got %s, maximum of %s', argv._.length, demanded._.max)
+          __('Too many non-option arguments: got %s, maximum of %s', _s, demanded._.max)
         )
       }
     }

--- a/test/validation.js
+++ b/test/validation.js
@@ -135,6 +135,30 @@ describe('validation tests', function () {
         })
         .argv
     })
+
+    it('interprets min relative to command', function () {
+      var failureMsg
+      yargs('lint')
+        .command('lint', 'Lint a file', function (yargs) {
+          yargs.demand(1).fail(function (msg) {
+            failureMsg = msg
+          })
+        })
+        .argv
+      expect(failureMsg).to.equal('Not enough non-option arguments: got 0, need at least 1')
+    })
+
+    it('interprets max relative to command', function () {
+      var failureMsg
+      yargs('lint one.js two.js')
+        .command('lint', 'Lint a file', function (yargs) {
+          yargs.demand(0, 1).fail(function (msg) {
+            failureMsg = msg
+          })
+        })
+        .argv
+      expect(failureMsg).to.equal('Too many non-option arguments: got 2, maximum of 1')
+    })
   })
 
   describe('choices', function () {


### PR DESCRIPTION
Fixes #451.

Previously, min and max values passed to `.demand()` were interpreted as the _total_ number of non-option arguments, which included the arguments representing the command(s) itself.

With this PR, the min and max values are now interpreted as the _additional_ number of non-option arguments, relative to the currently executing command.

Here's an example:

```js
require('yargs')
  .command(
    'lint',
    'Lint a single file',
    (yargs) => yargs.demand(1, 1),
    (argv) => console.log('linting file:', argv._[1])
  )
  .argv
```

Before this PR, the command would not work as expected (i.e. would not accept any flagless args) because the `lint` command itself would satisfy the min and max on the command line.

```console
$ program lint
linting file: undefined

$ program lint example.js
program lint

Too many non-option arguments: got 2, maximum of 1

$ program lint one.js two.js
program lint

Too many non-option arguments: got 3, maximum of 1
```

After this PR, the command works by requiring a single flagless arg on the command line besides the `lint` command itself.

```console
$ program lint
program lint

Not enough non-option arguments: got 0, need at least 1

$ program lint example.js
linting file: example.js

$ program lint one.js two.js
program lint

Too many non-option arguments: got 2, maximum of 1
```

When `.demand()` is used outside of a command builder, the functionality remains the same.

Note that this is a **BREAKING CHANGE** since users relying on the previous (now deemed incorrect) functionality will need to change the values they pass to `.demand()` within command builders, decrementing them by the "nested/depth count" of the command.

Also note that this **does not** change the contents of `argv._` within the command handler; `argv._` still contains the command key(s) it took to execute the command(s). (Note the use of `argv._[1]` in the above example.)

We could possibly change this (which would be another breaking change), but I'd rather leave it this way to potentially support command handlers that are reusable across multiple commands (allowing the handler to slightly change its functionality based on the command keys present in `argv._`).