### PR TITLE
feat: implement conflicts() for defining mutually exclusive arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,26 @@ $ node test.js
   '$0': 'test.js' }
 ```
 
+<a name="conflicts"></a>.conflicts(key1, key2)
+----------------------------------------------
+
+Implements mutual exclusion between `key1` and `key2`, it accepts only one or another.
+
+Setting `test.js` like this:
+```js
+var argv = require('yargs')
+  .conflicts('f', 'b')
+  .argv
+```
+
+Gives an error when calling with both arguments
+```
+$ node test.js -f -b
+Arguments f and b are mutually exclusive
+```
+
+You can also pass arrays as arguments.
+
 <a name="count"></a>.count(key)
 ------------
 

--- a/README.md
+++ b/README.md
@@ -985,25 +985,12 @@ $ node test.js
   '$0': 'test.js' }
 ```
 
-<a name="conflicts"></a>.conflicts(key1, key2)
+<a name="conflicts"></a>.conflicts(x, y)
 ----------------------------------------------
 
-Implements mutual exclusion between `key1` and `key2`, it accepts only one or another.
+Given the key `x` is set, the key `y` must not be set.
 
-Setting `test.js` like this:
-```js
-var argv = require('yargs')
-  .conflicts('f', 'b')
-  .argv
-```
-
-Gives an error when calling with both arguments
-```
-$ node test.js -f -b
-Arguments f and b are mutually exclusive
-```
-
-You can also pass arrays as arguments.
+Optionally `.conflicts()` can accept an object specifying multiple conflicting keys.
 
 <a name="count"></a>.count(key)
 ------------

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -271,11 +271,28 @@ module.exports = function (yargs, usage, y18n) {
     }
   }
 
+// checks conflicts if foo => !bar
   var conflicting = {}
   self.conflicts = function (key1, key2) {
-    if (typeof key1 === 'string' && typeof key2 === 'string' && key1 !== '_' && key2 !== '_') {
-      conflicting[key1] = key2
-      conflicting[key2] = key1
+    // TODO: add check to object key & value
+    // TODO: add conflict message
+    if (typeof key1 === 'string') {
+      if (typeof key2 === 'string') {
+        conflicting[key1] = key2
+        conflicting[key2] = key1
+      } else (Array.isArray(key2)) {
+        key2.forEach(function (key) {
+          self.conflicts(key1, key)
+        })
+      }
+    } else (Array.isArray(key1)) {
+      if (!key2) {
+        self.conflicts(key1.pop(), key1)
+      } else {
+        key1.forEach(function (key) {
+          self.conflicts(key, key2)
+        })
+      }
     }
   }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -271,6 +271,28 @@ module.exports = function (yargs, usage, y18n) {
     }
   }
 
+  var conflicting = {}
+  self.conflicts = function (key1, key2) {
+    if (typeof key1 === 'string' && typeof key2 === 'string' && key1 !== '_' && key2 !== '_') {
+      conflicting[key1] = key2
+      conflicting[key2] = key1
+    }
+  }
+
+  self.getConflicting = function () {
+    return conflicting
+  }
+
+  self.conflicting = function (argv) {
+    var args = Object.getOwnPropertyNames(argv)
+
+    args.forEach(function (arg) {
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1) {
+        usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
+      }
+    })
+  }
+
   self.recommendCommands = function (cmd, potentialCommands) {
     const distance = require('./levenshtein')
     const threshold = 3 // if it takes more than three edits, let's move on.
@@ -293,6 +315,7 @@ module.exports = function (yargs, usage, y18n) {
       return globalLookup[k]
     })
     checks = []
+    conflicting = {}
     return self
   }
 
@@ -301,10 +324,12 @@ module.exports = function (yargs, usage, y18n) {
     frozen = {}
     frozen.implied = implied
     frozen.checks = checks
+    frozen.conflicting = conflicting
   }
   self.unfreeze = function () {
     implied = frozen.implied
     checks = frozen.checks
+    conflicting = frozen.conflicting
     frozen = undefined
   }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -271,31 +271,16 @@ module.exports = function (yargs, usage, y18n) {
     }
   }
 
