### PR TITLE
fix: do not use cwd when resolving package.json for yargs parsing config

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -223,12 +223,6 @@ module.exports = function (yargs, usage, y18n) {
     const implyFail = []
 
     Object.keys(implied).forEach(function (key) {
-      var booleanNegation
-      if (yargs.getOptions().configuration['boolean-negation'] === false) {
-        booleanNegation = false
-      } else {
-        booleanNegation = true
-      }
       var num
       const origKey = key
       var value = implied[key]
@@ -240,7 +234,7 @@ module.exports = function (yargs, usage, y18n) {
       if (typeof key === 'number') {
         // check length of argv._
         key = argv._.length >= key
-      } else if (key.match(/^--no-.+/) && booleanNegation) {
+      } else if (key.match(/^--no-.+/)) {
         // check if key doesn't exist
         key = key.match(/^--no-(.+)/)[1]
         key = !argv[key]
@@ -254,7 +248,7 @@ module.exports = function (yargs, usage, y18n) {
 
       if (typeof value === 'number') {
         value = argv._.length >= value
-      } else if (value.match(/^--no-.+/) && booleanNegation) {
+      } else if (value.match(/^--no-.+/)) {
         value = value.match(/^--no-(.+)/)[1]
         value = !argv[value]
       } else {

--- a/test/validation.js
+++ b/test/validation.js
@@ -57,18 +57,6 @@ describe('validation tests', function () {
         })
         .argv
     })
-
-    it('does not treat --no- as a special case if boolean negation is disabled', function (done) {
-      yargs(['--foo'], './test/fixtures')
-        .implies({
-          'foo': '--no-foo'
-        })
-        .fail(function (msg) {
-          msg.should.match(/Implications failed/)
-          return done()
-        })
-        .argv
-    })
   })
 
   describe('demand', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -818,7 +818,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   function parseArgs (args, shortCircuit) {
     options.__ = y18n.__
-    options.configuration = pkgUp(cwd)['yargs'] || {}
+    options.configuration = pkgUp()['yargs'] || {}
     const parsed = Parser.detailed(args, options)
     var argv = parsed.argv
     if (parseContext) argv = assign(parseContext, argv)


### PR DESCRIPTION
Fixes a bug introduced with #556, demonstrated by https://github.com/laggingreflex/yargs-test-720.

Also, while investigating changes from 556, I found that validation logic for the `.implies()` method interprets a prefix of `--no-` on a key as a tiny DSL for "when this key is _not_ given". From this, we can actually ignore the `boolean-negation: false` setting for the `.implies()` method because `boolean-negation` affects _parsing_ but not the _DSL of implications_. To demonstrate this, I added some tests (with comments) showing how the DSL is interpreted.

The following use-cases are supported for `.implies()`:

1. `bar: 'foo'` = use of `--bar` requires that `--foo` be given
2. `bar: '--no-foo'` = use of `--bar` requires that `--foo` *cannot* be given
3. `bar: 'noFoo'` = use of `--bar` requires that `--noFoo` (or `--no-foo` with `"boolean-negation": false`) be given
4. `bar: '--no-noFoo'` = use of `--bar` requires that `--noFoo` (or `--no-foo` with `"boolean-negation": false`) *cannot* be given

In all use-cases, the `boolean-negation` config setting _only changes how `--no-foo` (or `--no-ANYTHING`) is parsed in `argv`_, it does not change how the implications are interpreted.

Thus, I also reverted 556 in its entirety.

Note that this fixes the bug found by #720, but it technically doesn't close 720 because I have not attempted to change the API to allow parsing config to be defined in any other way besides a `"yargs"` stanza in package.json.