### PR TITLE
fix: --help with default command should print top-level help

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -2521,4 +2521,28 @@ describe('usage tests', function () {
       ])
     })
   })
+
+  describe('default command', function () {
+    it('--help should display top-level help with no command given', function () {
+      var r = checkUsage(function () {
+        return yargs('--help')
+          .command(['list [pattern]', 'ls', '*'], 'List key-value pairs for pattern', {}, function () {})
+          .command('get <key>', 'Get value for key', {}, function () {})
+          .command('set <key> [value]', 'Set value for key', {}, function () {})
+          .help()
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  list [pattern]     List key-value pairs for pattern    [default] [aliases: ls]',
+        '  get <key>          Get value for key',
+        '  set <key> [value]  Set value for key',
+        '',
+        'Options:',
+        '  --help  Show help                                                    [boolean]',
+        ''
+      ])
+    })
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -1011,7 +1011,7 @@ function Yargs (processArgs, cwd, parentRequire) {
           self.showCompletionScript()
           self.exit(0)
         }
-      } else if (command.hasDefaultCommand()) {
+      } else if (command.hasDefaultCommand() && !argv[helpOpt]) {
         setPlaceholderKeys(argv)
         return command.runCommand(null, self, parsed)
       }


### PR DESCRIPTION
Fixes #803, see discussion there.

First wrote the failing test, then included the fix.