### PR TITLE
#540 - Changed parsing of the command string to ignore extra spaces

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -85,7 +85,8 @@ module.exports = function (yargs, usage, validation) {
   }
 
   function parseCommand (cmd) {
-    var splitCommand = cmd.split(/\s/)
+    var extraSpacesStrippedCommand = cmd.replace(/\s{2,}/g, ' ')
+    var splitCommand = extraSpacesStrippedCommand.split(/\s/)
     var bregex = /\.*[\][<>]/g
     var parsedCommand = {
       cmd: (splitCommand.shift()).replace(bregex, ''),

--- a/test/command.js
+++ b/test/command.js
@@ -621,4 +621,19 @@ describe('Command', function () {
       .argv
     argv.should.have.property('someone').and.equal('Leslie')
   })
+
+  // addresses https://github.com/yargs/yargs/issues/540
+  it('ignores extra spaces in command string', function () {
+    var y = yargs([])
+      .command('foo  [awesome]', 'my awesome command', function (yargs) {
+        return yargs
+      })
+    var command = y.getCommandInstance()
+    var handlers = command.getCommandHandlers()
+    handlers.foo.demanded.should.not.include({
+      cmd: '',
+      variadic: false
+    })
+    handlers.foo.demanded.should.have.lengthOf(0)
+  })
 })


### PR DESCRIPTION
Changed the parsing of the command string to ignore extra spaces between positional arguments, rather than create an additional required positional argument with a value of an empty string for each extra space. Wrote a test to confirm the fix.