### PR TITLE
Allow command to override global strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1809,7 +1809,7 @@ Specify --help for available options
 Specifies either a single option key (string), or an array of options.
 If any of the options is present, yargs validation is skipped.
 
-.strict([enabled=true], [global=true])
+.strict([enabled=true])
 ---------
 
 Any command-line argument given that is not demanded, or does not have a

--- a/README.md
+++ b/README.md
@@ -1809,7 +1809,7 @@ Specify --help for available options
 Specifies either a single option key (string), or an array of options.
 If any of the options is present, yargs validation is skipped.
 
-.strict([global=true])
+.strict([enabled=true], [global=true])
 ---------
 
 Any command-line argument given that is not demanded, or does not have a

--- a/test/command.js
+++ b/test/command.js
@@ -1037,6 +1037,19 @@ describe('Command', function () {
           })
       })
 
+      it('allows a command to override global`', function () {
+        var commandCalled = false
+        yargs('hi')
+         .strict(true)
+         .command('hi', 'The hi command', function (innerYargs) {
+           commandCalled = true
+           innerYargs.strict(false, false).getStrict().should.be.false
+         })
+        yargs.getStrict().should.be.true
+        yargs.argv // parse and run command
+        commandCalled.should.be.true
+      })
+
       it('does not fire command if validation fails', function (done) {
         var commandRun = false
         yargs()

--- a/test/command.js
+++ b/test/command.js
@@ -1003,7 +1003,7 @@ describe('Command', function () {
       it('does not apply strict globally when passed value of `false`', function () {
         var commandCalled = false
         yargs('hi')
-          .strict(false)
+          .strict(true, false)
           .command('hi', 'The hi command', function (innerYargs) {
             commandCalled = true
             innerYargs.getStrict().should.be.false
@@ -1040,10 +1040,10 @@ describe('Command', function () {
       it('allows a command to override global`', function () {
         var commandCalled = false
         yargs('hi')
-         .strict(true)
+         .strict()
          .command('hi', 'The hi command', function (innerYargs) {
            commandCalled = true
-           innerYargs.strict(false, false).getStrict().should.be.false
+           innerYargs.strict(false).getStrict().should.be.false
          })
         yargs.getStrict().should.be.true
         yargs.argv // parse and run command

--- a/test/command.js
+++ b/test/command.js
@@ -1000,19 +1000,6 @@ describe('Command', function () {
         commandCalled.should.be.true
       })
 
-      it('does not apply strict globally when passed value of `false`', function () {
-        var commandCalled = false
-        yargs('hi')
-          .strict(true, false)
-          .command('hi', 'The hi command', function (innerYargs) {
-            commandCalled = true
-            innerYargs.getStrict().should.be.false
-          })
-        yargs.getStrict().should.be.true
-        yargs.argv // parse and run command
-        commandCalled.should.be.true
-      })
-
       // address regression introduced in #766, thanks @nexdrew!
       it('does not fail strict check due to postional command arguments', function (done) {
         yargs()

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -225,7 +225,7 @@ describe('yargs dsl tests', function () {
         .implies('foo', 'snuh')
         .conflicts('qux', 'xyzzy')
         .group('foo', 'Group:')
-        .strict(false)
+        .strict(true, false)
         .exitProcess(false)  // defaults to true.
         .global('foo', false)
         .global('qux', false)

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -225,7 +225,6 @@ describe('yargs dsl tests', function () {
         .implies('foo', 'snuh')
         .conflicts('qux', 'xyzzy')
         .group('foo', 'Group:')
-        .strict(true, false)
         .exitProcess(false)  // defaults to true.
         .global('foo', false)
         .global('qux', false)
@@ -266,7 +265,6 @@ describe('yargs dsl tests', function () {
       expect(y.getValidationInstance().getConflicting()).to.deep.equal({})
       expect(y.getCommandInstance().getCommandHandlers()).to.deep.equal({})
       expect(y.getExitProcess()).to.equal(false)
-      expect(y.getStrict()).to.equal(false)
       expect(y.getDemandedOptions()).to.deep.equal({})
       expect(y.getDemandedCommands()).to.deep.equal({})
       expect(y.getGroups()).to.deep.equal({})

--- a/yargs.js
+++ b/yargs.js
@@ -696,9 +696,9 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   var strict = false
   var strictGlobal = false
-  self.strict = function (global) {
-    argsert('[boolean]', [global], arguments.length)
-    strict = true
+  self.strict = function (global, enabled) {
+    argsert('[boolean] [boolean]', [global], arguments.length)
+    strict = enabled !== false
     strictGlobal = global !== false
     return self
   }

--- a/yargs.js
+++ b/yargs.js
@@ -126,7 +126,6 @@ function Yargs (processArgs, cwd, parentRequire) {
     command = command ? command.reset() : Command(self, usage, validation)
     if (!completion) completion = Completion(self, usage, command)
 
-    if (!strictGlobal) strict = false
     completionCommand = null
     output = ''
     exitError = null
@@ -695,11 +694,9 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   var strict = false
-  var strictGlobal = false
-  self.strict = function (enabled, global) {
-    argsert('[boolean] [boolean]', [enabled, global], arguments.length)
+  self.strict = function (enabled) {
+    argsert('[boolean]', [enabled], arguments.length)
     strict = enabled !== false
-    strictGlobal = global !== false
     return self
   }
   self.getStrict = function () {

--- a/yargs.js
+++ b/yargs.js
@@ -696,8 +696,8 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   var strict = false
   var strictGlobal = false
-  self.strict = function (global, enabled) {
-    argsert('[boolean] [boolean]', [global], arguments.length)
+  self.strict = function (enabled, global) {
+    argsert('[boolean] [boolean]', [enabled, global], arguments.length)
     strict = enabled !== false
     strictGlobal = global !== false
     return self


### PR DESCRIPTION
This adds a second argument to `strict` to disable it for a command.