### PR TITLE
Lazily bind functions in singletonify

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,13 @@ function singletonify (inst) {
   Object.keys(inst).forEach(function (key) {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
+    } else if (typeof inst[key] === 'function') {
+      // bind to inst, but use a closure to avoid Function.prototype.bind() cost
+      Argv.__defineGetter__(key, function () {
+        return inst[key]
+      })
     } else {
-      Argv[key] = typeof inst[key] === 'function' ? inst[key].bind(inst) : inst[key]
+      Argv[key] = inst[key]
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -24,12 +24,7 @@ function singletonify (inst) {
   Object.keys(inst).forEach(function (key) {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
-    } else if (typeof inst[key] === 'function') {
-      // bind to inst, but use a closure to avoid Function.prototype.bind() cost
-      Argv.__defineGetter__(key, function () {
-        return inst[key]
-      })
-    } else {
+    } else { // no need to bind these functions; they don't ever use `this`
       Argv[key] = inst[key]
     }
   })


### PR DESCRIPTION
Less of a dramatic speedup than #610, but seems to shave off about 2-3ms from the total runtime of `require('yargs')`.

Since the `inst` object contains a lot of keys (>=67 it seems) which are mostly functions, calling `Function.prototype.bind()` for each one at startup can be expensive. Instead, we can just create a getter for each function that uses a closure, i.e. avoiding `Function.prototype.bind()` entirely.

Using this mini-benchmark:

```bash
for ((i=0;i<500;i++)); do node -e 'var now = require("performance-now"); var s = now(); require("./index"); var e = now() - s; console.log(e)'; done | awk '{sum+=$1} END { print sum/NR }'
```

I get these results in node 6.5.0 on a 2013 Macbook Air:

* **Before:** 43.2434
* **After:** 39.7419

Profiling with `node-nightly --inspect`, this is what it looks like before:

![screenshot 2016-08-29 13 59 07](https://cloud.githubusercontent.com/assets/283842/18067345/3d162018-6df1-11e6-9b0c-d9e72fc3fbda.png)


And after:

![screenshot 2016-08-29 14 00 02](https://cloud.githubusercontent.com/assets/283842/18067348/434a7f06-6df1-11e6-9e7b-2f39acb4e0e1.png)

(Note that these screenshots were just from a single run, so those ~6ms and ~3ms numbers will vary, which is why for the benchmark I used 500 iterations.)
