### PR TITLE
fix: context must be reset, or nested sub-commands fail on second invocation

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -134,6 +134,7 @@ module.exports = function (yargs, usage, validation) {
     var commandHandler = handlers[command] || handlers[aliasMap[command]]
     var innerArgv = argv
     var currentContext = yargs.getContext()
+    var numFiles = currentContext.files.length
     var parentCommands = currentContext.commands.slice()
     currentContext.commands.push(command)
     if (typeof commandHandler.builder === 'function') {
@@ -168,6 +169,8 @@ module.exports = function (yargs, usage, validation) {
       commandHandler.handler(innerArgv)
     }
     currentContext.commands.pop()
+    numFiles = currentContext.files.length - numFiles
+    if (numFiles > 0) currentContext.files.splice(numFiles * -1, numFiles)
     return innerArgv
   }
 

--- a/test/fixtures/cmddir/deep/within-a-dream.js
+++ b/test/fixtures/cmddir/deep/within-a-dream.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   handler: function (argv) {
     var factor = 7
+    if (argv.context) argv.context.counter++ // keep track of how many times we've invoked this handler.
     if (argv.extract) {
       if (!argv.withKick) factor -= 2
       if (!chancesLevel2(factor)) throw new Error('Something went wrong at level 2! Check your options for increased chance of success.')

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -954,6 +954,21 @@ describe('yargs dsl tests', function () {
         argv.what.should.equal(true)
       })
 
+      it('allows nested sub-commands to be invoked multiple times', function () {
+        var context = {counter: 0}
+
+        checkOutput(function () {
+          var parser = yargs()
+            .commandDir('fixtures/cmddir')
+
+          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
+          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
+          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
+        })
+
+        context.counter.should.equal(3)
+      })
+
       it('overwrites the prior context object, when parse is called multiple times', function () {
         var argv = null
         var parser = yargs()

--- a/yargs.js
+++ b/yargs.js
@@ -48,14 +48,10 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  var context = null
+  const context = { resets: -1, commands: [], files: [] }
   self.getContext = function () {
     return context
   }
-  function resetContext () {
-    context = { resets: -1, commands: [], files: [] }
-  }
-  resetContext()
 
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
@@ -173,7 +169,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     parseFn = null
     parseContext = null
     frozen = undefined
-    resetContext()
   }
 
   self.boolean = function (bools) {

--- a/yargs.js
+++ b/yargs.js
@@ -48,10 +48,14 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  const context = { resets: -1, commands: [], files: [] }
+  var context = null
   self.getContext = function () {
     return context
   }
+  function resetContext () {
+    context = { resets: -1, commands: [], files: [] }
+  }
+  resetContext()
 
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
@@ -169,6 +173,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     parseFn = null
     parseContext = null
     frozen = undefined
+    resetContext()
   }
 
   self.boolean = function (bools) {


### PR DESCRIPTION
This addresses an issue @ceejbot ran into using headless `.parse()` in conjunction with nested sub-commands.

CC: @nexdrew 