### PR TITLE
Defer windowWidth() to improve perf for non-help usage

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -153,7 +153,7 @@ module.exports = function (yargs, y18n) {
 
       commands.forEach(function (command) {
         ui.div(
-          {text: command[0], padding: [0, 2, 0, 2], width: maxWidth(commands) + 4},
+          {text: command[0], padding: [0, 2, 0, 2], width: maxWidth(commands, theWrap) + 4},
           {text: command[1]}
         )
       })
@@ -227,7 +227,7 @@ module.exports = function (yargs, y18n) {
         ].filter(Boolean).join(' ')
 
         ui.span(
-          {text: kswitch, padding: [0, 2, 0, 2], width: maxWidth(switches) + 4},
+          {text: kswitch, padding: [0, 2, 0, 2], width: maxWidth(switches, theWrap) + 4},
           desc
         )
 
@@ -248,7 +248,7 @@ module.exports = function (yargs, y18n) {
 
       examples.forEach(function (example) {
         ui.div(
-          {text: example[0], padding: [0, 2, 0, 2], width: maxWidth(examples) + 4},
+          {text: example[0], padding: [0, 2, 0, 2], width: maxWidth(examples, theWrap) + 4},
           example[1]
         )
       })
@@ -267,7 +267,7 @@ module.exports = function (yargs, y18n) {
 
   // return the maximum width of a string
   // in the left-hand column of a table.
-  function maxWidth (table) {
+  function maxWidth (table, theWrap) {
     var width = 0
 
     // table might be of the form [leftColumn],
@@ -284,7 +284,6 @@ module.exports = function (yargs, y18n) {
 
     // if we've enabled 'wrap' we should limit
     // the max-width of the left-column.
-    var theWrap = getWrap()
     if (theWrap) width = Math.min(width, parseInt(theWrap * 0.5, 10))
 
     return width

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -96,9 +96,21 @@ module.exports = function (yargs, y18n) {
     epilog = msg
   }
 
-  var wrap = windowWidth()
+  var wrapSet
+  var wrap
   self.wrap = function (cols) {
+    wrapSet = true
     wrap = cols
+  }
+
+  function getWrap () {
+    // lazily call windowWidth() because it's very expensive,
+    // and only needs to be called if the user wants to show usage/help
+    if (!wrapSet) {
+      wrap = windowWidth()
+    }
+    wrapSet = true
+    return wrap
   }
 
   var deferY18nLookupPrefix = '__yargsString__:'
@@ -122,9 +134,10 @@ module.exports = function (yargs, y18n) {
         return acc
       }, {})
     )
+    var theWrap = getWrap()
     var ui = require('cliui')({
-      width: wrap,
-      wrap: !!wrap
+      width: theWrap,
+      wrap: !!theWrap
     })
 
     // the usage string.
@@ -271,7 +284,8 @@ module.exports = function (yargs, y18n) {
 
     // if we've enabled 'wrap' we should limit
     // the max-width of the left-column.
-    if (wrap) width = Math.min(width, parseInt(wrap * 0.5, 10))
+    var theWrap = getWrap()
+    if (theWrap) width = Math.min(width, parseInt(theWrap * 0.5, 10))
 
     return width
   }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -96,7 +96,7 @@ module.exports = function (yargs, y18n) {
     epilog = msg
   }
 
-  var wrapSet
+  var wrapSet = false
   var wrap
   self.wrap = function (cols) {
     wrapSet = true
@@ -108,8 +108,8 @@ module.exports = function (yargs, y18n) {
     // and only needs to be called if the user wants to show usage/help
     if (!wrapSet) {
       wrap = windowWidth()
+      wrapSet = true
     }
-    wrapSet = true
     return wrap
   }
 


### PR DESCRIPTION
Hi :wave:, I'm a big fan of yargs, so after talking with @lrlna about https://github.com/yargs/yargs/issues/521, I wanted to try my hand at improving the overall runtime of `require('yargs')`.

I started by profiling with the Chrome dev tools using `node-nightly` and the `--inspect` option, where I noticed that `windowWidth()` is a very expensive function:

![screenshot 2016-08-29 09 12 12](https://cloud.githubusercontent.com/assets/283842/18064626/10d66122-6de5-11e6-9564-2ae9dcbdd5b1.png)


Since `windowWidth()` only has to be calculated when we need the column width, e.g. when the user has typed `--help` or `-h`, I figured we could lazily evaluate it. That's what this PR does.

Here is a very small benchmark to demonstrate the perf improvement:

```bash
time for i in {1..500}; do node -e 'require("./index")'; done
```

Running in node 5.12.0 on a 2013 Macbook Air, I got the following results (real time, averaged):

* **Before:** 122.14ms
* **After:** 108.746ms

Since that includes the cost of the Node process itself, we can also use `performance-now` to measure just the runtime of `require('yargs')`:

```bash
for ((i=0;i<500;i++)); do node -e 'var now = require("performance-now"); var s = now(); require("./index"); var e = now() - s; console.log(e)'; done | awk '{ sum+=$1 } END { print sum/NR }'
```

This gives: 

* **Before:** 41.3002ms
* **After:** 28.5307ms

So in rough terms `require('yargs')` should be about ~30% faster with this PR, with an average of ~12ms shaved off each invocation of `require('yargs')`. (Obviously it doesn't make any difference when doing `-h` or `--help`, but my hunch is that that's not the average use case.)

Please let me know if I missed something in the style/coverage/etc. or if this PR is unfeasible for some other reason I didn't notice. Hope this helps!