### PR TITLE
feat: add coerce api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-yargs
+  yargs
 ========
 
 Yargs be a node.js library fer hearties tryin' ter parse optstrings.
@@ -449,6 +449,49 @@ var argv = require('yargs')
     describe: 'choose a size',
     choices: ['xs', 's', 'm', 'l', 'xl']
   })
+  .argv
+```
+
+<a name="coerce"></a>.coerce(key, fn)
+----------------
+
+Provide a synchronous function to coerce or transform the value(s) given on the
+command line for `key`.
+
+The coercion function should accept one argument, representing the parsed value
+from the command line, and should return a new value or throw an error. The
+returned value will be used as the value for `key` (or one of its aliases) in
+`argv`. If the function throws, the error will be treated as a validation
+failure, delegating to either a custom [`.fail()`](#fail) handler or printing
+the error message in the console.
+
+```js
+var argv = require('yargs')
+  .coerce('file', function (arg) {
+    return require('fs').readFileSync(arg, 'utf8')
+  })
+  .argv
+```
+
+Optionally `.coerce()` can take an object that maps several keys to their
+respective coercion function.
+
+```js
+var argv = require('yargs')
+  .coerce({
+    date: Date.parse,
+    json: JSON.parse
+  })
+  .argv
+```
+
+You can also map the same function to several keys at one time. Just pass an
+array of keys as the first argument to `.coerce()`:
+
+```js
+var path = require('path')
+var argv = require('yargs')
+  .coerce(['src', 'dest'], path.resolve)
   .argv
 ```
 
@@ -1005,7 +1048,7 @@ By default, yargs exits the process when the user passes a help flag, uses the
 `.exitProcess(false)` disables this behavior, enabling further actions after
 yargs have been validated.
 
-.fail(fn)
+<a name="fail"></a>.fail(fn)
 ---------
 
 Method to execute when a failure occurs, rather than printing the failure message.
@@ -1324,6 +1367,7 @@ Valid `opt` keys include:
 - `array`: boolean, interpret option as an array, see [`array()`](#array)
 - `boolean`: boolean, interpret option as a boolean flag, see [`boolean()`](#boolean)
 - `choices`: value or array of values, limit valid option arguments to a predefined set, see [`choices()`](#choices)
+- `coerce`: function, coerce or transform parsed command line values into another value, see [`coerce()`](#coerce)
 - `config`: boolean, interpret option as a path to a JSON config file, see [`config()`](#config)
 - `configParser`: function, provide a custom config parsing function, see [`config()`](#config)
 - `count`: boolean, interpret option as a count of boolean flags, see [`count()`](#count)

--- a/lib/command.js
+++ b/lib/command.js
@@ -154,7 +154,7 @@ module.exports = function (yargs, usage, validation) {
       innerArgv = innerArgv.argv
     }
 
-    populatePositional(commandHandler, innerArgv, currentContext)
+    populatePositional(commandHandler, innerArgv, currentContext, yargs)
 
     if (commandHandler.handler) {
       commandHandler.handler(innerArgv)
@@ -163,7 +163,7 @@ module.exports = function (yargs, usage, validation) {
     return innerArgv
   }
 
-  function populatePositional (commandHandler, argv, context) {
+  function populatePositional (commandHandler, argv, context, yargs) {
     argv._ = argv._.slice(context.commands.length) // nuke the current commands
     var demanded = commandHandler.demanded.slice(0)
     var optional = commandHandler.optional.slice(0)
@@ -176,6 +176,7 @@ module.exports = function (yargs, usage, validation) {
       if (!argv._.length) break
       if (demand.variadic) argv[demand.cmd] = argv._.splice(0)
       else argv[demand.cmd] = argv._.shift()
+      postProcessPositional(yargs, argv, demand.cmd)
     }
 
     while (optional.length) {
@@ -184,9 +185,22 @@ module.exports = function (yargs, usage, validation) {
       if (!argv._.length) break
       if (maybe.variadic) argv[maybe.cmd] = argv._.splice(0)
       else argv[maybe.cmd] = argv._.shift()
+      postProcessPositional(yargs, argv, maybe.cmd)
     }
 
     argv._ = context.commands.concat(argv._)
+  }
+
+  // TODO move positional arg logic to yargs-parser and remove this duplication
+  function postProcessPositional (yargs, argv, key) {
+    var coerce = yargs.getOptions().coerce[key]
+    if (typeof coerce === 'function') {
+      try {
+        argv[key] = coerce(argv[key])
+      } catch (err) {
+        yargs.getUsageInstance().fail(err.message, err)
+      }
+    }
   }
 
   self.reset = function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1347,6 +1347,50 @@ describe('yargs dsl tests', function () {
       expect(argv.env).to.have.property('name').and.equal('SHELL')
       expect(argv.env).to.have.property('value').and.equal('/bin/bash')
     })
+
+    it('supports positional and variadic args for a command', function () {
+      var age
+      var dates
+      yargs('add 30days 2016-06-13 2016-07-18')
+        .command('add <age> [dates..]', 'Testing', function (yargs) {
+          return yargs
+            .coerce('age', function (arg) {
+              return parseInt(arg, 10) * 86400000
+            })
+            .coerce('dates', function (arg) {
+              return arg.map(function (str) {
+                return new Date(str)
+              })
+            })
+        }, function (argv) {
+          age = argv.age
+          dates = argv.dates
+        })
+        .argv
+      expect(age).to.equal(2592000000)
+      expect(dates).to.have.lengthOf(2)
+      dates[0].toString().should.equal(new Date('2016-06-13').toString())
+      dates[1].toString().should.equal(new Date('2016-07-18').toString())
+    })
+
+    it('allows an error from positional arg to be handled by fail() handler', function () {
+      var msg
+      var err
+      yargs('throw ball')
+        .command('throw <msg>', false, function (yargs) {
+          return yargs
+            .coerce('msg', function (arg) {
+              throw new Error(arg)
+            })
+            .fail(function (m, e) {
+              msg = m
+              err = e
+            })
+        })
+        .argv
+      expect(msg).to.equal('ball')
+      expect(err).to.exist
+    })
   })
 })
 

--- a/yargs.js
+++ b/yargs.js
@@ -98,7 +98,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     var objectOptions = [
       'narg', 'key', 'alias', 'default', 'defaultDescription',
-      'config', 'choices', 'demanded'
+      'config', 'choices', 'demanded', 'coerce'
     ]
 
     arrayOptions.forEach(function (k) {
@@ -240,6 +240,19 @@ function Yargs (processArgs, cwd, parentRequire) {
       })
     } else {
       options.alias[x] = (options.alias[x] || []).concat(y)
+    }
+    return self
+  }
+
+  self.coerce = function (key, fn) {
+    if (typeof key === 'object' && !Array.isArray(key)) {
+      Object.keys(key).forEach(function (k) {
+        self.coerce(k, key[k])
+      })
+    } else {
+      [].concat(key).forEach(function (k) {
+        options.coerce[k] = fn
+      })
     }
     return self
   }
@@ -403,6 +416,8 @@ function Yargs (processArgs, cwd, parentRequire) {
         self.normalize(key)
       } if ('choices' in opt) {
         self.choices(key, opt.choices)
+      } if ('coerce' in opt) {
+        self.coerce(key, opt.coerce)
       } if ('group' in opt) {
         self.group(key, opt.group)
       } if (opt.global) {


### PR DESCRIPTION
Closes #535.

Builds on top of yargs/yargs-parser#42 and yargs/yargs-parser#47.

Adds a `.coerce()` method that allows users to map a coercion (or transform) function to specific option keys. Coercion is then delegated to `yargs-parser`.

The new method accepts the following:

- a single key and a function
- an array of keys and a function
- an object mapping keys to functions

The `.option()` method was also augmented to support a `coerce` property.

Note that, in commit 46eaa9e, a special case of coercion logic was needed to support positional and variadic args for commands. This is because `yargs-parser` does not populate positional args in `argv` - those are populated in `lib/command.js` after parsing is complete - and so it was necessary to duplicate the execution of coercion functions after population of positional args. I would eventually like to replace this by moving the positional arg population logic down to `yargs-parser`, but that's a bigger change.

Also note that, when mixing default values with coercion for positional args, coercion is actually executed twice - first in `yargs-parser` against the default value and second in `yargs` against the "parsed" value. Similar to yargs/yargs-parser#51, variadic args are given to the coercion function as an array (function called once) instead of as individual element values.

- [x] Add `.coerce()` to API
- [x] Support for coercion of positional and variadic args for commands
- [x] Tests
- [x] Add docs to README