### PR TITLE
test: Made unit test passing with node-chakracore

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1823,8 +1823,14 @@ describe('yargs dsl tests', function () {
     it('allows an error to be handled by fail() handler', function () {
       var msg
       var err
+      var jsonErrMessage
       yargs('--json invalid')
         .coerce('json', function (arg) {
+          try {
+            JSON.parse(arg)
+          } catch (err) {
+            jsonErrMessage = err.message
+          }
           return JSON.parse(arg)
         })
         .fail(function (m, e) {
@@ -1832,7 +1838,7 @@ describe('yargs dsl tests', function () {
           err = e
         })
         .argv
-      expect(msg).to.match(/Unexpected token i/)
+      expect(msg).to.equal(jsonErrMessage)
       expect(err).to.exist
     })
 


### PR DESCRIPTION
There was 1 unit test that were failing with node-chakracore because of error message difference between v8 and chakracore. Added logic to generate error on fly and use that to compare the error message.

Ref: nodejs/node-chakracore#189