### PR TITLE
perf: defer requiring most external libs until needed

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,7 +1,5 @@
 const path = require('path')
 const inspect = require('util').inspect
-const requireDirectory = require('require-directory')
-const whichModule = require('which-module')
 
 // handles parsing positional arguments,
 // and populating argv with said positional
@@ -64,13 +62,13 @@ module.exports = function (yargs, usage, validation) {
       }
       return visited
     }
-    requireDirectory({ require: req, filename: callerFile }, dir, opts)
+    require('require-directory')({ require: req, filename: callerFile }, dir, opts)
   }
 
   // lookup module object from require()d command and derive name
   // if module was not require()d and no name given, throw error
   function moduleName (obj) {
-    const mod = whichModule(obj)
+    const mod = require('which-module')(obj)
     if (!mod) throw new Error('No command name given for module: ' + inspect(obj))
     return commandFromFilename(mod.filename)
   }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,5 +1,6 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
+const stringWidth = require('string-width')
 const objFilter = require('./obj-filter')
 const setBlocking = require('set-blocking')
 
@@ -265,7 +266,7 @@ module.exports = function (yargs, y18n) {
     }
 
     table.forEach(function (v) {
-      width = Math.max(require('string-width')(v[0]), width)
+      width = Math.max(stringWidth(v[0]), width)
     })
 
     // if we've enabled 'wrap' we should limit

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,9 +1,5 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-const cliui = require('cliui')
-const decamelize = require('decamelize')
-const stringWidth = require('string-width')
-const wsize = require('window-size')
 const objFilter = require('./obj-filter')
 const setBlocking = require('set-blocking')
 
@@ -125,7 +121,7 @@ module.exports = function (yargs, y18n) {
         return acc
       }, {})
     )
-    var ui = cliui({
+    var ui = require('cliui')({
       width: wrap,
       wrap: !!wrap
     })
@@ -269,7 +265,7 @@ module.exports = function (yargs, y18n) {
     }
 
     table.forEach(function (v) {
-      width = Math.max(stringWidth(v[0]), width)
+      width = Math.max(require('string-width')(v[0]), width)
     })
 
     // if we've enabled 'wrap' we should limit
@@ -329,7 +325,7 @@ module.exports = function (yargs, y18n) {
   }
 
   self.functionDescription = function (fn) {
-    var description = fn.name ? decamelize(fn.name, '-') : __('generated-value')
+    var description = fn.name ? require('decamelize')(fn.name, '-') : __('generated-value')
     return ['(', description, ')'].join('')
   }
 
@@ -375,6 +371,7 @@ module.exports = function (yargs, y18n) {
 
   // guess the width of the console window, max-width 80.
   function windowWidth () {
+    const wsize = require('window-size')
     return wsize.width ? Math.min(80, wsize.width) : null
   }
 

--- a/yargs.js
+++ b/yargs.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const assign = require('lodash.assign')
 const Command = require('./lib/command')
 const Completion = require('./lib/completion')
 const Parser = require('yargs-parser')
@@ -7,7 +6,6 @@ const path = require('path')
 const Usage = require('./lib/usage')
 const Validation = require('./lib/validation')
 const Y18n = require('y18n')
-const requireMainFilename = require('require-main-filename')
 const objFilter = require('./lib/obj-filter')
 const setBlocking = require('set-blocking')
 
@@ -364,7 +362,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     var obj = {}
     try {
       obj = readPkgUp.sync({
-        cwd: path || requireMainFilename(parentRequire || require)
+        cwd: path || require('require-main-filename')(parentRequire || require)
       })
     } catch (noop) {}
 
@@ -460,7 +458,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
   self.getGroups = function () {
     // combine explicit and preserved groups. explicit groups should be first
-    return assign({}, groups, preservedGroups)
+    return require('lodash.assign')({}, groups, preservedGroups)
   }
 
   // as long as options.envPrefix is not undefined,


### PR DESCRIPTION
Mainly since recent [benchmarks](https://github.com/yargs/yargs/issues/521) show that preloading a bunch of dependencies is the biggest performance killer in yargs. Let's just give deps the same "require on demand" treatment, especially for ones that are only used in certain cases.