### PR TITLE
fix: pull in yargs-parser with modified env precedence

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "string-width": "^1.0.2",
     "which-module": "^1.0.0",
     "y18n": "^3.2.1",
-    "yargs-parser": "^4.2.1"
+    "yargs-parser": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
BREAKING CHANGE: environment variables now take precedence over config files.

fixes: #627 


CC: @addaleax, @jaridmargolin