### PR TITLE
feat: reworking yargs API to make it easier to run in headless environments, e.g., Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ Give some example invocations of your program. Inside `cmd`, the string
 present script similar to how `$0` works in bash or perl.
 Examples will be printed out as part of the help message.
 
-.exitProcess(enable)
+<a name="exitprocess"></a>.exitProcess(enable)
 ----------------------------------
 
 By default, yargs exits the process when the user passes a help flag, uses the
@@ -1516,6 +1516,8 @@ parser.parse(bot.userText, function (err, argv, output) {
   if (output) bot.respond(output)
 })
 ```
+
+***Note:*** Providing a callback to `parse()` disables the [`exitProcess` setting](#exitprocess) until after the callback is invoked.
 
 .pkgConf(key, [cwd])
 ------------

--- a/README.md
+++ b/README.md
@@ -1506,36 +1506,15 @@ If a callback is given, it will be invoked with three arguments:
 // providing the `fn` argument to `parse()` runs yargs in headless mode, this
 // makes it easy to use yargs in contexts other than the CLI, e.g., writing
 // a chat-bot.
-yargs()
+const parser = yargs
   .command('lunch-train <restaurant> <time>', function () {}, function (argv) {
     api.scheduleLunch(argv.restaurant, moment(argv.time))
   })
-  .parse(bot.userText, function (err, argv, output) {
-    if (output) bot.respond(output)
-  })
-```
+  .help()
 
-If you are running yargs in a long-lived process, e.g., parsing incoming messages
-to a web-server, it's important that you do not execute yargs as a singleton:
-
-
-_so, don't do this!_
-
-```js
-yargs
-  .option('a')
-  .parse('--a b')
-```
-
-_instead, instantiate an instance of yargs to handle each request:_
-
-```js
-var yargs = require('yargs/yargs')
-yargs()
-  .option('a')
-  .parse('--a b', function (err, argv, output) {
-  // handle the incoming chat message.
-  })
+parser.parse(bot.userText, function (err, argv, output) {
+  if (output) bot.respond(output)
+})
 ```
 
 .pkgConf(key, [cwd])

