### PR TITLE
Fix the Hindi locale file

### DIFF
--- a/locales/hi.json
+++ b/locales/hi.json
@@ -14,9 +14,18 @@
   "generated-value": "उत्पन्न-मूल्य",
   "Not enough non-option arguments: got %s, need at least %s": "पर्याप्त गैर-विकल्प तर्क प्राप्त नहीं: %s प्राप्त, कम से कम %s की आवश्यकता है",
   "Too many non-option arguments: got %s, maximum of %s": "बहुत सारे गैर-विकल्प तर्क: %s प्राप्त, अधिकतम %s मान्य",
-  "Missing argument value: %s": "कुछ तर्को के मूल्य गुम हैं: %s",
-  "Missing required argument: %s": "आवश्यक तर्क गुम हैं: %s",
-  "Unknown argument: %s": "अज्ञात तर्क प्राप्त: %s",
+  "Missing argument value: %s": {
+    "one": "कुछ तर्को के मूल्य गुम हैं: %s",
+    "other": "कुछ तर्को के मूल्य गुम हैं: %s"
+  },
+  "Missing required argument: %s": {
+    "one": "आवश्यक तर्क गुम हैं: %s",
+    "other": "आवश्यक तर्क गुम हैं: %s"
+  },
+  "Unknown argument: %s": {
+    "one": "अज्ञात तर्क प्राप्त: %s",
+    "other": "अज्ञात तर्क प्राप्त: %s"
+  },
   "Invalid values:": "अमान्य मूल्य:",
   "Argument: %s, Given: %s, Choices: %s": "तर्क: %s, प्राप्त: %s, विकल्प: %s",
   "Argument check failed: %s": "तर्क जांच विफल: %s",

--- a/locales/id.json
+++ b/locales/id.json
@@ -35,6 +35,6 @@
   "Invalid JSON config file: %s": "Berkas konfigurasi JSON tidak valid: %s",
   "Path to JSON config file": "Alamat berkas konfigurasi JSON",
   "Show help": "Lihat bantuan",
-  "Did you mean %s?": "Maksud Anda: %s?",
-  "Show version number": "Lihat nomor versi"
+  "Show version number": "Lihat nomor versi",
+  "Did you mean %s?": "Maksud Anda: %s?"
 }


### PR DESCRIPTION
Otherwise y18n will blow up when attempting to lookup the singular/plural version of the localized string:

```js
require('yargs')
  .option('f', {
    alias: 'foo',
    desc: 'foo for thought',
    requiresArg: true
  })
  .option('b', {
    alias: 'bar',
    desc: 'a dog and a cat walk into a bar...',
    requiresArg: true
  })
  .argv
```

Before this fix:

```console
$ LANG=hi_IN.UTF-8 node locales.js -f -b
विकल्प:
  -f, --foo  foo for thought
  -b, --bar  a dog and a cat walk into a bar...

Cannot read property 'indexOf' of undefined
```

After this fix:

```console
$ LANG=hi_IN.UTF-8 node locales.js -f -b
विकल्प:
  -f, --foo  foo for thought
  -b, --bar  a dog and a cat walk into a bar...

कुछ तर्को के मूल्य गुम हैं: f, b
```

Also took the opportunity to make the id locale consistent with others in terms of where each localized string is defined in the json file.