### PR TITLE
Added getRawOptions() method to get back reusable options

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1439,6 +1439,29 @@ describe('yargs dsl tests', function () {
       expect(msg).to.equal('ball')
       expect(err).to.exist
     })
+
+    it('should save & reuse raw options', function () {
+      var opts = {
+        looks: {
+          choices: ['good', 'bad']
+        },
+        foo: {},
+        bar: {
+          number: true
+        }
+      }
+      var gotOptions = yargs('component')
+        .option('looks', opts.looks)
+        .option('foo')
+        .option({
+          bar: {
+            number: true
+          }
+        })
+        .getRawOptions()
+      expect(gotOptions).to.deep.equal(opts)
+      expect(yargs('reuse').options(gotOptions).getRawOptions()).to.deep.equal(opts)
+    })
   })
 })
 

--- a/yargs.js
+++ b/yargs.js
@@ -51,6 +51,11 @@ function Yargs (processArgs, cwd, parentRequire) {
     return context
   }
 
+  var rawOptions = {}
+  self.getRawOptions = function () {
+    return rawOptions
+  }
+
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
   // by this action.
@@ -397,6 +402,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         opt = {}
       }
 
+      rawOptions[key] = opt
       options.key[key] = true // track manually set keys.
 
       if (opt.alias) self.alias(key, opt.alias)


### PR DESCRIPTION
This would be useful for composite/wrapper modules to easily integrate options of sub-components.

```
var yargs = require('yargs')
var sub = require('sub').cli

yargs()
  .option(sub.yargs.getRawOptions())
  .option(...)
```
