### PR TITLE
docs: env vars now take precedence over config file/objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,8 +1203,8 @@ then all env vars will be applied to argv.
 Program arguments are defined in this order of precedence:
 
 1. Command line args
-2. Config file
-3. Env var
+2. Env vars
+3. Config file/objects
 4. Configured defaults
 
 ```js


### PR DESCRIPTION
Just update the README/docs to reflect the new order.

See yargs/yargs-parser#81 and #787