--- a/README.md
+++ b/README.md
@@ -1488,12 +1488,33 @@ Valid `opt` keys include:
     - `'number'`: synonymous for `number: true`, see [`number()`](#number)
     - `'string'`: synonymous for `string: true`, see [`string()`](#string)
 
-.parse(args)
+.parse(args, [fn])
 ------------
 
 Parse `args` instead of `process.argv`. Returns the `argv` object.
-
 `args` may either be a pre-processed argv array, or a raw argument string.
+
+A callback `fn` can optionally be provided as the second argument to `.parse()`.
+If a callback is given, it will be invoked with three arguments:
+
+1. `err`: populated if any validation errors raised while parsing.
+2. `argv`: the parsed argv object.
+3. `output`: any text that would have been output to the terminal, had a
+  callback not been provided.
+
+ > pro tip: providing the `fn` argument to `parse()` runs yargs in headless mode, this
+   makes it easy to use yargs in contexts other than the CLI, e.g., writing
+   a chat-bot.
+
+```js
+yargs()
+  .command('lunch-train <restaurant> <time>', function () {}, function (argv) {
+    api.scheduleLunch(argv.restaurant, moment(argv.time))
+  })
+  .parse(bot.userText, function (err, argv, output) {
+    if (output) bot.respond(output)
+  })
+```
 
 .pkgConf(key, [cwd])
 ------------

--- a/README.md
+++ b/README.md
@@ -1494,7 +1494,7 @@ Valid `opt` keys include:
 Parse `args` instead of `process.argv`. Returns the `argv` object.
 `args` may either be a pre-processed argv array, or a raw argument string.
 
-A `context` object can optionally as the second argument to `parse()`, providing a
+A `context` object can optionally be given as the second argument to `parse()`, providing a
 useful mechanism for passing state information to commands:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1502,11 +1502,10 @@ If a callback is given, it will be invoked with three arguments:
 3. `output`: any text that would have been output to the terminal, had a
   callback not been provided.
 
- > pro tip: providing the `fn` argument to `parse()` runs yargs in headless mode, this
-   makes it easy to use yargs in contexts other than the CLI, e.g., writing
-   a chat-bot.
-
 ```js
+// providing the `fn` argument to `parse()` runs yargs in headless mode, this
+// makes it easy to use yargs in contexts other than the CLI, e.g., writing
+// a chat-bot.
 yargs()
   .command('lunch-train <restaurant> <time>', function () {}, function (argv) {
     api.scheduleLunch(argv.restaurant, moment(argv.time))

--- a/README.md
+++ b/README.md
@@ -1515,6 +1515,29 @@ yargs()
   })
 ```
 
+If you are running yargs in a long-lived process, e.g., parsing incoming messages
+to a web-server, it's important that you do not execute yargs as a singleton:
+
+
+_so, don't do this!_
+
+```js
+yargs
+  .option('a')
+  .parse('--a b')
+```
+
+_instead, instantiate an instance of yargs to handle each request:_
+
+```js
+var yargs = require('yargs/yargs')
+yargs()
+  .option('a')
+  .parse('--a b', function (err, argv, output) {
+  // handle the incoming chat message.
+  })
+```
+
 .pkgConf(key, [cwd])
 ------------
 

--- a/README.md
+++ b/README.md
@@ -1488,14 +1488,24 @@ Valid `opt` keys include:
     - `'number'`: synonymous for `number: true`, see [`number()`](#number)
     - `'string'`: synonymous for `string: true`, see [`string()`](#string)
 
-.parse(args, [fn])
+.parse(args, [context], [parseCallback])
 ------------
 
 Parse `args` instead of `process.argv`. Returns the `argv` object.
 `args` may either be a pre-processed argv array, or a raw argument string.
 
-A callback `fn` can optionally be provided as the second argument to `.parse()`.
-If a callback is given, it will be invoked with three arguments:
+A `context` object can optionally as the second argument to `parse()`, providing a
+useful mechanism for passing state information to commands:
+
+```js
+const parser = yargs
+  .command('lunch-train <restaurant>', 'start lunch train', function () {}, function (argv) {
+    console.log(argv.restaurant, argv.time)
+  })
+  .parse("lunch-train rudy's", {time: '12:15'})
+```
+
+A `parseCallback` can also be provided to `.parse()`. If a callback is given, it will be invoked with three arguments:
 
 1. `err`: populated if any validation errors raised while parsing.
 2. `argv`: the parsed argv object.
@@ -1507,7 +1517,7 @@ If a callback is given, it will be invoked with three arguments:
 // makes it easy to use yargs in contexts other than the CLI, e.g., writing
 // a chat-bot.
 const parser = yargs
-  .command('lunch-train <restaurant> <time>', function () {}, function (argv) {
+  .command('lunch-train <restaurant> <time>', 'start lunch train', function () {}, function (argv) {
     api.scheduleLunch(argv.restaurant, moment(argv.time))
   })
   .help()

--- a/lib/command.js
+++ b/lib/command.js
@@ -164,7 +164,7 @@ module.exports = function (yargs, usage, validation) {
 
     populatePositional(commandHandler, innerArgv, currentContext, yargs)
 
-    if (commandHandler.handler) {
+    if (commandHandler.handler && !yargs._hasOutput()) {
       commandHandler.handler(innerArgv)
     }
     currentContext.commands.pop()

--- a/lib/command.js
+++ b/lib/command.js
@@ -161,8 +161,7 @@ module.exports = function (yargs, usage, validation) {
       })
       innerArgv = innerArgv.argv
     }
-
-    populatePositional(commandHandler, innerArgv, currentContext, yargs)
+    if (!yargs._hasOutput()) populatePositional(commandHandler, innerArgv, currentContext, yargs)
 
     if (commandHandler.handler && !yargs._hasOutput()) {
       commandHandler.handler(innerArgv)
@@ -215,6 +214,21 @@ module.exports = function (yargs, usage, validation) {
     handlers = {}
     aliasMap = {}
     return self
+  }
+
+  // used by yargs.parse() to freeze
+  // the state of commands such that
+  // we can apply .parse() multiple times
+  // with the same yargs instance.
+  var fHandlers = {}
+  var fAliasMap = {}
+  self.freeze = function () {
+    fHandlers = handlers
+    fAliasMap = aliasMap
+  }
+  self.unfreeze = function () {
+    handlers = fHandlers
+    aliasMap = fAliasMap
   }
 
   return self

--- a/lib/command.js
+++ b/lib/command.js
@@ -220,15 +220,16 @@ module.exports = function (yargs, usage, validation) {
   // the state of commands such that
   // we can apply .parse() multiple times
   // with the same yargs instance.
-  var fHandlers = {}
-  var fAliasMap = {}
+  var frozen
   self.freeze = function () {
-    fHandlers = handlers
-    fAliasMap = aliasMap
+    frozen = {}
+    frozen.handlers = handlers
+    frozen.aliasMap = aliasMap
   }
   self.unfreeze = function () {
-    handlers = fHandlers
-    aliasMap = fAliasMap
+    handlers = frozen.handlers
+    aliasMap = frozen.aliasMap
+    frozen = undefined
   }
 
   return self

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -53,7 +53,7 @@ module.exports = function (yargs, y18n) {
       err = err || new Error(msg)
       if (yargs.getExitProcess()) {
         return yargs.exit(1)
-      } else if (yargs._getParseFunction()) {
+      } else if (yargs._hasParseCallback()) {
         return yargs.exit(1, err)
       } else {
         throw err

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -30,8 +30,7 @@ module.exports = function (yargs, y18n) {
 
   var failureOutput = false
   self.fail = function (msg, err) {
-    const logger = yargs.getLoggerInstance()
-    const exitFn = yargs.getExitInstance()
+    const logger = yargs._getLoggerInstance()
 
     if (fails.length) {
       for (var i = fails.length - 1; i >= 0; --i) {
@@ -50,10 +49,14 @@ module.exports = function (yargs, y18n) {
           logger.error(failMessage)
         }
       }
+
+      err = err || new Error(msg)
       if (yargs.getExitProcess()) {
-        return exitFn(1)
+        return yargs.exit(1)
+      } else if (yargs._getParseFunction()) {
+        return yargs.exit(1, err)
       } else {
-        throw err || new Error(msg)
+        throw err
       }
     }
   }
@@ -341,7 +344,7 @@ module.exports = function (yargs, y18n) {
   }
 
   self.showHelp = function (level) {
-    const logger = yargs.getLoggerInstance()
+    const logger = yargs._getLoggerInstance()
     if (!level) level = 'error'
     var emit = typeof level === 'function' ? level : logger[level]
     emit(self.help())
@@ -405,7 +408,7 @@ module.exports = function (yargs, y18n) {
   }
 
   self.showVersion = function () {
-    const logger = yargs.getLoggerInstance()
+    const logger = yargs._getLoggerInstance()
     if (typeof version === 'function') logger.log(version())
     else logger.log(version)
   }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -282,7 +282,7 @@ module.exports = function (yargs, y18n) {
     var width = 0
 
     // table might be of the form [leftColumn],
-    // or {key: leftColumn}}
+    // or {key: leftColumn}
     if (!Array.isArray(table)) {
       table = Object.keys(table).map(function (key) {
         return [table[key]]
@@ -426,6 +426,28 @@ module.exports = function (yargs, y18n) {
       return globalLookup[k]
     })
     return self
+  }
+
+  var frozen
+  self.freeze = function () {
+    frozen = {}
+    frozen.failMessage = failMessage
+    frozen.failureOutput = failureOutput
+    frozen.usage = usage
+    frozen.epilog = epilog
+    frozen.examples = examples
+    frozen.commands = commands
+    frozen.descriptions = descriptions
+  }
+  self.unfreeze = function () {
+    failMessage = frozen.failMessage
+    failureOutput = frozen.failureOutput
+    usage = frozen.usage
+    epilog = frozen.epilog
+    examples = frozen.examples
+    commands = frozen.commands
+    descriptions = frozen.descriptions
+    frozen = undefined
   }
 
   return self

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -30,6 +30,9 @@ module.exports = function (yargs, y18n) {
 
   var failureOutput = false
   self.fail = function (msg, err) {
+    const logger = yargs.getLoggerInstance()
+    const exitFn = yargs.getExitInstance()
+
     if (fails.length) {
       for (var i = fails.length - 1; i >= 0; --i) {
         fails[i](msg, err)
@@ -41,14 +44,14 @@ module.exports = function (yargs, y18n) {
       if (!failureOutput) {
         failureOutput = true
         if (showHelpOnFail) yargs.showHelp('error')
-        if (msg) console.error(msg)
+        if (msg) logger.error(msg)
         if (failMessage) {
-          if (msg) console.error('')
-          console.error(failMessage)
+          if (msg) logger.error('')
+          logger.error(failMessage)
         }
       }
       if (yargs.getExitProcess()) {
-        process.exit(1)
+        return exitFn(1)
       } else {
         throw err || new Error(msg)
       }
@@ -338,8 +341,9 @@ module.exports = function (yargs, y18n) {
   }
 
   self.showHelp = function (level) {
+    const logger = yargs.getLoggerInstance()
     if (!level) level = 'error'
-    var emit = typeof level === 'function' ? level : console[ level ]
+    var emit = typeof level === 'function' ? level : logger[level]
     emit(self.help())
   }
 
@@ -401,8 +405,9 @@ module.exports = function (yargs, y18n) {
   }
 
   self.showVersion = function () {
-    if (typeof version === 'function') console.log(version())
-    else console.log(version)
+    const logger = yargs.getLoggerInstance()
+    if (typeof version === 'function') logger.log(version())
+    else logger.log(version)
   }
 
   self.reset = function (globalLookup) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -187,18 +187,21 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   self.customChecks = function (argv, aliases) {
-    checks.forEach(function (f) {
+    for (var i = 0, f; (f = checks[i]) !== undefined; i++) {
+      var result = null
       try {
-        const result = f(argv, aliases)
-        if (!result) {
-          usage.fail(__('Argument check failed: %s', f.toString()))
-        } else if (typeof result === 'string') {
-          usage.fail(result)
-        }
+        result = f(argv, aliases)
       } catch (err) {
         usage.fail(err.message ? err.message : err, err)
+        continue
       }
-    })
+
+      if (!result) {
+        usage.fail(__('Argument check failed: %s', f.toString()))
+      } else if (typeof result === 'string' || result instanceof Error) {
+        usage.fail(result.toString())
+      }
+    }
   }
 
   // check implications, argument foo implies => argument bar.

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -302,5 +302,17 @@ module.exports = function (yargs, usage, y18n) {
     return self
   }
 
+  var frozen
+  self.freeze = function () {
+    frozen = {}
+    frozen.implied = implied
+    frozen.checks = checks
+  }
+  self.unfreeze = function () {
+    implied = frozen.implied
+    checks = frozen.checks
+    frozen = undefined
+  }
+
   return self
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -199,7 +199,7 @@ module.exports = function (yargs, usage, y18n) {
       if (!result) {
         usage.fail(__('Argument check failed: %s', f.toString()))
       } else if (typeof result === 'string' || result instanceof Error) {
-        usage.fail(result.toString())
+        usage.fail(result.toString(), result)
       }
     }
   }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1496,7 +1496,7 @@ describe('yargs context', function () {
   })
 
   describe('exit', function () {
-    it('delegates to custom exit when printing completion script', function () {
+    it('delegates to custom exit when printing completion script', function (done) {
       var completionScript = null
       var argv = yargs('completion')
         .completion()
@@ -1505,9 +1505,10 @@ describe('yargs context', function () {
             completionScript = _completionScript
           }
         })
-        .exit(function (code, argv) {
+        .exit(function (code) {
           code.should.equal(0)
           completionScript.should.match(/yargs command completion script/)
+          process.nextTick(done)
         })
         .argv
 
@@ -1537,6 +1538,25 @@ describe('yargs context', function () {
         })
         .argv
       argv.getYargsCompletions.should.equal(true)
+    })
+
+    it('delegates to custom exit when help is shown', function (done) {
+      var helpMsg = null
+      var argv = yargs('help')
+        .logger({
+          log: function (_helpMsg) {
+            helpMsg = _helpMsg
+          }
+        })
+        .exit(function (code) {
+          code.should.equal(0)
+          helpMsg.should.match(/Show help/)
+          process.nextTick(done)
+        })
+        .help()
+        .argv
+
+      argv.help.should.equal(true)
     })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1494,4 +1494,49 @@ describe('yargs context', function () {
       .argv
     context.commands.should.deep.equal([])
   })
+
+  describe('exit', function () {
+    it('delegates to custom exit when printing completion script', function () {
+      var completionScript = null
+      var argv = yargs('completion')
+        .completion()
+        .logger({
+          log: function (_completionScript) {
+            completionScript = _completionScript
+          }
+        })
+        .exit(function (code, argv) {
+          code.should.equal(0)
+          completionScript.should.match(/yargs command completion script/)
+        })
+        .argv
+
+      argv._.should.include('completion')
+    })
+
+    it('delegates to custom exit when making completion suggestions', function (done) {
+      var completions = ''
+      var argv = yargs(['--get-yargs-completions'])
+        .completion('completion', function (current, argv) {
+          return new Promise(function (resolve, reject) {
+            setTimeout(function () {
+              resolve(['apple', 'banana'])
+            }, 10)
+          })
+        })
+        .logger({
+          log: function (completion) {
+            completions += completion
+          }
+        })
+        .exit(function (code) {
+          completions.should.match(/apple/)
+          completions.should.match(/banana/)
+          code.should.equal(0)
+          return done()
+        })
+        .argv
+      argv.getYargsCompletions.should.equal(true)
+    })
+  })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1495,7 +1495,7 @@ describe('yargs context', function () {
     context.commands.should.deep.equal([])
   })
 
-  context('override exit', function () {
+  context('custom exit handler', function () {
     it('delegates to custom exit when printing completion script', function (done) {
       var completionScript = null
       var argv = yargs('completion')
@@ -1559,6 +1559,34 @@ describe('yargs context', function () {
       argv.help.should.equal(true)
     })
 
+    it('invokes custom exit handler after argv is parsed', function (done) {
+      var out = ''
+      var argv = yargs('--batman')
+        .exit(function (code) {
+          code.should.equal(1)
+          out.should.match(/Not enough non-option arguments/)
+          argv.batman.should.equal(true)
+          return done()
+        })
+        .logger({
+          error: function (_out) {
+            out += _out
+          }
+        })
+        .demand(2)
+        .argv
+    })
+
+    it('invokes custom exit handler if yargs exits normally', function (done) {
+      var argv = yargs('--batman')
+        .exit(function (code) {
+          code.should.equal(0)
+          argv.batman.should.equal(true)
+          return done()
+        })
+        .argv
+    })
+
     describe('commands', function () {
       it('handles top-level command appropriately', function (done) {
         var helpMsg = null
@@ -1612,7 +1640,7 @@ describe('yargs context', function () {
     })
 
     describe('validation', function () {
-      it('calls exit handler when validation triggers', function (done) {
+      it('calls custom exit when validation triggers', function (done) {
         var out = ''
         yargs('')
           .demand(3)
@@ -1629,7 +1657,7 @@ describe('yargs context', function () {
           .argv
       })
 
-      it('calls exit handler when a custom check throws an exception', function (done) {
+      it('calls custom exit when a custom check throws an exception', function (done) {
         var out = ''
         yargs('--batman true')
           .check(function (argv, opts) {
@@ -1648,7 +1676,7 @@ describe('yargs context', function () {
           .argv
       })
 
-      it('calls exit handler when a custom check returns en error', function (done) {
+      it('calls custom exit when a custom check returns en error', function (done) {
         var out = ''
         yargs('--batman true')
           .check(function (argv, opts) {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1610,5 +1610,62 @@ describe('yargs context', function () {
         argv._.should.include('cool')
       })
     })
+
+    describe('validation', function () {
+      it('calls exit handler when validation triggers', function (done) {
+        var out = ''
+        yargs('')
+          .demand(3)
+          .logger({
+            error: function (msg) {
+              out += msg
+            }
+          })
+          .exit(function (code) {
+            code.should.equal(1)
+            out.should.match(/Not enough non-option argument/)
+            process.nextTick(done)
+          })
+          .argv
+      })
+
+      it('calls exit handler when a custom check throws an exception', function (done) {
+        var out = ''
+        yargs('--batman true')
+          .check(function (argv, opts) {
+            throw Error('why u no')
+          })
+          .logger({
+            error: function (msg) {
+              out += msg
+            }
+          })
+          .exit(function (code) {
+            code.should.equal(1)
+            out.should.equal('why u no')
+            process.nextTick(done)
+          })
+          .argv
+      })
+
+      it('calls exit handler when a custom check returns en error', function (done) {
+        var out = ''
+        yargs('--batman true')
+          .check(function (argv, opts) {
+            return Error('why u no')
+          })
+          .logger({
+            error: function (msg) {
+              out += msg
+            }
+          })
+          .exit(function (code) {
+            code.should.equal(1)
+            out.should.match(/why u no/)
+            process.nextTick(done)
+          })
+          .argv
+      })
+    })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global context, describe, it, beforeEach */
 
 var expect = require('chai').expect
 var fs = require('fs')
@@ -1495,7 +1495,7 @@ describe('yargs context', function () {
     context.commands.should.deep.equal([])
   })
 
-  describe('exit', function () {
+  context('override exit', function () {
     it('delegates to custom exit when printing completion script', function (done) {
       var completionScript = null
       var argv = yargs('completion')
@@ -1557,6 +1557,58 @@ describe('yargs context', function () {
         .argv
 
       argv.help.should.equal(true)
+    })
+
+    describe('commands', function () {
+      it('handles top-level command appropriately', function (done) {
+        var helpMsg = null
+        var argv = yargs('help')
+          .command('cool', 'my cool command', function (yargs) {
+            yargs.option('opt', {
+              describe: 'my cool option'
+            }).help()
+          }, function () {})
+          .logger({
+            log: function (_helpMsg) {
+              helpMsg = _helpMsg
+            }
+          })
+          .help()
+          .exit(function (code) {
+            code.should.equal(0)
+            helpMsg.should.not.match(/my cool option/)
+            process.nextTick(done)
+          })
+          .argv
+
+        argv.help.should.equal(true)
+        argv._.length.should.equal(0)
+      })
+
+      it('handles sub-command appropriately', function (done) {
+        var helpMsg = null
+        var argv = yargs('cool help')
+          .command('cool', 'my cool command', function (yargs) {
+            yargs.option('opt', {
+              describe: 'my cool option'
+            }).help()
+          }, function () {})
+          .logger({
+            log: function (_helpMsg) {
+              helpMsg = _helpMsg
+            }
+          })
+          .help()
+          .exit(function (code) {
+            code.should.equal(0)
+            helpMsg.should.match(/my cool option/)
+            process.nextTick(done)
+          })
+          .argv
+
+        argv.help.should.equal(true)
+        argv._.should.include('cool')
+      })
     })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -238,6 +238,7 @@ describe('yargs dsl tests', function () {
         normalize: [],
         number: [],
         config: {},
+        configObjects: [],
         envPrefix: 'YARGS', // preserved as global
         global: ['help'],
         demanded: {}
@@ -744,6 +745,15 @@ describe('yargs dsl tests', function () {
       var parsed = yargs.help().parse('help', true)
       parsed._.should.deep.equal(['help'])
     })
+
+    it('allows an optional context object to be provided', function () {
+      var a1 = yargs.parse('-x=2 --foo=bar', {
+        context: 'look at me go!'
+      })
+      a1.x.should.equal(2)
+      a1.foo.should.equal('bar')
+      a1.context.should.equal('look at me go!')
+    })
   })
 
   // yargs.parse(['foo', '--bar'], function (err, argv, output) {}
@@ -875,6 +885,21 @@ describe('yargs dsl tests', function () {
         r.logs.length.should.equal(0)
         r.errors.length.should.equal(0)
         output.should.equal('')
+        argv['api-token'].should.equal('robin')
+        argv.what.should.equal(true)
+      })
+
+      it('allows context object to be passed to parse', function () {
+        var argv = null
+        yargs()
+          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {
+            argv = _argv
+          })
+          .parse('batman robin --what', {
+            state: 'grumpy but rich'
+          }, function (_err, argv, _output) {})
+
+        argv.state.should.equal('grumpy but rich')
         argv['api-token'].should.equal('robin')
         argv.what.should.equal(true)
       })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -802,6 +802,48 @@ describe('yargs dsl tests', function () {
       output.should.match(/--robin.*\[required\]/)
     })
 
+    it('reinstates original exitProcess setting after invocation', function () {
+      var callbackCalled = false
+      var r = checkOutput(function () {
+        yargs
+          .exitProcess(true)
+          .help()
+          .parse('--help', function () {
+            callbackCalled = true
+            yargs.getExitProcess().should.be.false
+          })
+      })
+      r.logs.length.should.equal(0)
+      r.errors.length.should.equal(0)
+      r.exit.should.be.false
+      callbackCalled.should.be.true
+      yargs.getExitProcess().should.be.true
+    })
+
+    it('does not call callback if subsequently called without callback', function () {
+      var callbackCalled = 0
+      var callback = function () {
+        callbackCalled++
+      }
+      var r1 = checkOutput(function () {
+        yargs
+          .help()
+          .parse('--help', callback)
+      })
+      var r2 = checkOutput(function () {
+        yargs
+          .help()
+          .parse('--help')
+      })
+      callbackCalled.should.equal(1)
+      r1.logs.length.should.equal(0)
+      r1.errors.length.should.equal(0)
+      r1.exit.should.be.false
+      r2.exit.should.be.true
+      r2.errors.length.should.equal(0)
+      r2.logs[0].should.match(/--help.*Show help.*\[boolean\]/)
+    })
+
     describe('commands', function () {
       it('does not invoke command handler if output is populated', function () {
         var err = null

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -825,15 +825,12 @@ describe('yargs dsl tests', function () {
       var callback = function () {
         callbackCalled++
       }
+      yargs.help()
       var r1 = checkOutput(function () {
-        yargs
-          .help()
-          .parse('--help', callback)
+        yargs.parse('--help', callback)
       })
       var r2 = checkOutput(function () {
-        yargs
-          .help()
-          .parse('--help')
+        yargs.parse('--help')
       })
       callbackCalled.should.equal(1)
       r1.logs.length.should.equal(0)
@@ -972,6 +969,34 @@ describe('yargs dsl tests', function () {
           'Options:',
           '  --help  Show help  [boolean]',
           ''
+        ])
+      })
+
+      it('preserves top-level config when parse is called multiple times', function () {
+        var x = 'wrong'
+        var err
+        var output
+        // set some top-level, reset-able config
+        var parser = yargs()
+          .demand(1, 'Must call a command')
+          .strict()
+          .command('one <x>', 'The one and only command')
+        // first call parse with command, which calls reset
+        parser.parse('one two', function (_, argv) {
+          x = argv.x
+        })
+        // then call parse without command, which should enforce top-level config
+        parser.parse('', function (_err, argv, _output) {
+          err = _err || {}
+          output = _output || ''
+        })
+        x.should.equal('two')
+        err.should.have.property('message').and.equal('Must call a command')
+        output.split('\n').should.deep.equal([
+          'Commands:',
+          '  one <x>  The one and only command',
+          '',
+          'Must call a command'
         ])
       })
     })

--- a/yargs.js
+++ b/yargs.js
@@ -675,10 +675,24 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
+  self.getExitInstance = function () {
+    return exitFn
+  }
+
+  const ExitEarly = Error('exited early')
+  function exitEarly (code) {
+    ExitEarly.code = code
+    throw ExitEarly
+  }
+
   var logger = console
   self.logger = function (_logger) {
     logger = _logger
     return self
+  }
+
+  self.getLoggerInstance = function () {
+    return logger
   }
 
   var recommendCommands
@@ -866,12 +880,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     }
 
     return setPlaceholderKeys(argv)
-  }
-
-  const ExitEarly = Error('exited early')
-  function exitEarly (code) {
-    ExitEarly.code = code
-    throw ExitEarly
   }
 
   function guessLocale () {

--- a/yargs.js
+++ b/yargs.js
@@ -395,10 +395,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     // by providing a function as a second argument to
     // parse you can capture output that would otherwise
     // default to printing to stdout/stderr.
+    var exitProcessBeforeParse
     if (typeof shortCircuit === 'function') {
       parseFn = shortCircuit
       shortCircuit = null
-      self.exitProcess(false)
+      exitProcessBeforeParse = exitProcess
+      exitProcess = false
     }
     // completion short-circuits the parsing process,
     // skipping validation, etc.
@@ -410,6 +412,8 @@ function Yargs (processArgs, cwd, parentRequire) {
       parseFn(exitError, parsed, output)
       command.unfreeze()
       resetForNextParse()
+      parseFn = null
+      exitProcess = exitProcessBeforeParse
     }
 
     return parsed

--- a/yargs.js
+++ b/yargs.js
@@ -124,17 +124,12 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     strict = false
     completionCommand = null
-    resetForNextParse()
-
-    return self
-  }
-  // partially reset yargs, such that
-  // yargs.parse() can be invoked multiple times.
-  function resetForNextParse () {
     output = ''
     exitError = null
     hasOutput = false
     self.parsed = false
+
+    return self
   }
   self.resetOptions()
 
@@ -443,8 +438,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     var parsed = parseArgs(args, shortCircuit)
     if (parseFn) {
       parseFn(exitError, parsed, output)
+      self.reset()
       unfreeze()
-      resetForNextParse()
       parseFn = null
     }
 

--- a/yargs.js
+++ b/yargs.js
@@ -393,7 +393,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (typeof shortCircuit === 'function') {
       parseFn = shortCircuit
       shortCircuit = null
-      silent = true
       self.exitProcess(false)
     }
     // completion short-circuits the parsing process,
@@ -704,18 +703,19 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // we use a custom logger that buffers output,
   // so that we can print to non-CLIs, e.g., chat-bots.
-  var silent = false
   var _logger = {
     log: function () {
       var args = Array.prototype.slice.call(arguments)
-      if (!silent) console.log.apply(console, args)
+      if (!self._hasParseCallback()) console.log.apply(console, args)
       hasOutput = true
+      if (output.length) output += '\n'
       output += args.join(' ')
     },
     error: function () {
       var args = Array.prototype.slice.call(arguments)
-      if (!silent) console.error.apply(console, args)
+      if (!self._hasParseCallback()) console.error.apply(console, args)
       hasOutput = true
+      if (output.length) output += '\n'
       output += args.join(' ')
     }
   }
@@ -725,7 +725,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   // has yargs output an error our help
   // message in the current execution context.
   self._hasOutput = function () {
-    return !!hasOutput
+    return hasOutput
   }
 
   var recommendCommands

--- a/yargs.js
+++ b/yargs.js
@@ -65,6 +65,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     // hierarchy.
     var tmpOptions = {}
     tmpOptions.global = options.global ? options.global : []
+    tmpOptions.configObjects = options.configObjects ? options.configObjects : []
 
     // if a key has been set as a global, we
     // do not want to reset it or its aliases.
@@ -416,7 +417,14 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   var parseFn = null
-  self.parse = function (args, shortCircuit) {
+  self.parse = function (args, shortCircuit, _parseFn) {
+    // a context object can optionally be provided, this allows
+    // additional information to be passed to a command handler.
+    if (typeof shortCircuit === 'object') {
+      self.config(shortCircuit)
+      shortCircuit = _parseFn
+    }
+
     // by providing a function as a second argument to
     // parse you can capture output that would otherwise
     // default to printing to stdout/stderr.

--- a/yargs.js
+++ b/yargs.js
@@ -702,6 +702,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (exitProcess) process.exit(code)
   }
 
+  // we use a custom logger that buffers output,
+  // so that we can print to non-CLIs, e.g., chat-bots.
   var silent = false
   var _logger = {
     log: function () {
@@ -717,8 +719,6 @@ function Yargs (processArgs, cwd, parentRequire) {
       output += args.join(' ')
     }
   }
-  // we use a custom logger that buffers output,
-  // so that we can print to non-CLIs, e.g., Slack.
   self._getLoggerInstance = function () {
     return _logger
   }

--- a/yargs.js
+++ b/yargs.js
@@ -406,8 +406,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     return parsed
   }
 
-  self._getParseFunction = function () {
-    return parseFn
+  self._hasParseCallback = function () {
+    return !!parseFn
   }
 
   self.option = self.options = function (key, opt) {
@@ -725,7 +725,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   // has yargs output an error our help
   // message in the current execution context.
   self._hasOutput = function () {
-    return hasOutput
+    return !!hasOutput
   }
 
   var recommendCommands

--- a/yargs.js
+++ b/yargs.js
@@ -47,16 +47,10 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  var context = null
+  const context = { resets: -1, commands: [], files: [] }
   self.getContext = function () {
     return context
   }
-  // reset the context object used to track the depth
-  // of commands being invoked.
-  function resetContext () {
-    context = { resets: -1, commands: [], files: [] }
-  }
-  resetContext()
 
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
@@ -415,7 +409,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (parseFn) {
       parseFn(exitError, parsed, output)
       command.unfreeze()
-      resetContext()
       resetForNextParse()
     }
 


### PR DESCRIPTION
after discussion today, @nexdrew and I settled on what I think is a pretty clever extension to the `parse()` function, as a simple API extension that supports running yargs in headless mode (yargs with no terminal output).

----

A callback `fn` can optionally be provided as the second argument to `.parse()`.
If a callback is given, it will be invoked with three arguments:

1. `err`: populated if any validation errors raised while parsing.
2. `argv`: the parsed argv object.
3. `output`: any text that would have been output to the terminal, had a
  callback not been provided.

```js
// providing the `fn` argument to `parse()` runs yargs in headless mode, this
// makes it easy to use yargs in contexts other than the CLI, e.g., writing
// a chat-bot.
yargs()
  .command('lunch-train <restaurant> <time>', function () {}, function (argv) {
    api.scheduleLunch(argv.restaurant, moment(argv.time))
  })
  .parse(bot.userText, function (err, argv, output) {
    if (output) bot.respond(output)
  })
```

----

Long story short, `parse()` now accepts an optional `fn`, which if provided will:

1. prevent text from being output to the terminal.
2. prevent commands from being invoked if an error is thrown, or text has been output to the terminal.
3. get invoked with `err`, `argv`, `output` (allowing output to be routed somewhere elsewhere, .e.g., a chat-room).

reviewers: @nexdrew, @maxrimue, @lrlna