### PR TITLE
fix: line wrapping for examples without desc

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -261,10 +261,24 @@ module.exports = function (yargs, y18n) {
       })
 
       examples.forEach(function (example) {
-        ui.div(
-          {text: example[0], padding: [0, 2, 0, 2], width: maxWidth(examples, theWrap) + 4},
-          example[1]
-        )
+        if (example[1] === '') {
+          ui.div(
+            {
+              text: example[0],
+              padding: [0, 2, 0, 2]
+            }
+          )
+        } else {
+          ui.div(
+            {
+              text: example[0],
+              padding: [0, 2, 0, 2],
+              width: maxWidth(examples, theWrap) + 4
+            }, {
+              text: example[1]
+            }
+          )
+        }
       })
 
       ui.div()

--- a/test/usage.js
+++ b/test/usage.js
@@ -1337,6 +1337,25 @@ describe('usage tests', function () {
       })
     })
 
+    it('should not wrap left-hand-column if no description is provided', function () {
+      var r = checkUsage(function () {
+        return yargs([])
+          .example('i am a fairly long example that is like really long woooo')
+          .demand('foo')
+          .wrap(50)
+          .argv
+      })
+
+      r.errors[0].split('\n').forEach(function (line, i) {
+        // ignore headings and blank lines.
+        if (!line.match('i am a fairly long example')) return
+
+        // with two white space characters on the left,
+        // line length should be 50 - 2
+        line.length.should.equal(48)
+      })
+    })
+
     it('should wrap the usage string', function () {
       var r = checkUsage(function () {
         return yargs([])


### PR DESCRIPTION
This PR fixes #697. Now, if an example is defined without a description, the usage example will take up the entire line instead of just 50% of it.