### PR TITLE
make opts object not required anymore for .option()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,8 +1082,8 @@ For example:
 
 ```js
 require('yargs')
-  .option('foobar', {})
-  .option('foobaz', {})
+  .option('foobar')
+  .option('foobaz')
   .completion()
   .getCompletion(['./test.js', '--foo'], function (completions) {
     console.log(completions)
@@ -1310,13 +1310,14 @@ var argv = require('yargs')
   .argv
 ```
 
-.option(key, opt)
+.option(key, [opt])
 -----------------
-.options(key, opt)
+.options(key, [opt])
 ------------------
 
-Instead of chaining together `.alias().demand().default().describe().string()`, you can specify
-keys in `opt` for each of the chainable methods.
+This method can be used to make yargs aware of options that _could_
+exist. You can also pass an `opt` object which can hold further
+customization, like `.alias()`, `.demand()` etc. for that option.
 
 For example:
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -124,6 +124,16 @@ describe('yargs dsl tests', function () {
     })
   })
 
+  it('should not require config object for an option', function () {
+    var r = checkOutput(function () {
+      return yargs([])
+        .option('x')
+        .argv
+    })
+
+    expect(r.errors).to.deep.equal([])
+  })
+
   describe('showHelpOnFail', function () {
     it('should display custom failure message, if string is provided as first argument', function () {
       var r = checkOutput(function () {

--- a/yargs.js
+++ b/yargs.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const Command = require('./lib/command')
 const Completion = require('./lib/completion')
 const Parser = require('yargs-parser')
@@ -394,7 +393,9 @@ function Yargs (processArgs, cwd, parentRequire) {
         self.options(k, key[k])
       })
     } else {
-      assert(typeof opt === 'object', 'second argument to option must be an object')
+      if (typeof opt !== 'object') {
+        opt = {}
+      }
 
       options.key[key] = true // track manually set keys.
 


### PR DESCRIPTION
Usually, yargs always requires options to be featuring an object for customisation like so:
```javascript
yargs()
  .option('x', {})
  .argv
```

This however seemed strange to me, as said customisation never is needed, you can also use options without any further customisation.

This Pull Request removes the check for whether an object is given to allow for declaration of options like this:
```javascript
yargs()
  .option('x')
  .argv
```

Why would we do that? Because it the object isn't needed anyway, requiring it makes little sense, and it might be confusing to people. Also, some people (like me) might prefer to write down all options in the yargs configuration to make clear which ones exist, also making yargs list them in the `argv` object even if not passed.