### PR TITLE
refactor: use process.stdout.columns instead of dep

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -110,12 +110,11 @@ module.exports = function (yargs, y18n) {
   }
 
   function getWrap () {
-    // lazily call windowWidth() because it's very expensive,
-    // and only needs to be called if the user wants to show usage/help
     if (!wrapSet) {
       wrap = windowWidth()
       wrapSet = true
     }
+
     return wrap
   }
 
@@ -140,6 +139,7 @@ module.exports = function (yargs, y18n) {
         return acc
       }, {})
     )
+
     var theWrap = getWrap()
     var ui = require('cliui')({
       width: theWrap,
@@ -397,8 +397,11 @@ module.exports = function (yargs, y18n) {
 
   // guess the width of the console window, max-width 80.
   function windowWidth () {
-    const wsize = require('window-size')
-    return wsize.width ? Math.min(80, wsize.width) : null
+    if (process && process.stdout && process.stdout.columns && Math.min(80, process.stdout.colums)) {
+      return process.stdout.columns
+    } else {
+      return null
+    }
   }
 
   // logic for displaying application version.

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -397,10 +397,11 @@ module.exports = function (yargs, y18n) {
 
   // guess the width of the console window, max-width 80.
   function windowWidth () {
-    if (process && process.stdout && process.stdout.columns && Math.min(80, process.stdout.colums)) {
-      return process.stdout.columns
+    var maxWidth = 80
+    if (typeof process === 'object' && process.stdout && process.stdout.columns) {
+      return Math.min(maxWidth, process.stdout.columns)
     } else {
-      return null
+      return maxWidth
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "set-blocking": "^2.0.0",
     "string-width": "^1.0.2",
     "which-module": "^1.0.0",
-    "window-size": "^0.2.0",
     "y18n": "^3.2.1",
     "yargs-parser": "^4.2.0"
   },

--- a/test/usage.js
+++ b/test/usage.js
@@ -1284,7 +1284,7 @@ describe('usage tests', function () {
         return this.skip()
       }
 
-      var width = require('window-size').width
+      var width = process.stdout.columns
 
       var r = checkUsage(function () {
         return yargs([])

--- a/yargs.js
+++ b/yargs.js
@@ -804,7 +804,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self.terminalWidth = function () {
-    return require('window-size').width
+    return process.stdout.columns
   }
 
   Object.defineProperty(self, 'argv', {


### PR DESCRIPTION
I was able to remove the dependency `window-size` and instead use `process.stdout.columns` which effectively does the same thing but seems to be much less resource hungry.