### PR TITLE
Enable dynamic keys for config extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,41 @@ $ node test.js
   '$0': 'test.js' }
 ```
 
-Note that a configuration object may extend from a JSON file using the `"extends"` property. When doing so, the `"extends"` value should be a path (relative or absolute) to the extended JSON file.
+A configuration object may extend from a JSON file using the `"extends"` property. 
+When doing so, the `"extends"` value should be a path (relative or absolute) to the cwd.
+`"extendsKey"` can be used to further specify a single property to extend from.
+
+```js
+// config.json
+var argv = require('yargs')
+  .config({
+    foo: 1,
+    extends: "./node_modules/lib/config.json",
+    extendsKey: "read"
+  })
+  .argv
+```
+
+```json
+// node_modules/lib/config.json
+{
+  "ignored": {
+    "notUsed": "zed"
+  },
+  "read": {
+    "foo": 2,
+    "bar": 10
+  }
+}
+```
+
+Resulting argv configuration:
+```json
+{
+  "foo": 1,
+  "bar": 10
+}
+```
 
 <a name="conflicts"></a>.conflicts(x, y)
 ----------------------------------------------
@@ -1679,7 +1713,8 @@ as a configuration object.
 `cwd` can optionally be provided, the package.json will be read
 from this location.
 
-Note that a configuration stanza in package.json may extend from an identically keyed stanza in another package.json file using the `"extends"` property. When doing so, the `"extends"` value should be a path (relative or absolute) to the extended package.json file.
+You can use the same `"extends"` and `"extendsKey"` functionality as [`config()`](#config).
+When doing so, the `"extends"` value should be a path (relative or absolute) to the extended package.json file.
 
 .recommendCommands()
 ---------------------------

--- a/lib/apply-extends.js
+++ b/lib/apply-extends.js
@@ -9,13 +9,19 @@ function checkForCircularExtends (path) {
   if (previouslyVisitedConfigs.indexOf(path) > -1) {
     throw new YError("Circular extended configurations: '" + path + "'.")
   }
+
+  previouslyVisitedConfigs.push(path)
 }
 
 function getPathToDefaultConfig (cwd, pathToExtend) {
   return path.resolve(cwd, pathToExtend)
 }
 
-function applyExtends (config, cwd, subKey) {
+function resetVisitedConfigs () {
+  previouslyVisitedConfigs = []
+}
+
+function applyExtends (config, cwd) {
   var defaultConfig = {}
 
   if (config.hasOwnProperty('extends')) {
@@ -23,17 +29,19 @@ function applyExtends (config, cwd, subKey) {
 
     checkForCircularExtends(pathToDefault)
 
-    previouslyVisitedConfigs.push(pathToDefault)
     delete config.extends
 
     defaultConfig = JSON.parse(fs.readFileSync(pathToDefault, 'utf8'))
-    if (subKey) {
-      defaultConfig = defaultConfig[subKey] || {}
+
+    if (config.hasOwnProperty('extendsKey')) {
+      defaultConfig = defaultConfig[config.extendsKey] || {}
+      delete config.extendsKey
     }
-    defaultConfig = applyExtends(defaultConfig, path.dirname(pathToDefault), subKey)
+
+    defaultConfig = applyExtends(defaultConfig, path.dirname(pathToDefault))
   }
 
-  previouslyVisitedConfigs = []
+  resetVisitedConfigs()
 
   return assign(defaultConfig, config)
 }

--- a/test/fixtures/extends/dynamic/ack.json
+++ b/test/fixtures/extends/dynamic/ack.json
@@ -1,0 +1,5 @@
+{
+  "b": 123,
+  "extends": "./bar.json",
+  "extendsKey": "readHere"
+}

--- a/test/fixtures/extends/dynamic/bar.json
+++ b/test/fixtures/extends/dynamic/bar.json
@@ -1,0 +1,8 @@
+{
+  "ignore": {
+    "foo": "this"
+  },
+  "readHere": {
+    "c": 45
+  }
+}

--- a/test/fixtures/extends/packageA/package.json
+++ b/test/fixtures/extends/packageA/package.json
@@ -1,6 +1,7 @@
 {
   "foo": {
     "a": 80,
-    "extends": "../packageB/package.json"
+    "extends": "../packageB/package.json",
+    "extendsKey": "bar"
   }
 }

--- a/test/fixtures/extends/packageB/package.json
+++ b/test/fixtures/extends/packageB/package.json
@@ -1,5 +1,5 @@
 {
-  "foo": {
+  "bar": {
     "a": 90,
     "b": "riffiwobbles"
   }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1189,7 +1189,7 @@ describe('yargs dsl tests', function () {
         }).to.throw(YError)
       })
 
-      it('handles aboslute paths', function () {
+      it('handles absolute paths', function () {
         var absolutePath = path.join(process.cwd(), 'test', 'fixtures', 'extends', 'config_1.json')
 
         var argv = yargs
@@ -1202,6 +1202,31 @@ describe('yargs dsl tests', function () {
         argv.a.should.equal(2)
         argv.b.should.equal(22)
         argv.z.should.equal(15)
+      })
+
+      it('handles dynamic keys to read from', function () {
+        var argv = yargs
+          .config({
+            extends: './test/fixtures/extends/dynamic/ack.json',
+            a: 1
+          })
+          .argv
+
+        argv.a.should.equal(1)
+        argv.b.should.equal(123)
+        argv.c.should.equal(45)
+      })
+
+      it('ignores extends keywords in resulting config', function () {
+        var argv = yargs
+          .config({
+            extends: './test/fixtures/extends/dynamic/ack.json',
+            a: 1
+          })
+          .argv
+
+        expect(argv.extends).to.not.exist
+        expect(argv.extendsKey).to.not.exist
       })
     })
   })

--- a/yargs.js
+++ b/yargs.js
@@ -479,7 +479,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     // If an object exists in the key, add it to options.configObjects
     if (obj[key] && typeof obj[key] === 'object') {
-      conf = applyExtends(obj[key], path || cwd, key)
+      conf = applyExtends(obj[key], path || cwd)
       options.configObjects = (options.configObjects || []).concat(conf)
     }
 


### PR DESCRIPTION
This is an option to resolve #843. Would involve using another reserved keyword, `extendsKey`.