### PR TITLE
fix(command): splice context.files when popping context.commands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -134,6 +134,7 @@ module.exports = function (yargs, usage, validation) {
     var commandHandler = handlers[command] || handlers[aliasMap[command]]
     var innerArgv = argv
     var currentContext = yargs.getContext()
+    var numFiles = currentContext.files.length
     var parentCommands = currentContext.commands.slice()
     currentContext.commands.push(command)
     if (typeof commandHandler.builder === 'function') {
@@ -168,6 +169,8 @@ module.exports = function (yargs, usage, validation) {
       commandHandler.handler(innerArgv)
     }
     currentContext.commands.pop()
+    numFiles = currentContext.files.length - numFiles
+    if (numFiles > 0) currentContext.files.splice(numFiles * -1, numFiles)
     return innerArgv
   }
 

--- a/yargs.js
+++ b/yargs.js
@@ -48,14 +48,10 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   // use context object to keep track of resets, subcommand execution, etc
   // submodules should modify and check the state of context as necessary
-  var context = null
+  const context = { resets: -1, commands: [], files: [] }
   self.getContext = function () {
     return context
   }
-  function resetContext () {
-    context = { resets: -1, commands: [], files: [] }
-  }
-  resetContext()
 
   // puts yargs back into an initial state. any keys
   // that have been set to "global" will not be reset
@@ -173,7 +169,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     parseFn = null
     parseContext = null
     frozen = undefined
-    resetContext()
   }
 
   self.boolean = function (bools) {


### PR DESCRIPTION
This is my preferred alternative to resetting the `context`.

It works by removing any `files` that were added during the execution of a command - e.g. if a command `builder` function calls `.commandDir()` itself - putting the `context` back into the state it was in before running the command builder and handler (with the exception of the `resets` count, which is desired).

This is consistent with the treatment of `context.commands` and with expectations of maintaining command execution scope. In other words, I should have done this from the beginning.

reviewer: @bcoe 