### PR TITLE
feat: initial support for command aliases

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -27,7 +27,6 @@ module.exports = function (yargs, usage, validation) {
     }
 
     var parsedCommand = parseCommand(cmd)
-    var alias
     aliases = aliases.map(function (alias) {
       alias = parseCommand(alias).cmd // remove positional args
       aliasMap[alias] = parsedCommand.cmd

--- a/lib/command.js
+++ b/lib/command.js
@@ -8,27 +8,36 @@ module.exports = function (yargs, usage, validation) {
   const self = {}
 
   var handlers = {}
+  var aliasMap = {}
   self.addHandler = function (cmd, description, builder, handler) {
-    if (typeof cmd === 'object') {
-      const commandString = typeof cmd.command === 'string' ? cmd.command : moduleName(cmd)
+    var aliases = []
+    if (Array.isArray(cmd)) {
+      aliases = cmd.slice(1)
+      cmd = cmd[0]
+    } else if (typeof cmd === 'object') {
+      const commandString = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
       self.addHandler(commandString, extractDesc(cmd), cmd.builder, cmd.handler)
       return
     }
 
     // allow a module to be provided instead of separate builder and handler
     if (typeof builder === 'object' && builder.builder && typeof builder.handler === 'function') {
-      self.addHandler(cmd, description, builder.builder, builder.handler)
+      self.addHandler([cmd].concat(aliases), description, builder.builder, builder.handler)
       return
     }
 
+    var parsedCommand = parseCommand(cmd)
+    var alias
+    aliases = aliases.map(function (alias) {
+      alias = parseCommand(alias).cmd // remove positional args
+      aliasMap[alias] = parsedCommand.cmd
+      return alias
+    })
+
     if (description !== false) {
-      usage.command(cmd, description)
+      usage.command(cmd, description, aliases)
     }
 
-    // we should not register a handler if no
-    // builder is provided, e.g., user will
-    // handle command themselves with '_'.
-    var parsedCommand = parseCommand(cmd)
     handlers[parsedCommand.cmd] = {
       original: cmd,
       handler: handler,
@@ -112,7 +121,7 @@ module.exports = function (yargs, usage, validation) {
   }
 
   self.getCommands = function () {
-    return Object.keys(handlers)
+    return Object.keys(handlers).concat(Object.keys(aliasMap))
   }
 
   self.getCommandHandlers = function () {
@@ -121,7 +130,7 @@ module.exports = function (yargs, usage, validation) {
 
   self.runCommand = function (command, yargs, parsed) {
     var argv = parsed.argv
-    var commandHandler = handlers[command]
+    var commandHandler = handlers[command] || handlers[aliasMap[command]]
     var innerArgv = argv
     var currentContext = yargs.getContext()
     var parentCommands = currentContext.commands.slice()
@@ -204,6 +213,7 @@ module.exports = function (yargs, usage, validation) {
 
   self.reset = function () {
     handlers = {}
+    aliasMap = {}
     return self
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -15,8 +15,9 @@ module.exports = function (yargs, usage, validation) {
       aliases = cmd.slice(1)
       cmd = cmd[0]
     } else if (typeof cmd === 'object') {
-      const commandString = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
-      self.addHandler(commandString, extractDesc(cmd), cmd.builder, cmd.handler)
+      var command = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
+      if (cmd.aliases) command = [].concat(command).concat(cmd.aliases)
+      self.addHandler(command, extractDesc(cmd), cmd.builder, cmd.handler)
       return
     }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -70,8 +70,8 @@ module.exports = function (yargs, y18n) {
   }
 
   var commands = []
-  self.command = function (cmd, description) {
-    commands.push([cmd, description || ''])
+  self.command = function (cmd, description, aliases) {
+    commands.push([cmd, description || '', aliases])
   }
   self.getCommands = function () {
     return commands
@@ -152,10 +152,15 @@ module.exports = function (yargs, y18n) {
       ui.div(__('Commands:'))
 
       commands.forEach(function (command) {
-        ui.div(
+        ui.span(
           {text: command[0], padding: [0, 2, 0, 2], width: maxWidth(commands, theWrap) + 4},
           {text: command[1]}
         )
+        if (command[2] && command[2].length) {
+          ui.div({text: '[' + __('aliases:') + ' ' + command[2].join(', ') + ']', padding: [0, 0, 0, 2], align: 'right'})
+        } else {
+          ui.div()
+        }
       })
 
       ui.div()

--- a/locales/de.json
+++ b/locales/de.json
@@ -10,6 +10,7 @@
   "required": "erforderlich",
   "default:": "Standard:",
   "choices:": "Möglichkeiten:",
+  "aliases:": "Aliase:",
   "generated-value": "Generierter-Wert",
   "Not enough non-option arguments: got %s, need at least %s": "Nicht genügend Argumente ohne Optionen: %s vorhanden, mindestens %s benötigt",
   "Too many non-option arguments: got %s, maximum of %s": "Zu viele Argumente ohne Optionen: %s vorhanden, maximal %s erlaubt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -10,6 +10,7 @@
   "required": "required",
   "default:": "default:",
   "choices:": "choices:",
+  "aliases:": "aliases:",
   "generated-value": "generated-value",
   "Not enough non-option arguments: got %s, need at least %s": "Not enough non-option arguments: got %s, need at least %s",
   "Too many non-option arguments: got %s, maximum of %s": "Too many non-option arguments: got %s, maximum of %s",

--- a/test/command.js
+++ b/test/command.js
@@ -143,10 +143,11 @@ describe('Command', function () {
     it('accepts string, string as first 2 arguments', function () {
       var cmd = 'foo'
       var desc = 'i\'m not feeling very creative at the moment'
+      var aliases = []
 
       var y = yargs([]).command(cmd, desc)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([cmd, desc])
+      commands[0].should.deep.equal([cmd, desc, aliases])
     })
 
     it('accepts string, boolean as first 2 arguments', function () {
@@ -221,6 +222,7 @@ describe('Command', function () {
         builder: function (yargs) { return yargs },
         handler: function (argv) {}
       }
+      var aliases = []
 
       var y = yargs([]).command(module)
       var handlers = y.getCommandInstance().getCommandHandlers()
@@ -228,7 +230,7 @@ describe('Command', function () {
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([module.command, module.describe])
+      commands[0].should.deep.equal([module.command, module.describe, aliases])
     })
 
     it('accepts module (description key, builder function) as 1st argument', function () {
@@ -238,6 +240,7 @@ describe('Command', function () {
         builder: function (yargs) { return yargs },
         handler: function (argv) {}
       }
+      var aliases = []
 
       var y = yargs([]).command(module)
       var handlers = y.getCommandInstance().getCommandHandlers()
@@ -245,7 +248,7 @@ describe('Command', function () {
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([module.command, module.description])
+      commands[0].should.deep.equal([module.command, module.description, aliases])
     })
 
     it('accepts module (desc key, builder function) as 1st argument', function () {
@@ -255,6 +258,7 @@ describe('Command', function () {
         builder: function (yargs) { return yargs },
         handler: function (argv) {}
       }
+      var aliases = []
 
       var y = yargs([]).command(module)
       var handlers = y.getCommandInstance().getCommandHandlers()
@@ -262,7 +266,7 @@ describe('Command', function () {
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([module.command, module.desc])
+      commands[0].should.deep.equal([module.command, module.desc, aliases])
     })
 
     it('accepts module (false describe, builder function) as 1st argument', function () {
@@ -309,6 +313,7 @@ describe('Command', function () {
         },
         handler: function (argv) {}
       }
+      var aliases = []
 
       var y = yargs([]).command(module)
       var handlers = y.getCommandInstance().getCommandHandlers()
@@ -316,7 +321,7 @@ describe('Command', function () {
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([module.command, module.describe])
+      commands[0].should.deep.equal([module.command, module.describe, aliases])
     })
 
     it('accepts module (missing handler function) as 1st argument', function () {
@@ -329,6 +334,7 @@ describe('Command', function () {
           }
         }
       }
+      var aliases = []
 
       var y = yargs([]).command(module)
       var handlers = y.getCommandInstance().getCommandHandlers()
@@ -336,7 +342,7 @@ describe('Command', function () {
       handlers.foo.builder.should.equal(module.builder)
       expect(handlers.foo.handler).to.equal(undefined)
       var commands = y.getUsageInstance().getCommands()
-      commands[0].should.deep.equal([module.command, module.describe])
+      commands[0].should.deep.equal([module.command, module.describe, aliases])
     })
   })
 

--- a/test/command.js
+++ b/test/command.js
@@ -401,6 +401,66 @@ describe('Command', function () {
       var cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
     })
+
+    it('accepts module (with command string and aliases array) as 1st argument', function () {
+      var module = {
+        command: 'foo <qux>',
+        aliases: ['bar', 'baz'],
+        describe: 'i\'m not feeling very creative at the moment',
+        builder: function (yargs) { return yargs },
+        handler: function (argv) {}
+      }
+
+      var y = yargs([]).command(module)
+      var handlers = y.getCommandInstance().getCommandHandlers()
+      handlers.foo.original.should.equal(module.command)
+      handlers.foo.builder.should.equal(module.builder)
+      handlers.foo.handler.should.equal(module.handler)
+      var usageCommands = y.getUsageInstance().getCommands()
+      usageCommands[0].should.deep.equal([module.command, module.describe, module.aliases])
+      var cmdCommands = y.getCommandInstance().getCommands()
+      cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
+    })
+
+    it('accepts module (with command array and aliases array) as 1st argument', function () {
+      var module = {
+        command: ['foo <qux>', 'bar'],
+        aliases: ['baz', 'nat'],
+        describe: 'i\'m not feeling very creative at the moment',
+        builder: function (yargs) { return yargs },
+        handler: function (argv) {}
+      }
+
+      var y = yargs([]).command(module)
+      var handlers = y.getCommandInstance().getCommandHandlers()
+      handlers.foo.original.should.equal(module.command[0])
+      handlers.foo.builder.should.equal(module.builder)
+      handlers.foo.handler.should.equal(module.handler)
+      var usageCommands = y.getUsageInstance().getCommands()
+      usageCommands[0].should.deep.equal([module.command[0], module.describe, ['bar', 'baz', 'nat']])
+      var cmdCommands = y.getCommandInstance().getCommands()
+      cmdCommands.should.deep.equal(['foo', 'bar', 'baz', 'nat'])
+    })
+
+    it('accepts module (with command string and aliases string) as 1st argument', function () {
+      var module = {
+        command: 'foo <qux>',
+        aliases: 'bar',
+        describe: 'i\'m not feeling very creative at the moment',
+        builder: function (yargs) { return yargs },
+        handler: function (argv) {}
+      }
+
+      var y = yargs([]).command(module)
+      var handlers = y.getCommandInstance().getCommandHandlers()
+      handlers.foo.original.should.equal(module.command)
+      handlers.foo.builder.should.equal(module.builder)
+      handlers.foo.handler.should.equal(module.handler)
+      var usageCommands = y.getUsageInstance().getCommands()
+      usageCommands[0].should.deep.equal([module.command, module.describe, ['bar']])
+      var cmdCommands = y.getCommandInstance().getCommands()
+      cmdCommands.should.deep.equal(['foo', 'bar'])
+    })
   })
 
   describe('commandDir', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1791,11 +1791,11 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays aliases for commands that have them (default wrap)', function () {
+    it('displays aliases for commands that have them (with wrap)', function () {
       var r = checkUsage(function () {
         return yargs('help')
           .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
-          .help()
+          .help().wrap(80)
           .argv
       })
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -1772,6 +1772,42 @@ describe('usage tests', function () {
         ''
       ])
     })
+
+    it('displays aliases for commands that have them (no wrap)', function () {
+      var r = checkUsage(function () {
+        return yargs('help')
+          .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  copy <src> [dest]  Copy something  [aliases: cp, dupe]',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('displays aliases for commands that have them (default wrap)', function () {
+      var r = checkUsage(function () {
+        return yargs('help')
+          .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
+          .help()
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  copy <src> [dest]  Copy something                          [aliases: cp, dupe]',
+        '',
+        'Options:',
+        '  --help  Show help                                                    [boolean]',
+        ''
+      ])
+    })
   })
 
   describe('epilogue', function () {


### PR DESCRIPTION
Allows a command to have aliases if given as an array, e.g.

```js
.command(['start', 'run', 'go'], 'Start the app', builder, handler)
```

The first element in the array is treated as the canonical command, which supports positional args; the remaining elements are considered aliases. Aliases inherit their positional args from the canonical command and, thus, any positional args defined for an alias are ignored.

For example, all of the following are equivalent and only the `<name>` required positional arg will be parsed/validated:

```js
.command(['hi <name>', 'hello'], 'Say hi', builder, handler)
.command(['hi <name>', 'hello <name>'], 'Say hi', builder, handler)
.command(['hi <name>', 'hello <someone> [others..]'], 'Say hi', builder, handler)
```

For help text, command aliases are displayed in a new right-aligned column after the canonical command and description, e.g.

```console
$ node test.js help
Commands:
  start      Start the app                                    [aliases: go, run]
  hi <name>  Say hi                                             [aliases: hello]

Options:
  --help  Show help                                                    [boolean]
```

TODO:

- [x] Tests
- [x] ~~Add `"aliases:"` to all locales~~ Will create a new issue for this
- [x] Docs