### PR TITLE
perf: normalizing package data is an expensive operation

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -416,7 +416,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     var obj = {}
     try {
       obj = readPkgUp.sync({
-        cwd: path || require('require-main-filename')(parentRequire || require)
+        cwd: path || require('require-main-filename')(parentRequire || require),
+        normalize: false
       })
     } catch (noop) {}
 


### PR DESCRIPTION
For yargs' purposes, we do not need package information normalized (this involves checking license strings, applying semver, etc). The normalize step is also a fairly expensive operation.