### PR TITLE
For args that have skipValidation set to `true`, check if the parsed arg is `true`

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1041,6 +1041,20 @@ describe('yargs dsl tests', function () {
           .argv
       argv.koala.should.equal(true)
     })
+
+    it('allows having an option that skips validation but not skipping validation if that option is not used', function () {
+      var skippedValidation = true
+      yargs(['--no-skip'])
+          .demand(5)
+          .option('skip', {
+            skipValidation: true
+          })
+          .fail(function (msg) {
+            skippedValidation = false
+          })
+          .argv
+      expect(skippedValidation).to.equal(false)
+    })
   })
 
   describe('.help()', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -793,7 +793,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     // Check if any of the options to skip validation were provided
     if (!skipValidation && options.skipValidation.length > 0) {
       skipValidation = Object.keys(argv).some(function (key) {
-        return options.skipValidation.indexOf(key) >= 0
+        return options.skipValidation.indexOf(key) >= 0 && argv[key] === true
       })
     }
 


### PR DESCRIPTION
When an arg is defined, it will always exist in the parsed argv. Thus, validation would always be skipped, regardless of whether an arg that has `skipValidation` set to `true` is actually passed on the command line. This commit checks to see if the parsed argv value is actually set to true.