### PR TITLE
fix: drop lodash.assign

### DIFF
--- a/lib/assign.js
+++ b/lib/assign.js
@@ -1,0 +1,15 @@
+// lazy Object.assign logic that only works for merging
+// two objects; eventually we should replace this with Object.assign.
+module.exports = function assign (defaults, configuration) {
+  var o = {}
+  configuration = configuration || {}
+
+  Object.keys(defaults).forEach(function (k) {
+    o[k] = defaults[k]
+  })
+  Object.keys(configuration).forEach(function (k) {
+    o[k] = configuration[k]
+  })
+
+  return o
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
     "get-caller-file": "^1.0.1",
-    "lodash.assign": "^4.2.0",
     "os-locale": "^1.4.0",
     "read-pkg-up": "^1.0.1",
     "require-directory": "^2.1.1",

--- a/yargs.js
+++ b/yargs.js
@@ -504,7 +504,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
   self.getGroups = function () {
     // combine explicit and preserved groups. explicit groups should be first
-    return require('lodash.assign')({}, groups, preservedGroups)
+    return require('./lib/assign')(groups, preservedGroups)
   }
 
   // as long as options.envPrefix is not undefined,


### PR DESCRIPTION
lodash.assign is now deprecated; given how simple our use-case is, I opted to simply add the functionality to yargs itself.