-// checks conflicts if foo => !bar
   var conflicting = {}
-  self.conflicts = function (key1, key2) {
-    // TODO: add check to object key & value
-    // TODO: add conflict message
-    if (typeof key1 === 'string') {
-      if (typeof key2 === 'string') {
-        conflicting[key1] = key2
-        conflicting[key2] = key1
-      } else (Array.isArray(key2)) {
-        key2.forEach(function (key) {
-          self.conflicts(key1, key)
-        })
-      }
-    } else (Array.isArray(key1)) {
-      if (!key2) {
-        self.conflicts(key1.pop(), key1)
-      } else {
-        key1.forEach(function (key) {
-          self.conflicts(key, key2)
-        })
-      }
+  self.conflicts = function (key, value) {
+    if (typeof key === 'object') {
+      Object.keys(key).forEach(function (k) {
+        self.conflicts(k, key[k])
+      })
+    } else {
+      conflicting[key] = value
     }
   }
-
   self.getConflicting = function () {
     return conflicting
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -35,5 +35,6 @@
   "Path to JSON config file": "Path to JSON config file",
   "Show help": "Show help",
   "Show version number": "Show version number",
-  "Did you mean %s?": "Did you mean %s?"
+  "Did you mean %s?": "Did you mean %s?",
+  "Arguments %s and %s are mutually exclusive" : "Arguments %s and %s are mutually exclusive"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -33,5 +33,6 @@
   "Invalid JSON config file: %s": "Arquivo de configuração em JSON esta inválido: %s",
   "Path to JSON config file": "Caminho para o arquivo de configuração em JSON",
   "Show help": "Mostra ajuda",
-  "Show version number": "Mostra número de versão"
+  "Show version number": "Mostra número de versão",
+  "Arguments %s and %s are mutually exclusive" : "Argumentos %s e %s são mutualmente exclusivos"
 }

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -35,5 +35,6 @@
   "Path to JSON config file": "Caminho para o arquivo JSON de configuração",
   "Show help": "Exibe ajuda",
   "Show version number": "Exibe a versão",
-  "Did you mean %s?": "Você quis dizer %s?"
+  "Did you mean %s?": "Você quis dizer %s?",
+  "Arguments %s and %s are mutually exclusive" : "Argumentos %s e %s são mutualmente exclusivos"
 }

--- a/test/validation.js
+++ b/test/validation.js
@@ -136,18 +136,49 @@ describe('validation tests', function () {
 
     it('should not fail if only one argument is supplied', function () {
       yargs(['-b'])
-          .conflicts('f', 'b')
-          .fail(function (msg) {
-            expect.fail()
-          })
-          .argv
+        .conflicts('f', 'b')
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
 
       yargs(['-f'])
-      .conflicts('f', 'b')
-      .fail(function (msg) {
-        expect.fail()
-      })
-      .argv
+        .conflicts('f', 'b')
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+    })
+
+    it('should not fail with arrays as arguments', function () {
+      yargs(['-b'])
+        .conflicts('f', ['b', 'c', 'd'])
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+
+      yargs(['-b'])
+        .conflicts(['b', 'c', 'd'], 'f')
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+
+
+      yargs(['-b'])
+        .conflicts(['b', 'c', 'd'], ['f', 'g', 'h'])
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+
+        yargs(['-b'])
+        .conflicts(['b', 'c', 'd'])
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
     })
   })
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -165,7 +165,6 @@ describe('validation tests', function () {
         })
         .argv
 
-
       yargs(['-b'])
         .conflicts(['b', 'c', 'd'], ['f', 'g', 'h'])
         .fail(function (msg) {
@@ -173,7 +172,7 @@ describe('validation tests', function () {
         })
         .argv
 
-        yargs(['-b'])
+      yargs(['-b'])
         .conflicts(['b', 'c', 'd'])
         .fail(function (msg) {
           expect.fail()

--- a/test/validation.js
+++ b/test/validation.js
@@ -123,6 +123,34 @@ describe('validation tests', function () {
     })
   })
 
+  describe('conflicts', function () {
+    it('fails if both arguments are supplied', function (done) {
+      yargs(['-f', '-b'])
+          .conflicts('f', 'b')
+          .fail(function (msg) {
+            msg.should.equal('Arguments f and b are mutually exclusive')
+            return done()
+          })
+          .argv
+    })
+
+    it('should not fail if only one argument is supplied', function () {
+      yargs(['-b'])
+          .conflicts('f', 'b')
+          .fail(function (msg) {
+            expect.fail()
+          })
+          .argv
+
+      yargs(['-f'])
+      .conflicts('f', 'b')
+      .fail(function (msg) {
+        expect.fail()
+      })
+      .argv
+    })
+  })
+
   describe('demand', function () {
     it('fails with standard error message if msg is not defined', function (done) {
       yargs([])

--- a/test/validation.js
+++ b/test/validation.js
@@ -3,6 +3,8 @@
 var expect = require('chai').expect
 var yargs = require('../')
 
+require('chai').should()
+
 describe('validation tests', function () {
   beforeEach(function () {
     yargs.reset()
@@ -134,15 +136,8 @@ describe('validation tests', function () {
           .argv
     })
 
-    it('should not fail if only one argument is supplied', function () {
-      yargs(['-b'])
-        .conflicts('f', 'b')
-        .fail(function (msg) {
-          expect.fail()
-        })
-        .argv
-
-      yargs(['-f'])
+    it('should not fail if no conflicting arguments are provided', function () {
+      yargs(['-b', '-c'])
         .conflicts('f', 'b')
         .fail(function (msg) {
           expect.fail()
@@ -150,32 +145,15 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('should not fail with arrays as arguments', function () {
-      yargs(['-b'])
-        .conflicts('f', ['b', 'c', 'd'])
-        .fail(function (msg) {
-          expect.fail()
+    it('allows an object to be provided defining conflicting option pairs', function (done) {
+      yargs(['-t', '-s'])
+        .conflicts({
+          'c': 'a',
+          's': 't'
         })
-        .argv
-
-      yargs(['-b'])
-        .conflicts(['b', 'c', 'd'], 'f')
         .fail(function (msg) {
-          expect.fail()
-        })
-        .argv
-
-      yargs(['-b'])
-        .conflicts(['b', 'c', 'd'], ['f', 'g', 'h'])
-        .fail(function (msg) {
-          expect.fail()
-        })
-        .argv
-
-      yargs(['-b'])
-        .conflicts(['b', 'c', 'd'])
-        .fail(function (msg) {
-          expect.fail()
+          console.log(msg)
+          return done()
         })
         .argv
     })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -217,6 +217,7 @@ describe('yargs dsl tests', function () {
         .choices('foo', ['bar', 'baz'])
         .coerce('foo', function (foo) { return foo + 'bar' })
         .implies('foo', 'snuh')
+        .conflicts('qux', 'xyzzy')
         .group('foo', 'Group:')
         .strict()
         .exitProcess(false)  // defaults to true.
@@ -249,6 +250,7 @@ describe('yargs dsl tests', function () {
       expect(y.getOptions()).to.deep.equal(emptyOptions)
       expect(y.getUsageInstance().getDescriptions()).to.deep.equal({help: '__yargsString__:Show help'})
       expect(y.getValidationInstance().getImplied()).to.deep.equal({})
+      expect(y.getValidationInstance().getConflicting()).to.deep.equal({})
       expect(y.getCommandInstance().getCommandHandlers()).to.deep.equal({})
       expect(y.getExitProcess()).to.equal(false)
       expect(y.getStrict()).to.equal(false)

--- a/yargs.js
+++ b/yargs.js
@@ -354,6 +354,11 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
+  self.conflicts = function (key1, key2) {
+    validation.conflicts(key1, key2)
+    return self
+  }
+
   self.usage = function (msg, opts) {
     if (!opts && typeof msg === 'object') {
       opts = msg
@@ -952,6 +957,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         validation.customChecks(argv, aliases)
         validation.limitedChoices(argv)
         validation.implications(argv)
+        validation.conflicting(argv)
       }
     }
 


### PR DESCRIPTION
This pull request sees @madcampos' hard work over the finish line 🎉 

I've made a few minor changes to make the `conflicts()` api almost identical to its cousin `implies()`.