### PR TITLE
Suggestions to improve headless yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ Give some example invocations of your program. Inside `cmd`, the string
 present script similar to how `$0` works in bash or perl.
 Examples will be printed out as part of the help message.
 
-.exitProcess(enable)
+<a name="exitProcess"></a>.exitProcess(enable)
 ----------------------------------
 
 By default, yargs exits the process when the user passes a help flag, uses the
@@ -1516,6 +1516,8 @@ parser.parse(bot.userText, function (err, argv, output) {
   if (output) bot.respond(output)
 })
 ```
+
+***Note:*** Providing a callback disables the [`exitProcess` setting](#exitProcess) until after the callback is invoked.
 
 .pkgConf(key, [cwd])
 ------------

--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ Give some example invocations of your program. Inside `cmd`, the string
 present script similar to how `$0` works in bash or perl.
 Examples will be printed out as part of the help message.
 
-<a name="exitProcess"></a>.exitProcess(enable)
+<a name="exitprocess"></a>.exitProcess(enable)
 ----------------------------------
 
 By default, yargs exits the process when the user passes a help flag, uses the
@@ -1517,7 +1517,7 @@ parser.parse(bot.userText, function (err, argv, output) {
 })
 ```
 
-***Note:*** Providing a callback to `parse()` disables the [`exitProcess` setting](#exitProcess) until after the callback is invoked.
+***Note:*** Providing a callback to `parse()` disables the [`exitProcess` setting](#exitprocess) until after the callback is invoked.
 
 .pkgConf(key, [cwd])
 ------------

--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ parser.parse(bot.userText, function (err, argv, output) {
 })
 ```
 
-***Note:*** Providing a callback disables the [`exitProcess` setting](#exitProcess) until after the callback is invoked.
+***Note:*** Providing a callback to `parse()` disables the [`exitProcess` setting](#exitProcess) until after the callback is invoked.
 
 .pkgConf(key, [cwd])
 ------------

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -802,6 +802,48 @@ describe('yargs dsl tests', function () {
       output.should.match(/--robin.*\[required\]/)
     })
 
+    it('reinstates original exitProcess setting after invocation', function () {
+      var callbackCalled = false
+      var r = checkOutput(function () {
+        yargs
+          .exitProcess(true)
+          .help()
+          .parse('--help', function () {
+            callbackCalled = true
+            yargs.getExitProcess().should.be.false
+          })
+      })
+      r.logs.length.should.equal(0)
+      r.errors.length.should.equal(0)
+      r.exit.should.be.false
+      callbackCalled.should.be.true
+      yargs.getExitProcess().should.be.true
+    })
+
+    it('does not call callback if subsequently called without callback', function () {
+      var callbackCalled = 0
+      var callback = function () {
+        callbackCalled++
+      }
+      var r1 = checkOutput(function () {
+        yargs
+          .help()
+          .parse('--help', callback)
+      })
+      var r2 = checkOutput(function () {
+        yargs
+          .help()
+          .parse('--help')
+      })
+      callbackCalled.should.equal(1)
+      r1.logs.length.should.equal(0)
+      r1.errors.length.should.equal(0)
+      r1.exit.should.be.false
+      r2.exit.should.be.true
+      r2.errors.length.should.equal(0)
+      r2.logs[0].should.match(/--help.*Show help.*\[boolean\]/)
+    })
+
     describe('commands', function () {
       it('does not invoke command handler if output is populated', function () {
         var err = null

--- a/yargs.js
+++ b/yargs.js
@@ -395,10 +395,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     // by providing a function as a second argument to
     // parse you can capture output that would otherwise
     // default to printing to stdout/stderr.
+    var exitProcessBeforeParse
     if (typeof shortCircuit === 'function') {
       parseFn = shortCircuit
       shortCircuit = null
-      self.exitProcess(false)
+      exitProcessBeforeParse = exitProcess
+      exitProcess = false
     }
     // completion short-circuits the parsing process,
     // skipping validation, etc.
@@ -410,6 +412,8 @@ function Yargs (processArgs, cwd, parentRequire) {
       parseFn(exitError, parsed, output)
       command.unfreeze()
       resetForNextParse()
+      parseFn = null
+      exitProcess = exitProcessBeforeParse
     }
 
     return parsed


### PR DESCRIPTION
This adds 3 things to the existing `headless-yargs` branch:

1. Changes `.parse(msg, cb)` so that the original `exitProcess` setting is reinstated after callback invocation
2. Resets the `parseFn` after each call such that you can mix and match `.parse(msg, cb)` calls (where `cb` is invoked) and `.parse(msg)` calls (where no callback is invoked)
3. Adds a note to `parse()` docs about implicitly (and temporarily) disabling the `exitProcess` setting when providing a callback

Includes tests to verify the functionality of 1 and 2.

reviewer: @bcoe 