### PR TITLE
feat: support for positional argument aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,18 @@ yargs.command('get <source> [proxy]', 'make a get HTTP request')
   .argv
 ```
 
+#### Positional Argument Aliases
+
+Aliases can be provided for positional arguments using the
+`|` character. As an example, suppose our application allows either a username _or_
+an email as the first argument:
+
+```js
+yargs.command('get <username|email> [password]', 'fetch a user by username or email.')
+  .help()
+  .argv
+```
+
 #### Variadic Positional Arguments
 
 The last positional argument can optionally accept an array of
@@ -1152,7 +1164,7 @@ Method to execute when a failure occurs, rather than printing the failure messag
 
 `fn` is called with the failure message that would have been printed, the
 `Error` instance originally thrown and yargs state when the failure
-occured. 
+occured.
 
 ```js
 var argv = require('yargs')

--- a/README.md
+++ b/README.md
@@ -611,8 +611,8 @@ yargs.command('get <source> [proxy]', 'make a get HTTP request')
 
 #### Positional Argument Aliases
 
-Aliases can be provided for positional arguments using the
-`|` character. As an example, suppose our application allows either a username _or_
+Aliases can be provided for positional arguments using the `|` character.
+As an example, suppose our application allows either a username _or_
 an email as the first argument:
 
 ```js
@@ -620,6 +620,9 @@ yargs.command('get <username|email> [password]', 'fetch a user by username or em
   .help()
   .argv
 ```
+
+In this way, both `argv.username` and `argv.email` would be populated with the
+same value when the command is executed.
 
 #### Variadic Positional Arguments
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -108,12 +108,12 @@ module.exports = function (yargs, usage, validation) {
       if (/\.+[\]>]/.test(cmd) && i === splitCommand.length - 1) variadic = true
       if (/^\[/.test(cmd)) {
         parsedCommand.optional.push({
-          cmd: cmd.replace(bregex, ''),
+          cmd: cmd.replace(bregex, '').split('|'),
           variadic: variadic
         })
       } else {
         parsedCommand.demanded.push({
-          cmd: cmd.replace(bregex, ''),
+          cmd: cmd.replace(bregex, '').split('|'),
           variadic: variadic
         })
       }
@@ -163,7 +163,7 @@ module.exports = function (yargs, usage, validation) {
       })
       innerArgv = innerArgv.argv
     }
