### PR TITLE
fix: still freeze/unfreeze if parse() is called in isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "^3.0.1",
     "nyc": "^10.0.0",
     "rimraf": "^2.5.0",
-    "standard": "^8.2.0",
+    "standard": "^8.6.0",
     "standard-version": "^3.0.0",
     "which": "^1.2.9"
   },

--- a/test/command.js
+++ b/test/command.js
@@ -735,6 +735,18 @@ describe('Command', function () {
     argv.second.should.equal('bar')
   })
 
+  // addresses https://github.com/yargs/yargs/issues/710
+  it('invokes command handler repeatedly if parse() is called multiple times', function () {
+    var counter = 0
+    var y = yargs([])
+      .command('foo', 'the foo command', {}, function (argv) {
+        counter++
+      })
+    y.parse(['foo'])
+    y.parse(['foo'])
+    counter.should.equal(2)
+  })
+
   // addresses https://github.com/yargs/yargs/issues/522
   it('does not require builder function to return', function () {
     var argv = yargs('yo')

--- a/test/usage.js
+++ b/test/usage.js
@@ -2331,7 +2331,7 @@ describe('usage tests', function () {
           .argv
       })
 
-      r.logs.join(' ').should.match(/\[count\]/)
+      r.logs.join(' ').should.match(/\[count]/)
     })
   })
 
@@ -2348,7 +2348,7 @@ describe('usage tests', function () {
           .argv
       })
 
-      r.logs.join(' ').should.match(/\[array\]/)
+      r.logs.join(' ').should.match(/\[array]/)
     })
   })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -450,7 +450,7 @@ describe('yargs dsl tests', function () {
           builder: function (yargs) { return yargs },
           handler: function (argv) {}
         })
-      }).to.throw(/No command name given for module: { desc: 'A command with no name',\n {2}builder: \[Function(: builder)?\],\n {2}handler: \[Function(: handler)?\] }/)
+      }).to.throw(/No command name given for module: { desc: 'A command with no name',\n {2}builder: \[Function(: builder)?],\n {2}handler: \[Function(: handler)?] }/)
     })
   })
 
@@ -809,7 +809,7 @@ describe('yargs dsl tests', function () {
       })
       r.logs.length.should.equal(0)
       r.errors.length.should.equal(0)
-      output.should.match(/--robin.*\[required\]/)
+      output.should.match(/--robin.*\[required]/)
     })
 
     it('reinstates original exitProcess setting after invocation', function () {
@@ -848,7 +848,7 @@ describe('yargs dsl tests', function () {
       r1.exit.should.be.false
       r2.exit.should.be.true
       r2.errors.length.should.equal(0)
-      r2.logs[0].should.match(/--help.*Show help.*\[boolean\]/)
+      r2.logs[0].should.match(/--help.*Show help.*\[boolean]/)
     })
 
     it('resets error state between calls to parse', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -446,16 +446,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     // skipping validation, etc.
     if (!shortCircuit) processArgs = args
 
-    if (parseFn) {
-      freeze()
-      exitProcess = false
-    }
+    freeze()
+    if (parseFn) exitProcess = false
 
     var parsed = parseArgs(args, shortCircuit)
-    if (parseFn) {
-      parseFn(exitError, parsed, output)
-      unfreeze()
-    }
+    if (parseFn) parseFn(exitError, parsed, output)
+    unfreeze()
 
     return parsed
   }


### PR DESCRIPTION
I see no reason for us to not still call freeze()/unfreeze() to put yargs back into an initial state when `parse()` is called in isolation.

