### PR TITLE
Number commands don't work

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -1317,4 +1317,14 @@ describe('Command', function () {
     called.should.equal(false)
     r.errors.should.match(/Missing required argument/)
   })
+
+  it('should support numeric commands', function () {
+    var output = []
+    yargs('1')
+      .command('1', 'numeric command', function (yargs) {
+        output.push('1')
+      })
+      .argv
+    output.should.include('1')
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -983,7 +983,8 @@ function Yargs (processArgs, cwd, parentRequire) {
         var handlerKeys = command.getCommands()
         if (handlerKeys.length) {
           var firstUnknownCommand
-          for (var i = 0, cmd; (cmd = argv._[i]) !== undefined; i++) {
+          for (var i = 0, cmd; argv._[i] !== undefined; i++) {
+            cmd = String(argv._[i])
             if (~handlerKeys.indexOf(cmd) && cmd !== completionCommand) {
               setPlaceholderKeys(argv)
               return command.runCommand(cmd, self, parsed)


### PR DESCRIPTION
casting argv._ elements back to string when evaluating for commands to
allow non-string commands to be correctly found and matched

Resolves https://github.com/yargs/yargs/issues/824