### PR TITLE
fix: running parse() multiple failed when help() enabled

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -747,6 +747,21 @@ describe('Command', function () {
     counter.should.equal(2)
   })
 
+  // addresses: https://github.com/yargs/yargs/issues/776
+  it('allows command handler to be invoked repeatedly when help is enabled', function (done) {
+    var counter = 0
+    var y = yargs([])
+      .command('foo', 'the foo command', {}, function (argv) {
+        counter++
+      })
+      .help()
+    y.parse(['foo'], function () {})
+    y.parse(['foo'], function () {
+      counter.should.equal(2)
+      return done()
+    })
+  })
+
   // addresses https://github.com/yargs/yargs/issues/522
   it('does not require builder function to return', function () {
     var argv = yargs('yo')

--- a/yargs.js
+++ b/yargs.js
@@ -957,7 +957,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         // consider any multi-char helpOpt alias as a valid help command
         // unless all helpOpt aliases are single-char
         // note that parsed.aliases is a normalized bidirectional map :)
-        var helpCmds = [helpOpt].concat(aliases[helpOpt])
+        var helpCmds = [helpOpt].concat(aliases[helpOpt] || [])
         var multiCharHelpCmds = helpCmds.filter(function (k) {
           return k.length > 1
         })


### PR DESCRIPTION
there was a bug that caused an exception to be raised when `parse()` was called multiple times on the same yargs instance if `help()` is enabled.

fixes #776 