### PR TITLE
chore: add greenkeeper ignore rule for string-width, which no longer Node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,10 @@
   "license": "MIT",
   "engine": {
     "node": ">=0.10"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "string-width"
+    ]
   }
 }


### PR DESCRIPTION
I'd like to continue supporting Node 0.10 in the medium term, since this is a widely used utility library.