### PR TITLE
separate demand API into demandOption and demandCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,13 +1028,24 @@ require('yargs')
     alias: 'p', 
     describe: 'provide a path to file'
   })
-  .option('spec, {
+  .option('spec', {
     alias: 's', 
     describe: 'program specifications'
   })
   .demand(['run', 'path'], 'Please provide both run and path arguments to work with this tool')
   .help()
   .argv
+```
+which will provide the following output:
+```bash
+Options:
+  --run, -r   run your program                [required]
+  --path, -p  provide a path to file          [required]
+  --spec, -s  program specifications
+  --help      Show help                        [boolean]
+        
+  Missing required arguments: run, path
+  Please provide both run and path arguments to work with this tool
 ```
 
 If a `boolean` value is given, it controls whether the option is demanded;
@@ -1043,22 +1054,34 @@ this is useful when using `.options()` to specify command line parameters.
 ```javascript
 // demand individual options within the option constructor
 require('yargs')
-  .option('run', {
-    alias: 'r', 
-    describe: 'run your program',
-    demand: true
-  })
-  .option('path', {
-    alias: 'p', 
-    describe: 'provide a path to file', 
-    demand: true
-  })
-  .option('spec, {
-    alias: 's', 
-    describe: 'program specifications'
+  .options({
+    'run': {
+      alias: 'r', 
+      describe: 'run your program',
+      demand: true
+    },
+    path': {
+      alias: 'p', 
+      describe: 'provide a path to file', 
+      demand: true
+    },
+    'spec': {
+      alias: 's', 
+      describe: 'program specifications'
+    }
   })
   .help()
   .argv
+```
+which will provide the following output:
+```bash
+Options:
+  --run, -r   run your program                                       [required]
+  --path, -p  provide a path to file                                 [required]
+  --spec, -s  program specifications
+  --help      Show help                                               [boolean]
+        
+Missing required arguments: run, path
 ```
 
 <a name="demandCommand"></a>.demandCommand(min, [minMsg])
@@ -1078,9 +1101,20 @@ require('yargs')
       console.log(`setting ${argv.key} to ${argv.value}`)
     }
   })
-  .demandCommand(1)
+  // provide a minimum demand and a minimum demand message
+  .demandCommand(1, 'You need at least one command before moving on')
   .help()
   .argv
+```
+which will provide the following output:
+```bash
+Commands:
+  configure <key> [value]  Set a config variable         [aliases: config, cfg]
+  
+Options:
+  --help  Show help                                                   [boolean]
+    
+You need at least one command before moving on
 ```
 
 <a name="describe"></a>.describe(key, desc)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ area.js:
 #!/usr/bin/env node
 var argv = require('yargs')
     .usage('Usage: $0 -w [num] -h [num]')
-    .demand(['w','h'])
+    .demandOption(['w','h'])
     .argv;
 
 console.log("The area is:", argv.w * argv.h);
@@ -188,7 +188,7 @@ demand_count.js:
 ````javascript
 #!/usr/bin/env node
 var argv = require('yargs')
-    .demand(2)
+    .demandCommand(2)
     .argv;
 console.dir(argv);
 ````
@@ -298,7 +298,7 @@ var argv = require('yargs')
     .alias('f', 'file')
     .nargs('f', 1)
     .describe('f', 'Load a file')
-    .demand(1, ['f'])
+    .demandOption(['f'])
     .help('h')
     .alias('h', 'help')
     .epilog('copyright 2015')
@@ -663,7 +663,7 @@ require('yargs')
       console.log(`setting ${argv.key} to ${argv.value}`)
     }
   })
-  .demand(1)
+  .demandCommand(1)
   .help()
   .wrap(72)
   .argv
@@ -809,7 +809,7 @@ cli.js:
 #!/usr/bin/env node
 require('yargs')
   .commandDir('cmds')
-  .demand(1)
+  .demandCommand(1)
   .help()
   .argv
 ```
@@ -1005,43 +1005,81 @@ displaying the value in the usage instructions:
 .default('timeout', 60000, '(one-minute)')
 ```
 
-<a name="demand"></a>.demand(key, [msg | boolean])
+<a name="demandOption"></a>.demandOption(key, [msg | boolean])
 ------------------------------
-.demand(count, [max], [msg])
+.demandOption(count, [max], [msg])
 ------------------------------
 
 If `key` is a string, show the usage information and exit if `key` wasn't
 specified in `process.argv`.
 
-If `key` is a number, demand at least as many non-option arguments, which show
-up in `argv._`. A second number can also optionally be provided, which indicates
-the maximum number of non-option arguments.
-
 If `key` is an array, demand each element.
 
-If a `msg` string is given, it will be printed when the argument is missing,
-instead of the standard error message. This is especially helpful for the non-option arguments in `argv._`.
+If a `msg` string is given, it will be printed when the argument is missing, instead of the standard error message.
+
+```javascript
+// demand an array of keys to be provided
+require('yargs')
+  .option('run', {
+    alias: 'r', 
+    describe: 'run your program'
+  })
+  .option('path', {
+    alias: 'p', 
+    describe: 'provide a path to file'
+  })
+  .option('spec, {
+    alias: 's', 
+    describe: 'program specifications'
+  })
+  .demand(['run', 'path'], 'Please provide both run and path arguments to work with this tool')
+  .help()
+  .argv
+```
 
 If a `boolean` value is given, it controls whether the option is demanded;
 this is useful when using `.options()` to specify command line parameters.
 
