### PR TITLE
fix: address min/max validation message regression

### DIFF
--- a/test/validation.js
+++ b/test/validation.js
@@ -239,6 +239,17 @@ describe('validation tests', function () {
         .argv
     })
 
+    // address regression in: https://github.com/yargs/yargs/pull/740
+    it('custom failure message should be printed for both min and max constraints', function (done) {
+      yargs(['foo'])
+        .demand(0, 0, 'hey! give me a custom exit message')
+        .fail(function (msg) {
+          expect(msg).to.equal('hey! give me a custom exit message')
+          return done()
+        })
+        .argv
+    })
+
     it('interprets min relative to command', function () {
       var failureMsg
       yargs('lint')

--- a/yargs.js
+++ b/yargs.js
@@ -318,7 +318,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     }
 
     if (typeof keys === 'number') {
-      self.demandCommand(keys, max, msg)
+      self.demandCommand(keys, max, msg, msg)
     } else if (Array.isArray(keys)) {
       keys.forEach(function (key) {
         self.demandOption(key, msg)


### PR DESCRIPTION
@kumar303 pointed out a regression we accidentally introduced, in the process of reworking the command logic.

@kumar303, thanks for appreciating the nice CHANGELOG, we owe it to the [standard-version](https://github.com/conventional-changelog/standard-version) project which grew out of @nexdrew and my work at npm and on yargs.