### PR TITLE
fix: preserve top-level, reset-able state for execution of parse callback

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -220,15 +220,16 @@ module.exports = function (yargs, usage, validation) {
   // the state of commands such that
   // we can apply .parse() multiple times
   // with the same yargs instance.
-  var fHandlers = {}
-  var fAliasMap = {}
+  var frozen
   self.freeze = function () {
-    fHandlers = handlers
-    fAliasMap = aliasMap
+    frozen = {}
+    frozen.handlers = handlers
+    frozen.aliasMap = aliasMap
   }
   self.unfreeze = function () {
-    handlers = fHandlers
-    aliasMap = fAliasMap
+    handlers = frozen.handlers
+    aliasMap = frozen.aliasMap
+    frozen = undefined
   }
 
   return self

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -282,7 +282,7 @@ module.exports = function (yargs, y18n) {
     var width = 0
 
     // table might be of the form [leftColumn],
-    // or {key: leftColumn}}
+    // or {key: leftColumn}
     if (!Array.isArray(table)) {
       table = Object.keys(table).map(function (key) {
         return [table[key]]
@@ -426,6 +426,28 @@ module.exports = function (yargs, y18n) {
       return globalLookup[k]
     })
     return self
+  }
+
+  var frozen
+  self.freeze = function () {
+    frozen = {}
+    frozen.failMessage = failMessage
+    frozen.failureOutput = failureOutput
+    frozen.usage = usage
+    frozen.epilog = epilog
+    frozen.examples = examples
+    frozen.commands = commands
+    frozen.descriptions = descriptions
+  }
+  self.unfreeze = function () {
+    failMessage = frozen.failMessage
+    failureOutput = frozen.failureOutput
+    usage = frozen.usage
+    epilog = frozen.epilog
+    examples = frozen.examples
+    commands = frozen.commands
+    descriptions = frozen.descriptions
+    frozen = undefined
   }
 
   return self

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -302,5 +302,17 @@ module.exports = function (yargs, usage, y18n) {
     return self
   }
 
+  var frozen
+  self.freeze = function () {
+    frozen = {}
+    frozen.implied = implied
+    frozen.checks = checks
+  }
+  self.unfreeze = function () {
+    implied = frozen.implied
+    checks = frozen.checks
+    frozen = undefined
+  }
+
   return self
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -825,15 +825,12 @@ describe('yargs dsl tests', function () {
       var callback = function () {
         callbackCalled++
       }
+      yargs.help()
       var r1 = checkOutput(function () {
-        yargs
-          .help()
-          .parse('--help', callback)
+        yargs.parse('--help', callback)
       })
       var r2 = checkOutput(function () {
-        yargs
-          .help()
-          .parse('--help')
+        yargs.parse('--help')
       })
       callbackCalled.should.equal(1)
       r1.logs.length.should.equal(0)
@@ -972,6 +969,34 @@ describe('yargs dsl tests', function () {
           'Options:',
           '  --help  Show help  [boolean]',
           ''
+        ])
+      })
+
+      it('preserves top-level config when parse is called multiple times', function () {
+        var x = 'wrong'
+        var err
+        var output
+        // set some top-level, reset-able config
+        var parser = yargs()
+          .demand(1, 'Must call a command')
+          .strict()
+          .command('one <x>', 'The one and only command')
+        // first call parse with command, which calls reset
+        parser.parse('one two', function (_, argv) {
+          x = argv.x
+        })
+        // then call parse without command, which should enforce top-level config
+        parser.parse('', function (_err, argv, _output) {
+          err = _err || {}
+          output = _output || ''
+        })
+        x.should.equal('two')
+        err.should.have.property('message').and.equal('Must call a command')
+        output.split('\n').should.deep.equal([
+          'Commands:',
+          '  one <x>  The one and only command',
+          '',
+          'Must call a command'
         ])
       })
     })


### PR DESCRIPTION
Otherwise, if you `parse(msg1, cb)` a message that executes a command and then `parse(msg2, cb)` a message that *doesn't* execute a command, the second invocation will have lost all top-level state like `.strict()` and `.demand(1)`.

Added test for this scenario.

I kinda consider this a hack until we can encapsulate all state into a new submodule, but it works. 🎉 

reviewer: @bcoe 