### PR TITLE
feat: apply default builder to command() and apply fail() handlers globally

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -34,9 +34,7 @@ module.exports = function (yargs, usage, validation) {
     handlers[parsedCommand.cmd] = {
       original: cmd,
       handler: handler,
-      // TODO: default to a noop builder in
-      // yargs@5.x
-      builder: builder,
+      builder: builder || {},
       demanded: parsedCommand.demanded,
       optional: parsedCommand.optional
     }
@@ -129,7 +127,7 @@ module.exports = function (yargs, usage, validation) {
     var currentContext = yargs.getContext()
     var parentCommands = currentContext.commands.slice()
     currentContext.commands.push(command)
-    if (commandHandler.builder && typeof commandHandler.builder === 'function') {
+    if (typeof commandHandler.builder === 'function') {
       // a function can be provided, which builds
       // up a yargs chain and possibly returns it.
       innerArgv = commandHandler.builder(yargs.reset(parsed.aliases))
@@ -145,7 +143,7 @@ module.exports = function (yargs, usage, validation) {
       } else {
         innerArgv = yargs.parsed.argv
       }
-    } else if (commandHandler.builder && typeof commandHandler.builder === 'object') {
+    } else if (typeof commandHandler.builder === 'object') {
       // as a short hand, an object can instead be provided, specifying
       // the options that a command takes.
       innerArgv = yargs.reset(parsed.aliases)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -34,9 +34,9 @@ module.exports = function (yargs, y18n) {
   var failureOutput = false
   self.fail = function (msg, err) {
     if (fails.length) {
-      fails.forEach(function (f) {
-        f(msg, err)
-      })
+      for (var i = fails.length - 1; i >= 0; --i) {
+        fails[i](msg, err)
+      }
     } else {
       if (yargs.getExitProcess()) setBlocking(true)
 
@@ -391,7 +391,7 @@ module.exports = function (yargs, y18n) {
 
   self.reset = function (globalLookup) {
     // do not reset wrap here
-    fails = []
+    // do not reset fails here
     failMessage = null
     failureOutput = false
     usage = undefined

--- a/test/completion.js
+++ b/test/completion.js
@@ -34,7 +34,7 @@ describe('Completion', function () {
           .argv
       })
 
-      r.logs.should.include('foo')
+      // should not suggest foo for completion unless foo is subcommand of apple
       r.logs.should.not.include('apple')
     })
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -501,7 +501,7 @@ describe('usage tests', function () {
             try {
               return yargs('test')
                 .fail(function () {
-                  console.log('is not triggered')
+                  console.log('is triggered last')
                 })
                 .exitProcess(false)
                 .wrap(null)
@@ -511,7 +511,7 @@ describe('usage tests', function () {
                       console.log([error.name, error.message])
                     })
                     .exitProcess(false)
-
+                }, function (argv) {
                   throw new Error('foo')
                 })
                 .argv
@@ -519,7 +519,7 @@ describe('usage tests', function () {
 
             }
           })
-          r.logs.should.deep.equal([['Error', 'foo']])
+          r.logs.should.deep.equal([['Error', 'foo'], 'is triggered last'])
           r.should.have.property('exit').and.be.false
         })
       })


### PR DESCRIPTION
Addresses this TODO from #545:

> TODO: default to a noop builder in yargs@5.x

When implementing this, I discovered it was necessary to either (a) change the expectations of some tests to move a top-level `.fail()` handler to a command-specific one or (b) start applying `.fail()` handlers globally. I opted for the latter due to [conversation in #539](https://github.com/yargs/yargs/issues/539#issuecomment-230987860).

Therefore, this PR solves 2 main problems:

1. Do not require a command to specify a builder in order for validation to apply

    Prior to this, code such as `.command('hi').demand('name').global('name')` would not enforce the globally required `--name` option when `hi` is given on the command line, which [has been outlined here](https://github.com/yargs/yargs/pull/567#issuecomment-234270884), because "running" a command without a builder would actually bypass a reset, reparse, and subsequent validation.

    This PR changes that so a command like `.command('hi')` is now equivalent to a command like `.command('hi', '', {})`.

    Note that I have an [alternative implementation](https://github.com/yargs/yargs/compare/validate-commands-option1) that applies validation to builder-less commands without the reset or reparse (and means options do not have to be global to be, e.g., required), but I prefer the approach of this PR since it (i) causes all commands to be treated equally as running within a "command context" and (ii) satisfies the previous TODO (and whatever thought process/concerns went with it).

    Accepting this PR means options must be explicitly global (or command-specific) in order to apply to a command.

2. Allow a top-level `.fail()` handler to handle errors that occur during command execution

    As previously discussed in #539.

    This also means that multiple fail handlers at different "command depths" will all be called in depth-first, reverse order. For example, the following code:

    ```js
    require('yargs')
      .fail((msg, err) => {
        console.log('top-level fail handler 1')
      })
      .command(
        'hi', '',
        (yargs) => {
          yargs
            .fail((msg, err) => console.log('command fail handler 1'))
            .fail((msg, err) => console.log('command fail handler 2'))
        }
      )
      .fail((msg, err) => {
        console.log('top-level fail handler 2')
      })
      .demand('name').global('name').argv
    ```

    Would produce this:

    ```console
    $ node validate-command.js hi
    command fail handler 2
    command fail handler 1
    top-level fail handler 2
    top-level fail handler 1
    ```

Note that both of these are **BREAKING CHANGES**.