### PR TITLE
fix: context should override parsed argv

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -768,6 +768,14 @@ describe('yargs dsl tests', function () {
       a1.foo.should.equal('bar')
       a1.context.should.equal('look at me go!')
     })
+
+    // see https://github.com/yargs/yargs/issues/724
+    it('overrides parsed value of argv with context object', function () {
+      var a1 = yargs.parse('-x=33', {
+        x: 42
+      })
+      a1.x.should.equal(42)
+    })
   })
 
   // yargs.parse(['foo', '--bar'], function (err, argv, output) {}

--- a/yargs.js
+++ b/yargs.js
@@ -935,7 +935,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     options.configuration = pkgUp()['yargs'] || {}
     const parsed = Parser.detailed(args, options)
     var argv = parsed.argv
-    if (parseContext) argv = assign(parseContext, argv)
+    if (parseContext) argv = assign(argv, parseContext)
     var aliases = parsed.aliases
 
     argv.$0 = self.$0


### PR DESCRIPTION
BREAKING CHANGE: context now takes precedence over argv

----
context object should take precedence over parsed values in argv.

fixes: #724 

CC: @scriptdaemon I think this is better behavior for writing chat-bots using yargs.