-A combination of `.demand(1)` and `.strict()` will allow you to require a user to pass at least one command:
-
-```js
-var argv = require('yargs')
-  .command('install', 'tis a mighty fine package to install')
-  .demand(1)
-  .strict()
+```javascript
+// demand individual options within the option constructor
+require('yargs')
+  .option('run', {
+    alias: 'r', 
+    describe: 'run your program',
+    demand: true
+  })
+  .option('path', {
+    alias: 'p', 
+    describe: 'provide a path to file', 
+    demand: true
+  })
+  .option('spec, {
+    alias: 's', 
+    describe: 'program specifications'
+  })
+  .help()
   .argv
 ```
 
-Similarly, you can require a command and arguments at the same time:
+<a name="demandCommand"></a>.demandCommand(min, [minMsg])
+------------------------------
+.demandCommand(min, [max], [minMsg], [maxMsg])
+------------------------------
 
-```js
-var argv = require('yargs')
-  .command('install', 'tis a mighty fine package to install')
-  .demand(1, ['w', 'm'])
-  .strict()
+Demand in context of commands. You can demand a minimum and a maximum number a user can have within your program, as well as provide corresponding error messages if either of the demands is not met. 
+```javascript
+require('yargs')
+  .command({
+    command: 'configure <key> [value]',
+    aliases: ['config', 'cfg'],
+    desc: 'Set a config variable',
+    builder: (yargs) => yargs.default('value', 'true'),
+    handler: (argv) => {
+      console.log(`setting ${argv.key} to ${argv.value}`)
+    }
+  })
+  .demandCommand(1)
+  .help()
   .argv
 ```
 
