### PR TITLE
docs: remove demand examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,12 +1081,12 @@ require('yargs')
     'run': {
       alias: 'r',
       describe: 'run your program',
-      demand: true
+      demandOption: true
     },
     'path': {
       alias: 'p',
       describe: 'provide a path to file',
-      demand: true
+      demandOption: true
     },
     'spec': {
       alias: 's',
@@ -1412,7 +1412,7 @@ var argv = require('yargs')
   .option('option', {
     alias: 'o',
     describe: "'tis a mighty fine option",
-    demand: true
+    demandOption: true
   })
   .command('run', "Arrr, ya best be knowin' what yer doin'")
   .example('$0 run foo', "shiver me timbers, here's an example for ye")
@@ -1529,7 +1529,7 @@ For example:
 var argv = require('yargs')
     .option('f', {
         alias: 'file',
-        demand: true,
+        demandOption: true,
         default: '/etc/passwd',
         describe: 'x marks the spot',
         type: 'string'
@@ -1558,7 +1558,7 @@ var argv = require('yargs')
     .options({
       'f': {
         alias: 'file',
-        demand: true,
+        demandOption: true,
         default: '/etc/passwd',
         describe: 'x marks the spot',
         type: 'string'

--- a/yargs.js
+++ b/yargs.js
@@ -517,6 +517,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
       var demand = opt.demand || opt.required || opt.require
 
+      // deprecated, use 'demandOption' instead
       if (demand) {
         self.demand(key, demand)
       }


### PR DESCRIPTION
Replaces `demand` in examples with `demandOption`. Closes #771.