### PR TITLE
docs: mention config file names must end in .json

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,9 @@ var argv = require('yargs')
 
 Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
-and parsed, and its properties are set as arguments.
+and parsed, and its properties are set as arguments. Because the file is
+loaded using Node's require(), the filename MUST end in `.json` to be
+interpreted correctly.
 
 If invoked without parameters, `.config()` will make `--config` the option to pass the JSON config file.
 


### PR DESCRIPTION
This one drove me crazy until I finally figured it out. Because [the default configParser implementation](https://github.com/yargs/yargs-parser/blob/cc4dc5663bf9a29527127cf575d37b461c1c47a2/index.js#L426) loads the file using node's `require`, it breaks if your config file is named `.my-app.conf` (for instance). Short term solution: just mention that! (It's easy enough to workaround using a custom parser function.)