### PR TITLE
Further fixes to skipValidation functionality

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1054,7 +1054,7 @@ describe('yargs dsl tests', function () {
 
     it('allows having an option that skips validation but not skipping validation if that option is not used', function () {
       var skippedValidation = true
-      yargs(['--no-skip'])
+      yargs(['--dont-skip'])
           .demand(5)
           .option('skip', {
             skipValidation: true
@@ -1064,6 +1064,23 @@ describe('yargs dsl tests', function () {
           })
           .argv
       expect(skippedValidation).to.equal(false)
+    })
+
+    it('allows skipping validation with non-boolean, aliased options', function () {
+      var skippedValidation = true
+      yargs(['--do-skip'])
+          .demand(5)
+          .option('d', {
+            alias: 'do-skip',
+            type: 'string',
+            default: 'yes',
+            skipValidation: true
+          })
+          .fail(function (msg) {
+            skippedValidation = false
+          })
+          .argv
+      expect(skippedValidation).to.equal(true)
     })
   })
 

--- a/yargs.js
+++ b/yargs.js
@@ -712,6 +712,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     const parsed = Parser.detailed(args, options)
     const argv = parsed.argv
     var aliases = parsed.aliases
+    var processed = parsed.processedKeys
 
     argv.$0 = self.$0
     self.parsed = parsed
@@ -823,8 +824,8 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     // Check if any of the options to skip validation were provided
     if (!skipValidation && options.skipValidation.length > 0) {
-      skipValidation = Object.keys(argv).some(function (key) {
-        return options.skipValidation.indexOf(key) >= 0 && argv[key] === true
+      skipValidation = processed.some(function (key) {
+        return options.skipValidation.indexOf(key) >= 0
       })
     }
 


### PR DESCRIPTION
I previously made a change to fix the broken `skipValidation` functionality of `yargs` (see #619). However, as I noted [here](https://github.com/yargs/yargs/pull/619#issuecomment-250929482), the functionality still had issues. The only clean way to fix those issues and get this functionality working how it is supposed to work required more information to be provided from `yargs-parser` (see yargs/yargs-parser#60). I've created a PR on that repo that is depended upon by this PR. If those changes are approved, merged, and released, I can update the dependency version for this PR. Until then, this PR will be expected to fail CI tests.