-    if (!yargs._hasOutput()) populatePositional(commandHandler, innerArgv, currentContext, yargs)
+    if (!yargs._hasOutput()) populatePositionals(commandHandler, innerArgv, currentContext, yargs)
 
     if (commandHandler.handler && !yargs._hasOutput()) {
       commandHandler.handler(innerArgv)
@@ -174,7 +174,7 @@ module.exports = function (yargs, usage, validation) {
     return innerArgv
   }
 
-  function populatePositional (commandHandler, argv, context, yargs) {
+  function populatePositionals (commandHandler, argv, context, yargs) {
     argv._ = argv._.slice(context.commands.length) // nuke the current commands
     var demanded = commandHandler.demanded.slice(0)
     var optional = commandHandler.optional.slice(0)
@@ -183,25 +183,36 @@ module.exports = function (yargs, usage, validation) {
 
     while (demanded.length) {
       var demand = demanded.shift()
-      if (demand.variadic) argv[demand.cmd] = []
-      if (!argv._.length) break
-      if (demand.variadic) argv[demand.cmd] = argv._.splice(0)
-      else argv[demand.cmd] = argv._.shift()
-      postProcessPositional(yargs, argv, demand.cmd)
-      addCamelCaseExpansions(argv, demand.cmd)
+      populatePositional(demand, argv, yargs)
     }
 
     while (optional.length) {
       var maybe = optional.shift()
-      if (maybe.variadic) argv[maybe.cmd] = []
-      if (!argv._.length) break
-      if (maybe.variadic) argv[maybe.cmd] = argv._.splice(0)
-      else argv[maybe.cmd] = argv._.shift()
-      postProcessPositional(yargs, argv, maybe.cmd)
-      addCamelCaseExpansions(argv, maybe.cmd)
+      populatePositional(maybe, argv, yargs)
     }
 
     argv._ = context.commands.concat(argv._)
+  }
+
+  // populate a single positional argument and its
+  // aliases on argv.
+  function populatePositional (positional, argv, yargs) {
+    // a positional consists of an array of the positional
+    // argument and its aliases command <positional | alias>
+    var variadics = null
+    var value = null
+    for (var i = 0, cmd; (cmd = positional.cmd[i]) !== undefined; i++) {
+      if (positional.variadic) {
+        if (variadics) argv[cmd] = variadics.slice(0)
+        else argv[cmd] = variadics = argv._.splice(0)
+      } else {
+        if (!value && !argv._.length) continue
+        if (value) argv[cmd] = value
+        else argv[cmd] = value = argv._.shift()
+      }
+      postProcessPositional(yargs, argv, cmd)
+      addCamelCaseExpansions(argv, cmd)
+    }
   }
 
   // TODO move positional arg logic to yargs-parser and remove this duplication

--- a/lib/command.js
+++ b/lib/command.js
@@ -96,7 +96,7 @@ module.exports = function (yargs, usage, validation) {
 
   function parseCommand (cmd) {
     var extraSpacesStrippedCommand = cmd.replace(/\s{2,}/g, ' ')
-    var splitCommand = extraSpacesStrippedCommand.split(/\s/)
+    var splitCommand = extraSpacesStrippedCommand.split(/\s+(?![^[]*]|[^<]*>)/)
     var bregex = /\.*[\][<>]/g
     var parsedCommand = {
       cmd: (splitCommand.shift()).replace(bregex, ''),
@@ -105,15 +105,15 @@ module.exports = function (yargs, usage, validation) {
     }
     splitCommand.forEach(function (cmd, i) {
       var variadic = false
-      if (/\.+[\]>]/.test(cmd) && i === splitCommand.length - 1) variadic = true
+      if (/\.+[\]>]/.test(cmd.replace(/\s/g, '')) && i === splitCommand.length - 1) variadic = true
       if (/^\[/.test(cmd)) {
         parsedCommand.optional.push({
-          cmd: cmd.replace(bregex, '').split('|'),
+          cmd: cmd.replace(/\s/g, '').replace(bregex, '').split('|'),
           variadic: variadic
         })
       } else {
         parsedCommand.demanded.push({
-          cmd: cmd.replace(bregex, '').split('|'),
+          cmd: cmd.replace(/\s/g, '').replace(bregex, '').split('|'),
           variadic: variadic
         })
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -174,6 +174,8 @@ module.exports = function (yargs, usage, validation) {
     return innerArgv
   }
 
+  // transcribe all positional arguments "command <foo> <bar> [apple]"
+  // onto argv.
   function populatePositionals (commandHandler, argv, context, yargs) {
     argv._ = argv._.slice(context.commands.length) // nuke the current commands
     var demanded = commandHandler.demanded.slice(0)
@@ -195,10 +197,11 @@ module.exports = function (yargs, usage, validation) {
   }
 
   // populate a single positional argument and its
-  // aliases on argv.
+  // aliases onto argv.
   function populatePositional (positional, argv, yargs) {
-    // a positional consists of an array of the positional
-    // argument and its aliases command <positional | alias>
+    // "positional" consists of the positional.cmd, an array representing
+    // the positional's name and aliases, and positional.variadic
+    // indicating whether or not it is a variadic array.
     var variadics = null
     var value = null
     for (var i = 0, cmd; (cmd = positional.cmd[i]) !== undefined; i++) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -105,15 +105,16 @@ module.exports = function (yargs, usage, validation) {
     }
     splitCommand.forEach(function (cmd, i) {
       var variadic = false
-      if (/\.+[\]>]/.test(cmd.replace(/\s/g, '')) && i === splitCommand.length - 1) variadic = true
+      cmd = cmd.replace(/\s/g, '')
+      if (/\.+[\]>]/.test(cmd) && i === splitCommand.length - 1) variadic = true
       if (/^\[/.test(cmd)) {
         parsedCommand.optional.push({
-          cmd: cmd.replace(/\s/g, '').replace(bregex, '').split('|'),
+          cmd: cmd.replace(bregex, '').split('|'),
           variadic: variadic
         })
       } else {
         parsedCommand.demanded.push({
-          cmd: cmd.replace(/\s/g, '').replace(bregex, '').split('|'),
+          cmd: cmd.replace(bregex, '').split('|'),
           variadic: variadic
         })
       }

--- a/test/command.js
+++ b/test/command.js
@@ -19,11 +19,11 @@ describe('Command', function () {
       var command = y.getCommandInstance()
       var handlers = command.getCommandHandlers()
       handlers.foo.demanded.should.include({
-        cmd: 'bar',
+        cmd: ['bar'],
         variadic: false
       })
       handlers.foo.optional.should.include({
-        cmd: 'awesome',
+        cmd: ['awesome'],
         variadic: false
       })
     })
@@ -96,7 +96,7 @@ describe('Command', function () {
       var command = y.getCommandInstance()
       var handlers = command.getCommandHandlers()
       handlers.foo.optional.should.include({
-        cmd: 'awesome',
+        cmd: ['awesome'],
         variadic: false
       })
       handlers.foo.demanded.should.deep.equal([])
@@ -806,5 +806,34 @@ describe('Command', function () {
       .argv
     argv.should.have.property('someone').and.equal('world')
     commandCalled.should.be.true
+  })
+
+  describe('positional aliases', function () {
+    it('allows an alias to be defined for a required positional argument', function () {
+      var parser = yargs('yo')
+        .command('yo <user|email> [ssn]', 'Send someone a yo')
+      var argv = parser.parse('yo bcoe 113993')
+      argv.user.should.equal('bcoe')
+      argv.email.should.equal('bcoe')
+      argv.ssn.should.equal(113993)
+    })
+
+    it('allows an alias to be defined for an optional positional argument', function () {
+      var parser = yargs('yo')
+        .command('yo [ssn|sin]', 'Send someone a yo')
+      var argv = parser.parse('yo 113993')
+      argv.ssn.should.equal(113993)
+      argv.sin.should.equal(113993)
+    })
+
+    it('allows variadic and positional arguments to be combined', function () {
+      var parser = yargs('yo')
+        .command('yo <user|email> [ssns|sins...]', 'Send someone a yo')
+      var argv = parser.parse('yo bcoe 113993 112888')
+      argv.user.should.equal('bcoe')
+      argv.email.should.equal('bcoe')
+      argv.ssns.should.deep.equal([113993, 112888])
+      argv.sins.should.deep.equal([113993, 112888])
+    })
   })
 })

--- a/test/command.js
+++ b/test/command.js
@@ -819,17 +819,20 @@ describe('Command', function () {
     })
 
     it('allows an alias to be defined for an optional positional argument', function () {
-      var argv = yargs('yo 113993')
-        .command('yo [ssn|sin]', 'Send someone a yo')
+      var argv
+      yargs('yo 113993')
+        .command('yo [ssn|sin]', 'Send someone a yo', {}, function (_argv) {
+          argv = _argv
+        })
         .argv
       argv.ssn.should.equal(113993)
       argv.sin.should.equal(113993)
     })
 
     it('allows variadic and positional arguments to be combined', function () {
-      var argv = yargs('yo bcoe 113993 112888')
-        .command('yo <user|email> [ssns|sins...]', 'Send someone a yo')
-        .argv
+      var parser = yargs
+        .command('yo <user|email> [ ssns | sins... ]', 'Send someone a yo')
+      var argv = parser.parse('yo bcoe 113993 112888')
       argv.user.should.equal('bcoe')
       argv.email.should.equal('bcoe')
       argv.ssns.should.deep.equal([113993, 112888])

--- a/test/command.js
+++ b/test/command.js
@@ -810,26 +810,26 @@ describe('Command', function () {
 
   describe('positional aliases', function () {
     it('allows an alias to be defined for a required positional argument', function () {
-      var parser = yargs('yo')
-        .command('yo <user|email> [ssn]', 'Send someone a yo')
-      var argv = parser.parse('yo bcoe 113993')
+      var argv = yargs('yo bcoe 113993')
+        .command('yo <user | email> [ssn]', 'Send someone a yo')
+        .argv
       argv.user.should.equal('bcoe')
       argv.email.should.equal('bcoe')
       argv.ssn.should.equal(113993)
     })
 
     it('allows an alias to be defined for an optional positional argument', function () {
-      var parser = yargs('yo')
+      var argv = yargs('yo 113993')
         .command('yo [ssn|sin]', 'Send someone a yo')
-      var argv = parser.parse('yo 113993')
+        .argv
       argv.ssn.should.equal(113993)
       argv.sin.should.equal(113993)
     })
 
     it('allows variadic and positional arguments to be combined', function () {
-      var parser = yargs('yo')
+      var argv = yargs('yo bcoe 113993 112888')
         .command('yo <user|email> [ssns|sins...]', 'Send someone a yo')
-      var argv = parser.parse('yo bcoe 113993 112888')
+        .argv
       argv.user.should.equal('bcoe')
       argv.email.should.equal('bcoe')
       argv.ssns.should.deep.equal([113993, 112888])


### PR DESCRIPTION
When migrating one of npm, Inc's internal chat-bots to yargs, I ran into some help strings that were documented like so:

`delete <user|org>    delete a user or organization`

Given that it's not a huge amount of work, I thought it would be worth adding this syntax to yargs' command API, in the form of positional argument aliases.

CC: @ceejbot, @nexdrew 