### PR TITLE
Also pass yargs to the fail handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,15 +1055,17 @@ yargs have been validated.
 
 Method to execute when a failure occurs, rather than printing the failure message.
 
-`fn` is called with the failure message that would have been printed and the
-`Error` instance originally thrown, if any.
+`fn` is called with the failure message that would have been printed, the
+`Error` instance originally thrown and yargs state when the failure
+occured. 
 
 ```js
 var argv = require('yargs')
-  .fail(function (msg, err) {
+  .fail(function (msg, err, yargs) {
     if (err) throw err // preserve stack
     console.error('You broke it!')
     console.error(msg)
+    console.error('You should be doing', yargs.help())
     process.exit(1)
   })
   .argv

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -32,7 +32,7 @@ module.exports = function (yargs, y18n) {
   self.fail = function (msg, err) {
     if (fails.length) {
       for (var i = fails.length - 1; i >= 0; --i) {
-        fails[i](msg, err)
+        fails[i](msg, err, self)
       }
     } else {
       if (yargs.getExitProcess()) setBlocking(true)

--- a/test/usage.js
+++ b/test/usage.js
@@ -476,26 +476,23 @@ describe('usage tests', function () {
 
       it('gives the ability to log a per-command error message if failure occurs in a command', function () {
         var r = checkUsage(function () {
-          try {
-            return yargs
-              .command('foo', 'desc', {
-                bar: {
-                  describe: 'bar command'
-                }
-              }, function (argv) {
-                throw new Error('blah')
-              })
-              .fail(function (message, error, yargs) {
-                console.log(yargs.help())
-              })
-              .exitProcess(false)
-              .wrap(null)
-              .argv
-          } catch (e) {
-          }
-        }, 'foo')
+          return yargs('foo')
+            .command('foo', 'desc', {
+              bar: {
+                describe: 'bar command'
+              }
+            }, function (argv) {
+              throw new Error('blah')
+            })
+            .fail(function (message, error, yargs) {
+              yargs.showHelp()
+            })
+            .exitProcess(false)
+            .wrap(null)
+            .argv
+        })
 
-        r.logs[0].should.contain('bar command')
+        r.errors[0].should.contain('bar command')
       })
 
       describe('when check() throws error', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -473,6 +473,31 @@ describe('usage tests', function () {
         r.logs.should.deep.equal(['foo'])
         r.should.have.property('exit').and.be.false
       })
+
+      it('gives the ability to log a per-command error message if failure occurs in a command', function () {
+        var r = checkUsage(function () {
+          try {
+            return yargs
+              .command('foo', 'desc', {
+                bar: {
+                  describe: 'bar command'
+                }
+              }, function (argv) {
+                throw new Error('blah')
+              })
+              .fail(function (message, error, yargs) {
+                console.log(yargs.help())
+              })
+              .exitProcess(false)
+              .wrap(null)
+              .argv
+          } catch (e) {
+          }
+        }, 'foo')
+
+        r.logs[0].should.contain('bar command')
+      })
+
       describe('when check() throws error', function () {
         it('fail() is called with the original error object as the second parameter', function () {
           var r = checkUsage(function () {


### PR DESCRIPTION
This is needed to display a complete help message for a command that failed in a top-level `fail` handler
