### PR TITLE
feat(command): add camelcase commands to argv

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const inspect = require('util').inspect
+const camelCase = require('camelcase')
 
 // handles parsing positional arguments,
 // and populating argv with said positional
@@ -185,6 +186,11 @@ module.exports = function (yargs, usage, validation) {
       if (demand.variadic) argv[demand.cmd] = argv._.splice(0)
       else argv[demand.cmd] = argv._.shift()
       postProcessPositional(yargs, argv, demand.cmd)
+      if (/-/.test(demand.cmd)) {
+        var cc = camelCase(demand.cmd)
+        if (typeof argv[demand.cmd] === 'object') argv[cc] = argv[demand.cmd].splice(0)
+        else argv[cc] = argv[demand.cmd]
+      }
     }
 
     while (optional.length) {
@@ -194,6 +200,11 @@ module.exports = function (yargs, usage, validation) {
       if (maybe.variadic) argv[maybe.cmd] = argv._.splice(0)
       else argv[maybe.cmd] = argv._.shift()
       postProcessPositional(yargs, argv, maybe.cmd)
+      if (/-/.test(maybe.cmd)) {
+        cc = camelCase(maybe.cmd)
+        if (typeof argv[maybe.cmd] === 'object') argv[cc] = argv[maybe.cmd].splice(0)
+        else argv[cc] = argv[maybe.cmd]
+      }
     }
 
     argv._ = context.commands.concat(argv._)

--- a/lib/command.js
+++ b/lib/command.js
@@ -186,11 +186,7 @@ module.exports = function (yargs, usage, validation) {
       if (demand.variadic) argv[demand.cmd] = argv._.splice(0)
       else argv[demand.cmd] = argv._.shift()
       postProcessPositional(yargs, argv, demand.cmd)
-      if (/-/.test(demand.cmd)) {
-        var cc = camelCase(demand.cmd)
-        if (typeof argv[demand.cmd] === 'object') argv[cc] = argv[demand.cmd].splice(0)
-        else argv[cc] = argv[demand.cmd]
-      }
+      addCamelCaseExpansions(argv, demand.cmd)
     }
 
     while (optional.length) {
@@ -200,11 +196,7 @@ module.exports = function (yargs, usage, validation) {
       if (maybe.variadic) argv[maybe.cmd] = argv._.splice(0)
       else argv[maybe.cmd] = argv._.shift()
       postProcessPositional(yargs, argv, maybe.cmd)
-      if (/-/.test(maybe.cmd)) {
-        cc = camelCase(maybe.cmd)
-        if (typeof argv[maybe.cmd] === 'object') argv[cc] = argv[maybe.cmd].splice(0)
-        else argv[cc] = argv[maybe.cmd]
-      }
+      addCamelCaseExpansions(argv, maybe.cmd)
     }
 
     argv._ = context.commands.concat(argv._)
@@ -219,6 +211,14 @@ module.exports = function (yargs, usage, validation) {
       } catch (err) {
         yargs.getUsageInstance().fail(err.message, err)
       }
+    }
+  }
+
+  function addCamelCaseExpansions (argv, option) {
+    if (/-/.test(option)) {
+      const cc = camelCase(option)
+      if (typeof argv[option] === 'object') argv[cc] = argv[option].slice(0)
+      else argv[cc] = argv[option]
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "camelcase": "^3.0.0",
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
     "get-caller-file": "^1.0.1",

--- a/test/command.js
+++ b/test/command.js
@@ -61,6 +61,18 @@ describe('Command', function () {
       argv['baz-qux'].should.equal('world')
     })
 
+    it('populates argv with camel-case variants of variadic args when possible', function () {
+      var argv = yargs('foo hello world !')
+        .command('foo <foo-bar> [baz-qux..]')
+        .argv
+
+      argv._.should.include('foo')
+      argv['foo-bar'].should.equal('hello')
+      argv.fooBar.should.equal('hello')
+      argv.bazQux.should.deep.equal(['world', '!'])
+      argv['baz-qux'].should.deep.equal(['world', '!'])
+    })
+
     it('populates subcommand\'s inner argv with positional arguments', function () {
       yargs('foo bar hello world')
         .command('foo', 'my awesome command', function (yargs) {

--- a/test/command.js
+++ b/test/command.js
@@ -49,6 +49,18 @@ describe('Command', function () {
       argv.awesome.should.equal('world')
     })
 
+    it('populates argv with camel-case variants of arguments when possible', function () {
+      var argv = yargs('foo hello world')
+        .command('foo <foo-bar> [baz-qux]')
+        .argv
+
+      argv._.should.include('foo')
+      argv['foo-bar'].should.equal('hello')
+      argv.fooBar.should.equal('hello')
+      argv.bazQux.should.equal('world')
+      argv['baz-qux'].should.equal('world')
+    })
+
     it('populates subcommand\'s inner argv with positional arguments', function () {
       yargs('foo bar hello world')
         .command('foo', 'my awesome command', function (yargs) {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1435,6 +1435,34 @@ describe('yargs dsl tests', function () {
       dates[1].toString().should.equal(new Date('2016-07-18').toString())
     })
 
+    it('returns camelcase args for a command', function () {
+      var age1
+      var age2
+      var dates
+      yargs('add 30days 2016-06-13 2016-07-18')
+        .command('add <age-in-days> [dates..]', 'Testing', function (yargs) {
+          return yargs
+            .coerce('age-in-days', function (arg) {
+              return parseInt(arg, 10) * 86400000
+            })
+            .coerce('dates', function (arg) {
+              return arg.map(function (str) {
+                return new Date(str)
+              })
+            })
+        }, function (argv) {
+          age1 = argv.ageInDays
+          age2 = argv['age-in-days']
+          dates = argv.dates
+        })
+        .argv
+      expect(age1).to.equal(2592000000)
+      expect(age2).to.equal(2592000000)
+      expect(dates).to.have.lengthOf(2)
+      dates[0].toString().should.equal(new Date('2016-06-13').toString())
+      dates[1].toString().should.equal(new Date('2016-07-18').toString())
+    })
+
     it('allows an error from positional arg to be handled by fail() handler', function () {
       var msg
       var err


### PR DESCRIPTION
Populate argv object with camelcase variants of hyphenated arguments.

Fixes #653 