### PR TITLE
feat: allow strict mode to be applied globally

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -756,7 +756,7 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  // yargs.parse(['foo', '--bar'], function (err, argv, output) {}
+  // yargs.parse(['foo', '--bar'], function (err, argv, output) {})
   context('function passed as second argument to parse', function () {
     it('does not print to stdout', function () {
       var r = checkOutput(function () {
@@ -1858,6 +1858,84 @@ describe('yargs dsl tests', function () {
         .argv
       expect(msg).to.equal('ball')
       expect(err).to.exist
+    })
+  })
+
+  describe('strict', function () {
+    it('defaults to false when not called', function () {
+      var commandCalled = false
+      yargs('hi')
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.getStrict().should.be.false
+        })
+      yargs.getStrict().should.be.false
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
+    })
+
+    it('can be enabled just for a command', function () {
+      var commandCalled = false
+      yargs('hi')
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.strict().getStrict().should.be.true
+        })
+      yargs.getStrict().should.be.false
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
+    })
+
+    it('is true but non-global when called without arguments', function () {
+      var commandCalled = false
+      yargs('hi')
+        .strict()
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.getStrict().should.be.false
+        })
+      yargs.getStrict().should.be.true
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
+    })
+
+    it('is false when passed a value of `false`', function () {
+      var commandCalled = false
+      yargs('hi')
+        .strict(false)
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.getStrict().should.be.false
+        })
+      yargs.getStrict().should.be.false
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
+    })
+
+    it('is true and global when passed a value of `true`', function () {
+      var commandCalled = false
+      yargs('hi')
+        .strict(true)
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.getStrict().should.be.true
+        })
+      yargs.getStrict().should.be.true
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
+    })
+
+    it('allows a command to override global with a value of `false`', function () {
+      var commandCalled = false
+      yargs('hi')
+        .strict(true)
+        .command('hi', 'The hi command', function (innerYargs) {
+          commandCalled = true
+          innerYargs.strict(false).getStrict().should.be.false
+        })
+      yargs.getStrict().should.be.true
+      yargs.argv // parse and run command
+      commandCalled.should.be.true
     })
   })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -123,7 +123,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
-    strict = false
+    if (!strictGlobal) strict = false
     completionCommand = null
     output = ''
     exitError = null
@@ -594,8 +594,10 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   var strict = false
-  self.strict = function () {
-    strict = true
+  var strictGlobal = false
+  self.strict = function (_global) {
+    strict = _global !== false
+    strictGlobal = !!_global
     return self
   }
   self.getStrict = function () {


### PR DESCRIPTION
While recently working on a yargs-based Slackbot with several nested commands, I wanted to apply `.strict()` mode at each level so that when an invalid command/subcommand is given (e.g. mistyped) it would return help text (with an error message) instead of not running/returning anything. Since there is currently no way to apply strict mode globally in yargs, I ended up having to call `.strict()` in each command's builder function at every nested level. Ugh.

This PR augments the `.strict()` API so that it can accept a boolean value to either (a) apply globally when passed `true` or (b) be disabled when passed `false` (to allow a command to override a global strict mode). The method maintains backwards-compatibility with the previous API of enabling strict mode in a non-global way when called without any arguments.

It might be slightly odd interpreting a boolean value in two different ways based on its value, but I think it's acceptable since it provides for all use-cases:

1. enable strict mode for the current level only: `.strict()`
2. enable strict mode globally (for the current level and its sub-levels): `.strict(true)`
3. disable strict mode for the current level: `.strict(false)`

Note that strict mode defaults to "globally" disabled, so not calling the method at all satisfies that use-case.