@@ -1475,7 +1513,7 @@ Valid `opt` keys include:
 - `count`: boolean, interpret option as a count of boolean flags, see [`count()`](#count)
 - `default`: value, set a default value for the option, see [`default()`](#default)
 - `defaultDescription`: string, use this description for the default value in help content, see [`default()`](#default)
-- `demand`/`require`/`required`: boolean or string, demand the option be given, with optional error message, see [`demand()`](#demand)
+- `demandOption`/`demand`/`require`/`required`: boolean or string, demand the option be given, with optional error message, see [`demand()`](#demand)
 - `desc`/`describe`/`description`: string, the option description for help content, see [`describe()`](#describe)
 - `global`: boolean, indicate that this key should not be [reset](#reset) when a command is invoked, see [`global()`](#global)
 - `group`: string, when displaying usage instructions place the option under an alternative group heading, see [`group()`](#group)

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,7 @@ require('yargs')
       describe: 'run your program',
       demand: true
     },
-    path': {
+    'path': {
       alias: 'p', 
       describe: 'provide a path to file', 
       demand: true

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -128,6 +128,7 @@ module.exports = function (yargs, y18n) {
   self.help = function () {
     normalizeAliases()
 
+    // handle old demanded API
     var demandedOptions = yargs.getDemandedOptions()
     var demandedCommands = yargs.getDemandedCommands()
     var groups = yargs.getGroups()
@@ -305,6 +306,7 @@ module.exports = function (yargs, y18n) {
   // make sure any options set for aliases,
   // are copied to the keys being aliased.
   function normalizeAliases () {
+    // handle old demanded API
     var demandedOptions = yargs.getDemandedOptions()
     var options = yargs.getOptions()
 
@@ -313,7 +315,7 @@ module.exports = function (yargs, y18n) {
         // copy descriptions.
         if (descriptions[alias]) self.describe(key, descriptions[alias])
         // copy demanded.
-        if (demandedOptions[alias]) yargs.demand(key, demandedOptions[alias].msg)
+        if (demandedOptions[alias]) yargs.demandOption(key, demandedOptions[alias].msg)
         // type messages.
         if (~options.boolean.indexOf(alias)) yargs.boolean(key)
         if (~options.count.indexOf(alias)) yargs.count(key)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -128,14 +128,14 @@ module.exports = function (yargs, y18n) {
   self.help = function () {
     normalizeAliases()
 
-    var demandedOption = yargs.getDemandedOption()
-    var demandedCommand = yargs.getDemandedCommand()
+    var demandedOptions = yargs.getDemandedOptions()
+    var demandedCommands = yargs.getDemandedCommands()
     var groups = yargs.getGroups()
     var options = yargs.getOptions()
     var keys = Object.keys(
       Object.keys(descriptions)
-      .concat(Object.keys(demandedOption))
-      .concat(Object.keys(demandedCommand))
+      .concat(Object.keys(demandedOptions))
+      .concat(Object.keys(demandedCommands))
       .concat(Object.keys(options.default))
       .reduce(function (acc, key) {
         if (key !== '_') acc[key] = true
@@ -233,7 +233,7 @@ module.exports = function (yargs, y18n) {
 
         var extra = [
           type,
-          demandedOption[key] ? '[' + __('required') + ']' : null,
+          demandedOptions[key] ? '[' + __('required') + ']' : null,
           options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
             self.stringifiedValues(options.choices[key]) + ']' : null,
           defaultString(options.default[key], options.defaultDescription[key])
@@ -305,7 +305,7 @@ module.exports = function (yargs, y18n) {
   // make sure any options set for aliases,
   // are copied to the keys being aliased.
   function normalizeAliases () {
-    var demandedOption = yargs.getDemandedOption()
+    var demandedOptions = yargs.getDemandedOptions()
     var options = yargs.getOptions()
 
     ;(Object.keys(options.alias) || []).forEach(function (key) {
@@ -313,7 +313,7 @@ module.exports = function (yargs, y18n) {
         // copy descriptions.
         if (descriptions[alias]) self.describe(key, descriptions[alias])
         // copy demanded.
-        if (demandedOption[alias]) yargs.demand(key, demandedOption[alias].msg)
+        if (demandedOptions[alias]) yargs.demand(key, demandedOptions[alias].msg)
         // type messages.
         if (~options.boolean.indexOf(alias)) yargs.boolean(key)
         if (~options.count.indexOf(alias)) yargs.count(key)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -128,12 +128,14 @@ module.exports = function (yargs, y18n) {
   self.help = function () {
     normalizeAliases()
 
-    var demanded = yargs.getDemanded()
+    var demandedOption = yargs.getDemandedOption()
+    var demandedCommand = yargs.getDemandedCommand()
     var groups = yargs.getGroups()
     var options = yargs.getOptions()
     var keys = Object.keys(
       Object.keys(descriptions)
-      .concat(Object.keys(demanded))
+      .concat(Object.keys(demandedOption))
+      .concat(Object.keys(demandedCommand))
       .concat(Object.keys(options.default))
       .reduce(function (acc, key) {
         if (key !== '_') acc[key] = true
@@ -231,7 +233,7 @@ module.exports = function (yargs, y18n) {
 
         var extra = [
           type,
-          demanded[key] ? '[' + __('required') + ']' : null,
+          demandedOption[key] ? '[' + __('required') + ']' : null,
           options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
             self.stringifiedValues(options.choices[key]) + ']' : null,
           defaultString(options.default[key], options.defaultDescription[key])
@@ -303,7 +305,7 @@ module.exports = function (yargs, y18n) {
   // make sure any options set for aliases,
   // are copied to the keys being aliased.
   function normalizeAliases () {
-    var demanded = yargs.getDemanded()
+    var demandedOption = yargs.getDemandedOption()
     var options = yargs.getOptions()
 
     ;(Object.keys(options.alias) || []).forEach(function (key) {
@@ -311,7 +313,7 @@ module.exports = function (yargs, y18n) {
         // copy descriptions.
         if (descriptions[alias]) self.describe(key, descriptions[alias])
         // copy demanded.
-        if (demanded[alias]) yargs.demand(key, demanded[alias].msg)
+        if (demandedOption[alias]) yargs.demand(key, demandedOption[alias].msg)
         // type messages.
         if (~options.boolean.indexOf(alias)) yargs.boolean(key)
         if (~options.count.indexOf(alias)) yargs.count(key)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -10,21 +10,27 @@ module.exports = function (yargs, usage, y18n) {
   // validate appropriate # of non-option
   // arguments were provided, i.e., '_'.
   self.nonOptionCount = function (argv) {
-    const demanded = yargs.getDemanded()
+    const demandedCommand = yargs.getDemandedCommand()
     // don't count currently executing commands
     const _s = argv._.length - yargs.getContext().commands.length
 
-    if (demanded._ && (_s < demanded._.count || _s > demanded._.max)) {
-      if (demanded._.msg !== undefined) {
-        usage.fail(demanded._.msg)
-      } else if (_s < demanded._.count) {
-        usage.fail(
-          __('Not enough non-option arguments: got %s, need at least %s', _s, demanded._.count)
-        )
+    if (demandedCommand._ && (_s < demandedCommand._.min || _s > demandedCommand._.max)) {
+      if (_s < demandedCommand._.min) {
+        if (demandedCommand._.minMsg !== undefined) {
+          usage.fail(demandedCommand._.minMsg)
+        } else {
+          usage.fail(
+            __('Not enough non-option arguments: got %s, need at least %s', _s, demandedCommand._.min)
+          )
+        }
       } else {
-        usage.fail(
-          __('Too many non-option arguments: got %s, maximum of %s', _s, demanded._.max)
-        )
+        if (demandedCommand._.maxMsg !== undefined) {
+          usage.fail(demandedCommand._.maxMsg)
+        } else {
+          usage.fail(
+          __('Too many non-option arguments: got %s, maximum of %s', _s, demandedCommand._.max)
+          )
+        }
       }
     }
   }
@@ -73,13 +79,13 @@ module.exports = function (yargs, usage, y18n) {
 
   // make sure all the required arguments are present.
   self.requiredArguments = function (argv) {
-    const demanded = yargs.getDemanded()
+    const demandedOption = yargs.getDemandedOption()
     var missing = null
 
-    Object.keys(demanded).forEach(function (key) {
+    Object.keys(demandedOption).forEach(function (key) {
       if (!argv.hasOwnProperty(key)) {
         missing = missing || {}
-        missing[key] = demanded[key]
+        missing[key] = demandedOption[key]
       }
     })
 
@@ -107,7 +113,7 @@ module.exports = function (yargs, usage, y18n) {
   self.unknownArguments = function (argv, aliases) {
     const aliasLookup = {}
     const descriptions = usage.getDescriptions()
-    const demanded = yargs.getDemanded()
+    const demandedOption = yargs.getDemandedOption()
     const commandKeys = yargs.getCommandInstance().getCommands()
     const unknown = []
     const currentContext = yargs.getContext()
@@ -121,7 +127,7 @@ module.exports = function (yargs, usage, y18n) {
     Object.keys(argv).forEach(function (key) {
       if (key !== '$0' && key !== '_' &&
         !descriptions.hasOwnProperty(key) &&
-        !demanded.hasOwnProperty(key) &&
+        !demandedOption.hasOwnProperty(key) &&
         !aliasLookup.hasOwnProperty(key)) {
         unknown.push(key)
       }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -23,7 +23,7 @@ module.exports = function (yargs, usage, y18n) {
             __('Not enough non-option arguments: got %s, need at least %s', _s, demandedCommand._.min)
           )
         }
-      } else {
+      } else if (_s > demandedCommand._.max) {
         if (demandedCommand._.maxMsg !== undefined) {
           usage.fail(demandedCommand._.maxMsg)
         } else {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -10,25 +10,25 @@ module.exports = function (yargs, usage, y18n) {
   // validate appropriate # of non-option
   // arguments were provided, i.e., '_'.
   self.nonOptionCount = function (argv) {
-    const demandedCommand = yargs.getDemandedCommand()
+    const demandedCommands = yargs.getDemandedCommands()
     // don't count currently executing commands
     const _s = argv._.length - yargs.getContext().commands.length
 
-    if (demandedCommand._ && (_s < demandedCommand._.min || _s > demandedCommand._.max)) {
-      if (_s < demandedCommand._.min) {
-        if (demandedCommand._.minMsg !== undefined) {
-          usage.fail(demandedCommand._.minMsg)
+    if (demandedCommands._ && (_s < demandedCommands._.min || _s > demandedCommands._.max)) {
+      if (_s < demandedCommands._.min) {
+        if (demandedCommands._.minMsg !== undefined) {
+          usage.fail(demandedCommands._.minMsg)
         } else {
           usage.fail(
-            __('Not enough non-option arguments: got %s, need at least %s', _s, demandedCommand._.min)
+            __('Not enough non-option arguments: got %s, need at least %s', _s, demandedCommands._.min)
           )
         }
-      } else if (_s > demandedCommand._.max) {
-        if (demandedCommand._.maxMsg !== undefined) {
-          usage.fail(demandedCommand._.maxMsg)
+      } else if (_s > demandedCommands._.max) {
+        if (demandedCommands._.maxMsg !== undefined) {
+          usage.fail(demandedCommands._.maxMsg)
         } else {
           usage.fail(
-          __('Too many non-option arguments: got %s, maximum of %s', _s, demandedCommand._.max)
+          __('Too many non-option arguments: got %s, maximum of %s', _s, demandedCommands._.max)
           )
         }
       }
@@ -79,13 +79,13 @@ module.exports = function (yargs, usage, y18n) {
 
   // make sure all the required arguments are present.
   self.requiredArguments = function (argv) {
-    const demandedOption = yargs.getDemandedOption()
+    const demandedOptions = yargs.getDemandedOptions()
     var missing = null
 
-    Object.keys(demandedOption).forEach(function (key) {
+    Object.keys(demandedOptions).forEach(function (key) {
       if (!argv.hasOwnProperty(key)) {
         missing = missing || {}
-        missing[key] = demandedOption[key]
+        missing[key] = demandedOptions[key]
       }
     })
 
@@ -113,7 +113,7 @@ module.exports = function (yargs, usage, y18n) {
   self.unknownArguments = function (argv, aliases) {
     const aliasLookup = {}
     const descriptions = usage.getDescriptions()
-    const demandedOption = yargs.getDemandedOption()
+    const demandedOptions = yargs.getDemandedOptions()
     const commandKeys = yargs.getCommandInstance().getCommands()
     const unknown = []
     const currentContext = yargs.getContext()
@@ -127,7 +127,7 @@ module.exports = function (yargs, usage, y18n) {
     Object.keys(argv).forEach(function (key) {
       if (key !== '$0' && key !== '_' &&
         !descriptions.hasOwnProperty(key) &&
-        !demandedOption.hasOwnProperty(key) &&
+        !demandedOptions.hasOwnProperty(key) &&
         !aliasLookup.hasOwnProperty(key)) {
         unknown.push(key)
       }

--- a/test/usage.js
+++ b/test/usage.js
@@ -60,6 +60,7 @@ describe('usage tests', function () {
           r.exit.should.be.ok
         })
       })
+    })
 
     it('should show an error along with a custom message on demand fail', function () {
       var r = checkUsage(function () {
@@ -462,7 +463,7 @@ describe('usage tests', function () {
         .argv
     })
     r.should.have.property('result')
-    r.should.have.property('logs').with.length(2)
+    r.should.have.property('logs').with.length(0)
     r.should.have.property('exit').and.be.ok
     r.result.should.have.property('_').and.deep.equal(['src', 'dest'])
     r.errors.join('\n').split(/\n+/).should.deep.equal([

--- a/test/usage.js
+++ b/test/usage.js
@@ -61,25 +61,6 @@ describe('usage tests', function () {
         })
       })
 
-      it('no failure occurs if the required arguments and the required number of commands are provided.', function () {
-        var r = checkUsage(function () {
-          return yargs('wombat -w 10 -m 10')
-            .usage('Usage: $0 -w NUM -m NUM')
-            .command('wombat', 'wombat handlers')
-            .require(1, ['w', 'm'])
-            .strict()
-            .wrap(null)
-            .argv
-        })
-        r.result.should.have.property('w', 10)
-        r.result.should.have.property('m', 10)
-        r.result.should.have.property('_').with.length(1)
-        r.should.have.property('errors').with.length(0)
-        r.should.have.property('logs').with.length(0)
-        r.should.have.property('exit', false)
-      })
-    })
-
     it('should show an error along with a custom message on demand fail', function () {
       var r = checkUsage(function () {
         return yargs('-z 20')
@@ -469,6 +450,24 @@ describe('usage tests', function () {
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Usage: ./usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
       'src and dest files are both required'
+    ])
+  })
+
+  it('should return a custom failure message when too many non-hyphenated arguments are found after a demand count', function () {
+    var r = checkUsage(function () {
+      return yargs(['src', 'dest'])
+        .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
+        .demandCommand(0, 1, 'src and dest files are both required', 'too many arguments are provided')
+        .wrap(null)
+        .argv
+    })
+    r.should.have.property('result')
+    r.should.have.property('logs').with.length(2)
+    r.should.have.property('exit').and.be.ok
+    r.result.should.have.property('_').and.deep.equal(['src', 'dest'])
+    r.errors.join('\n').split(/\n+/).should.deep.equal([
+      'Usage: ./usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
+      'too many arguments are provided'
     ])
   })
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -37,70 +37,6 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
-      it('missing argument message given if one command, but an argument not on the list is provided', function () {
-        var r = checkUsage(function () {
-          return yargs('wombat -w 10 -y 10')
-            .usage('Usage: $0 -w NUM -m NUM')
-            .demand(1, ['w', 'm'])
-            .strict()
-            .wrap(null)
-            .argv
-        })
-        r.result.should.have.property('w', 10)
-        r.result.should.have.property('y', 10)
-        r.result.should.have.property('_').with.length(1)
-        r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
-          'Options:',
-          '  -w  [required]',
-          '  -m  [required]',
-          'Missing required argument: m'
-        ])
-        r.logs.should.have.length(0)
-        r.exit.should.be.ok
-      })
-
-      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
-        var r = checkUsage(function () {
-          return yargs('-w 10 -y 10')
-            .usage('Usage: $0 -w NUM -m NUM')
-            .demand(1, ['w', 'm'])
-            .strict()
-            .wrap(null)
-            .argv
-        })
-        r.result.should.have.property('w', 10)
-        r.result.should.have.property('y', 10)
-        r.result.should.have.property('_').with.length(0)
-        r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
-          'Options:',
-          '  -w  [required]',
-          '  -m  [required]',
-          'Not enough non-option arguments: got 0, need at least 1'
-        ])
-        r.logs.should.have.length(0)
-        r.exit.should.be.ok
-      })
-
-      it('no failure occurs if the required arguments and the required number of commands are provided.', function () {
-        var r = checkUsage(function () {
-          return yargs('wombat -w 10 -m 10')
-            .usage('Usage: $0 -w NUM -m NUM')
-            .command('wombat', 'wombat handlers')
-            .demand(1, ['w', 'm'])
-            .strict()
-            .wrap(null)
-            .argv
-        })
-        r.result.should.have.property('w', 10)
-        r.result.should.have.property('m', 10)
-        r.result.should.have.property('_').with.length(1)
-        r.should.have.property('errors').with.length(0)
-        r.should.have.property('logs').with.length(0)
-        r.should.have.property('exit', false)
-      })
-
       describe('using .require()', function () {
         it('should show an error along with the missing arguments on demand fail', function () {
           var r = checkUsage(function () {
@@ -123,51 +59,6 @@ describe('usage tests', function () {
           r.logs.should.have.length(0)
           r.exit.should.be.ok
         })
-        it('missing argument message given if one command and an argument not on the list are provided', function () {
-          var r = checkUsage(function () {
-            return yargs('wombat -w 10 -y 10')
-              .usage('Usage: $0 -w NUM -m NUM')
-              .required(1, ['w', 'm'])
-              .strict()
-              .wrap(null)
-              .argv
-          })
-          r.result.should.have.property('w', 10)
-          r.result.should.have.property('y', 10)
-          r.result.should.have.property('_').with.length(1)
-          r.errors.join('\n').split(/\n+/).should.deep.equal([
-            'Usage: ./usage -w NUM -m NUM',
-            'Options:',
-            '  -w  [required]',
-            '  -m  [required]',
-            'Missing required argument: m'
-          ])
-          r.logs.should.have.length(0)
-          r.exit.should.be.ok
-        })
-      })
-
-      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
-        var r = checkUsage(function () {
-          return yargs('-w 10 -y 10')
-            .usage('Usage: $0 -w NUM -m NUM')
-            .require(1, ['w', 'm'])
-            .strict()
-            .wrap(null)
-            .argv
-        })
-        r.result.should.have.property('w', 10)
-        r.result.should.have.property('y', 10)
-        r.result.should.have.property('_').with.length(0)
-        r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
-          'Options:',
-          '  -w  [required]',
-          '  -m  [required]',
-          'Not enough non-option arguments: got 0, need at least 1'
-        ])
-        r.logs.should.have.length(0)
-        r.exit.should.be.ok
       })
 
       it('no failure occurs if the required arguments and the required number of commands are provided.', function () {
@@ -232,7 +123,7 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs('')
           .usage('Usage: foo')
-          .demand(1, null)
+          .demandCommand(1, null)
           .wrap(null)
           .argv
       })
@@ -249,7 +140,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['foo', 'bar', 'apple'])
             .usage('Usage: foo')
-            .demand(2, 3)
+            .demandCommand(2, 3)
             .wrap(null)
             .argv
         })
@@ -261,7 +152,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['foo', 'bar', 'apple', 'banana'])
             .usage('Usage: foo')
-            .demand(2, 3)
+            .demandCommand(2, 3)
             .wrap(null)
             .argv
         })
@@ -276,7 +167,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['foo'])
             .usage('Usage: foo')
-            .demand(2, 3)
+            .demandCommand(2, 3)
             .wrap(null)
             .argv
         })
@@ -291,7 +182,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['foo'])
             .usage('Usage: foo')
-            .demand(2, 3, 'pork chop sandwiches')
+            .demandCommand(2, 3, 'pork chop sandwiches')
             .wrap(null)
             .argv
         })
@@ -530,7 +421,7 @@ describe('usage tests', function () {
     var r = checkUsage(function () {
       return yargs('1 2 3 --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS}')
-      .demand(3)
+      .demandCommand(3)
       .argv
     })
     r.should.have.property('result')
@@ -545,7 +436,7 @@ describe('usage tests', function () {
     var r = checkUsage(function () {
       return yargs('1 2 --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS}')
-      .demand(3)
+      .demandCommand(3)
       .wrap(null)
       .argv
     })
@@ -565,7 +456,7 @@ describe('usage tests', function () {
     var r = checkUsage(function () {
       return yargs('src --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
-      .demand(2, 'src and dest files are both required')
+      .demandCommand(2, 'src and dest files are both required')
       .wrap(null)
       .argv
     })
@@ -615,7 +506,7 @@ describe('usage tests', function () {
       return yargs('')
         .alias('f', 'foo')
         .default('f', 5)
-        .demand(1)
+        .demandCommand(1)
         .wrap(null)
         .argv
     })
@@ -743,8 +634,8 @@ describe('usage tests', function () {
     it('should fail given an option argument that is not demanded', function () {
       var r = checkUsage(function () {
         var opts = {
-          foo: { demand: 'foo option', alias: 'f' },
-          bar: { demand: 'bar option', alias: 'b' }
+          foo: { demandOption: 'foo option', alias: 'f' },
+          bar: { demandOption: 'bar option', alias: 'b' }
         }
 
         return yargs('-f 10 --bar 20 --baz 30')
@@ -894,8 +785,8 @@ describe('usage tests', function () {
           return yargs('-y 10 -z 20')
             .usage('Usage: $0 -x NUM [-y NUM]')
             .options({
-              'x': { description: 'an option', demand: true },
-              'y': { description: 'another option', demand: false }
+              'x': { description: 'an option', demandOption: true },
+              'y': { description: 'another option', demandOption: false }
             })
             .wrap(null)
             .argv
@@ -1336,7 +1227,7 @@ describe('usage tests', function () {
           .option('f', {
             alias: 'file',
             describe: noColorAddedDescr,
-            demand: true,
+            demandOption: true,
             type: 'string'
           })
           .help('h').alias('h', 'help')
@@ -1360,7 +1251,7 @@ describe('usage tests', function () {
           .option('f', {
             alias: 'file',
             describe: yellowDescription,
-            demand: true,
+            demandOption: true,
             type: 'string'
           })
           .help('h').alias('h', 'help')
@@ -1701,7 +1592,7 @@ describe('usage tests', function () {
         return yargs('upload --help')
           .command('upload', 'upload something', {
             builder: function (yargs) {
-              return yargs.usage('Usage: program upload <something> [opts]').demand(1)
+              return yargs.usage('Usage: program upload <something> [opts]').demandCommand(1)
             },
             handler: function (argv) {}
           })

--- a/test/validation.js
+++ b/test/validation.js
@@ -74,7 +74,7 @@ describe('validation tests', function () {
   describe('demand', function () {
     it('fails with standard error message if msg is not defined', function (done) {
       yargs([])
-        .demand(1)
+        .demandCommand(1)
         .fail(function (msg) {
           msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
           return done()
@@ -86,7 +86,7 @@ describe('validation tests', function () {
       yargs(['koala'])
         .command('wombat', 'wombat burrows')
         .command('kangaroo', 'kangaroo handlers')
-        .demand(1)
+        .demandCommand(1)
         .strict()
         .fail(function (msg) {
           msg.should.equal('Unknown argument: koala')
@@ -97,7 +97,7 @@ describe('validation tests', function () {
 
     it('does not fail in strict mode when no commands configured', function () {
       var argv = yargs('koala')
-        .demand(1)
+        .demandCommand(1)
         .strict()
         .fail(function (msg) {
           expect.fail()
@@ -106,29 +106,9 @@ describe('validation tests', function () {
       argv._[0].should.equal('koala')
     })
 
-    it('fails when a required argument is missing', function (done) {
-      yargs('-w 10 marsupial')
-        .demand(1, ['w', 'b'])
-        .fail(function (msg) {
-          msg.should.equal('Missing required argument: b')
-          return done()
-        })
-        .argv
-    })
-
-    it('fails when required arguments are present, but a command is missing', function (done) {
-      yargs('-w 10 -m wombat')
-        .demand(1, ['w', 'm'])
-        .fail(function (msg) {
-          msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
-          return done()
-        })
-        .argv
-    })
-
     it('fails without a message if msg is null', function (done) {
       yargs([])
-        .demand(1, null)
+        .demandCommand(1, null)
         .fail(function (msg) {
           expect(msg).to.equal(null)
           return done()
@@ -140,7 +120,7 @@ describe('validation tests', function () {
       var failureMsg
       yargs('lint')
         .command('lint', 'Lint a file', function (yargs) {
-          yargs.demand(1).fail(function (msg) {
+          yargs.demandCommand(1).fail(function (msg) {
             failureMsg = msg
           })
         })
@@ -152,7 +132,7 @@ describe('validation tests', function () {
       var failureMsg
       yargs('lint one.js two.js')
         .command('lint', 'Lint a file', function (yargs) {
-          yargs.demand(0, 1).fail(function (msg) {
+          yargs.demandCommand(0, 1).fail(function (msg) {
             failureMsg = msg
           })
         })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -252,7 +252,7 @@ describe('yargs dsl tests', function () {
       expect(y.getExitProcess()).to.equal(false)
       expect(y.getStrict()).to.equal(false)
       expect(y.getDemandedOption()).to.deep.equal({})
-      expect(y.getDemandedommand()).to.deep.equal({})
+      expect(y.getDemandedCommand()).to.deep.equal({})
       expect(y.getGroups()).to.deep.equal({})
     })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -241,8 +241,8 @@ describe('yargs dsl tests', function () {
         configObjects: [],
         envPrefix: 'YARGS', // preserved as global
         global: ['help'],
-        demandedCommand: {},
-        demandedOption: {}
+        demandedCommands: {},
+        demandedOptions: {}
       }
 
       expect(y.getOptions()).to.deep.equal(emptyOptions)
@@ -251,8 +251,8 @@ describe('yargs dsl tests', function () {
       expect(y.getCommandInstance().getCommandHandlers()).to.deep.equal({})
       expect(y.getExitProcess()).to.equal(false)
       expect(y.getStrict()).to.equal(false)
-      expect(y.getDemandedOption()).to.deep.equal({})
-      expect(y.getDemandedCommand()).to.deep.equal({})
+      expect(y.getDemandedOptions()).to.deep.equal({})
+      expect(y.getDemandedCommands()).to.deep.equal({})
       expect(y.getGroups()).to.deep.equal({})
     })
 
@@ -1243,11 +1243,11 @@ describe('yargs dsl tests', function () {
 
       options.key.foo.should.equal(true)
       options.string.should.include('awesome-sauce')
-      Object.keys(options.demandedOption).should.include('awesomeSauce')
+      Object.keys(options.demandedOptions).should.include('awesomeSauce')
 
       expect(options.key.bar).to.equal(undefined)
       options.string.should.not.include('bar')
-      Object.keys(options.demandedOption).should.not.include('bar')
+      Object.keys(options.demandedOptions).should.not.include('bar')
     })
 
     it('should set help to global option by default', function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -258,7 +258,7 @@ describe('yargs dsl tests', function () {
 
     it('does not invoke parse with an error if reset has been called', function (done) {
       var y = yargs()
-        .demand('cake')
+        .demandOption('cake')
 
       y.parse('hello', function (err) {
         err.message.should.match(/Missing required argumen/)

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -241,7 +241,8 @@ describe('yargs dsl tests', function () {
         configObjects: [],
         envPrefix: 'YARGS', // preserved as global
         global: ['help'],
-        demanded: {}
+        demandedCommand: {},
+        demandedOption: {}
       }
 
       expect(y.getOptions()).to.deep.equal(emptyOptions)
@@ -853,7 +854,7 @@ describe('yargs dsl tests', function () {
 
     it('resets error state between calls to parse', function () {
       var y = yargs()
-        .demand(2)
+        .demandCommand(2)
 
       var err1 = null
       var out1 = null
@@ -1086,7 +1087,7 @@ describe('yargs dsl tests', function () {
         var output
         // set some top-level, reset-able config
         var parser = yargs()
-          .demand(1, 'Must call a command')
+          .demandCommand(1, 'Must call a command')
           .strict()
           .command('one <x>', 'The one and only command')
         // first call parse with command, which calls reset
@@ -1241,11 +1242,11 @@ describe('yargs dsl tests', function () {
 
       options.key.foo.should.equal(true)
       options.string.should.include('awesome-sauce')
-      Object.keys(options.demanded).should.include('awesomeSauce')
+      Object.keys(options.demandedOption).should.include('awesomeSauce')
 
       expect(options.key.bar).to.equal(undefined)
       options.string.should.not.include('bar')
-      Object.keys(options.demanded).should.not.include('bar')
+      Object.keys(options.demandedOption).should.not.include('bar')
     })
 
     it('should set help to global option by default', function () {
@@ -1408,7 +1409,7 @@ describe('yargs dsl tests', function () {
 
     it('does not skip validation if no option with skipValidation is present', function (done) {
       var argv = yargs(['--koala'])
-          .demand(1)
+          .demandCommand(1)
           .fail(function (msg) {
             return done()
           })
@@ -1433,7 +1434,7 @@ describe('yargs dsl tests', function () {
     it('allows having an option that skips validation but not skipping validation if that option is not used', function () {
       var skippedValidation = true
       yargs(['--no-skip'])
-          .demand(5)
+          .demandCommand(5)
           .option('skip', {
             skipValidation: true
           })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -251,7 +251,8 @@ describe('yargs dsl tests', function () {
       expect(y.getCommandInstance().getCommandHandlers()).to.deep.equal({})
       expect(y.getExitProcess()).to.equal(false)
       expect(y.getStrict()).to.equal(false)
-      expect(y.getDemanded()).to.deep.equal({})
+      expect(y.getDemandedOption()).to.deep.equal({})
+      expect(y.getDemandedommand()).to.deep.equal({})
       expect(y.getGroups()).to.deep.equal({})
     })
 

--- a/yargs.js
+++ b/yargs.js
@@ -316,11 +316,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       max = Infinity
     }
 
-    if (typeof keys === 'number') {
-      if (!options.demandedOption._) options.demandedOption._ = { count: 0, msg: null, max: max }
-      options.demandedOption._.count = keys
-      options.demandedOption._.msg = msg
-    } else if (Array.isArray(keys)) {
+    if (Array.isArray(keys)) {
       keys.forEach(function (key) {
         self.demandOption(key, msg)
       })
@@ -339,18 +335,19 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (typeof max !== 'number') {
       minMsg = max
       max = Infinity
-      options.demandedCommand._ = {
-        min: min,
-        max: max,
-        minMsg: minMsg,
-        maxMsg: maxMsg
-      }
+    }
+
+    options.demandedCommand._ = {
+      min: min,
+      max: max,
+      minMsg: minMsg,
+      maxMsg: maxMsg
     }
 
     return self
   }
 
-  self.getDemandedOption = function () {
+  self.getDemandedOption = self.getDemanded = function () {
     return options.demandedOption
   }
 

--- a/yargs.js
+++ b/yargs.js
@@ -98,7 +98,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     var objectOptions = [
       'narg', 'key', 'alias', 'default', 'defaultDescription',
-      'config', 'choices', 'demandedOption', 'demandedCommand', 'coerce'
+      'config', 'choices', 'demandedOptions', 'demandedCommands', 'coerce'
     ]
 
     arrayOptions.forEach(function (k) {
@@ -322,9 +322,9 @@ function Yargs (processArgs, cwd, parentRequire) {
       })
     } else {
       if (typeof msg === 'string') {
-        options.demandedOption[keys] = { msg: msg }
+        options.demandedOptions[keys] = { msg: msg }
       } else if (msg === true || typeof msg === 'undefined') {
-        options.demandedOption[keys] = { msg: undefined }
+        options.demandedOptions[keys] = { msg: undefined }
       }
     }
 
@@ -337,7 +337,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       max = Infinity
     }
 
-    options.demandedCommand._ = {
+    options.demandedCommands._ = {
       min: min,
       max: max,
       minMsg: minMsg,
@@ -347,12 +347,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.getDemandedOption = self.getDemanded = function () {
-    return options.demandedOption
+  self.getDemandedOptions = self.getDemanded = function () {
+    return options.demandedOptions
   }
 
-  self.getDemandedCommand = function () {
-    return options.demandedCommand
+  self.getDemandedCommands = function () {
+    return options.demandedCommands
   }
 
   self.requiresArg = function (requiresArgs) {

--- a/yargs.js
+++ b/yargs.js
@@ -301,11 +301,39 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.demandOption = self.demand = self.required = self.require = function (keys, max, msg) {
+  self.demand = self.required = self.require = function (keys, max, msg) {
     // you can optionally provide a 'max' key,
     // which will raise an exception if too many '_'
     // options are provided.
 
+    if (Array.isArray(max)) {
+      max.forEach(function (key) {
+        self.demandOption(key, msg)
+      })
+      max = Infinity
+    } else if (typeof max !== 'number') {
+      msg = max
+      max = Infinity
+    }
+
+    if (typeof keys === 'number') {
+      self.demandCommand(keys, max, msg)
+    } else if (Array.isArray(keys)) {
+      keys.forEach(function (key) {
+        self.demandOption(key, msg)
+      })
+    } else {
+      if (typeof msg === 'string') {
+        options.demandedOptions[keys] = { msg: msg }
+      } else if (msg === true || typeof msg === 'undefined') {
+        options.demandedOptions[keys] = { msg: undefined }
+      }
+    }
+
+    return self
+  }
+
+  self.demandOption = function (keys, max, msg) {
     if (Array.isArray(max)) {
       max.forEach(function (key) {
         self.demandOption(key, msg)
@@ -347,7 +375,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.getDemandedOptions = self.getDemanded = function () {
+  self.getDemandedOptions = function () {
     return options.demandedOptions
   }
 
@@ -496,6 +524,12 @@ function Yargs (processArgs, cwd, parentRequire) {
       var demandOption = opt.demandOption || opt.required || opt.require
 
       var demandCommand = opt.demandCommand
+
+      var demand = opt.demand
+
+      if (demand) {
+        self.demand(key, demand)
+      }
 
       if (demandOption) {
         self.demandOption(key, demandOption)


### PR DESCRIPTION
We've spoken quite a bit about having a separate demand API for both options and commands, specifically in #504, #438, #566, #618. 

This PR is creating this separation with: 

`demandCommand`,
```
demandCommand(min, max, minMsg, maxMsg)
```
or alternatively just the `min`,
```
demandCommand(min, minMsg)
```
and `demandOption`,
```
demandOption(['opt', 'anotherOpt'], msg)
```
or alternatively just,
```
demandOption('opt', msg')
```

I would love another pair of eyes on this, since I might have missed some aspects or use cases of this API, and I want to make sure I don't forget/break stuff \o/

cc @maxrimue @nexdrew @bcoe 