### PR TITLE
fix: extending config files breaks on node 0.10

### DIFF
--- a/lib/apply-extends.js
+++ b/lib/apply-extends.js
@@ -12,7 +12,7 @@ function checkForCircularExtends (path) {
 }
 
 function getPathToDefaultConfig (cwd, pathToExtend) {
-  return path.isAbsolute(pathToExtend) ? pathToExtend : path.join(cwd, pathToExtend)
+  return path.resolve(cwd, pathToExtend)
 }
 
 function applyExtends (config, cwd, subKey) {


### PR DESCRIPTION
issue from #779 

path.isAbsolute() not supported in node 0.10
use path.resolve() instead as mentioned in discussion in issue