### PR TITLE
fix: populating placeholder arguments broke validation

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -89,7 +89,7 @@ module.exports = function (yargs, usage, y18n) {
     var missing = null
 
     Object.keys(demandedOptions).forEach(function (key) {
-      if (!argv.hasOwnProperty(key)) {
+      if (!argv.hasOwnProperty(key) || typeof argv[key] === 'undefined') {
         missing = missing || {}
         missing[key] = demandedOptions[key]
       }

--- a/test/command.js
+++ b/test/command.js
@@ -1301,7 +1301,7 @@ describe('Command', function () {
   })
 
   // addresses: https://github.com/yargs/yargs/issues/819
-  it('should apply strict argument validation to inner commands', function () {
+  it('should kick along [demand] configuration to commands', function () {
     var called = false
     var r = checkOutput(function () {
       yargs('foo')

--- a/test/command.js
+++ b/test/command.js
@@ -1299,4 +1299,22 @@ describe('Command', function () {
       })
     })
   })
+
+  // addresses: https://github.com/yargs/yargs/issues/819
+  it('should apply strict argument validation to inner commands', function () {
+    var called = false
+    var r = checkOutput(function () {
+      yargs('foo')
+        .command('foo', 'foo command', function () {}, function (argv) {
+          called = true
+        })
+        .option('bar', {
+          describe: 'a foo command',
+          demand: true
+        })
+        .argv
+    })
+    called.should.equal(false)
+    r.errors.should.match(/Missing required argument/)
+  })
 })


### PR DESCRIPTION
yikes, because we populate placeholder keys for arguments it broke `demand` logic in commands.