### PR TITLE
fix: positional arguments of sub-command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-root = true
-
-[*.js]
-end_of_line = lf
-indent_style = space
-indent_size = 2
-insert_final_newline = true

--- a/lib/command.js
+++ b/lib/command.js
@@ -224,9 +224,10 @@ module.exports = function (yargs, usage, validation) {
 
     // we apply validation post-hoc, so that custom
     // checks get passed populated positional arguments.
-    yargs._runValidation(innerArgv, aliases, positionalMap, yargs.parsed.error)
+    if (!yargs._hasOutput()) yargs._runValidation(innerArgv, aliases, positionalMap, yargs.parsed.error)
 
     if (commandHandler.handler && !yargs._hasOutput()) {
+      yargs._setHasOutput()
       commandHandler.handler(innerArgv)
     }
 

--- a/test/command.js
+++ b/test/command.js
@@ -1024,6 +1024,19 @@ describe('Command', function () {
           })
       })
 
+      // address https://github.com/yargs/yargs/issues/795
+      it('does not fail strict check due to postional command arguments in nested commands', function (done) {
+        yargs()
+          .strict()
+          .command('hi', 'The hi command', function (yargs) {
+            yargs.command('ben <age>', 'ben command', function () {}, function () {})
+          })
+          .parse('hi ben 99', function (err, argv, output) {
+            expect(err).to.equal(null)
+            return done()
+          })
+      })
+
       it('does not fire command if validation fails', function (done) {
         var commandRun = false
         yargs()

--- a/yargs.js
+++ b/yargs.js
@@ -897,6 +897,10 @@ function Yargs (processArgs, cwd, parentRequire) {
     return hasOutput
   }
 
+  self._setHasOutput = function () {
+    hasOutput = true
+  }
+
   var recommendCommands
   self.recommendCommands = function (recommend) {
     argsert('[boolean]', [recommend], arguments.length)


### PR DESCRIPTION
fixes: #795 

positional arguments in sub-commands aren't white-listed for `strict()`.