### PR TITLE
fix: we shouldn't output help if we've printed a prior help-like message

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -346,8 +346,9 @@ describe('yargs dsl tests', function () {
         .help()
         .recommendCommands()
 
-      parser.parse('boat help', {}, function (_err, argv, output) {
+      parser.parse('boat help', {}, function (err, _argv, output) {
         // it should not have printed the help text twice!
+        err.message.should.equal('Did you mean goat?')
         output.split('Commands:').length.should.equal(2)
         return done()
       })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -339,6 +339,20 @@ describe('yargs dsl tests', function () {
       r.errors[1].should.match(/Did you mean goat/)
     })
 
+    // see: https://github.com/yargs/yargs/issues/822
+    it('does not print help message if recommendation has been made', function (done) {
+      const parser = yargs()
+        .command('goat')
+        .help()
+        .recommendCommands()
+
+      parser.parse('boat help', {}, function (_err, argv, output) {
+        // it should not have printed the help text twice!
+        output.split('Commands:').length.should.equal(2)
+        return done()
+      })
+    })
+
     it("skips executing top-level command if builder's help is executed", function () {
       var r = checkOutput(function () {
         yargs(['blerg', '-h'])

--- a/yargs.js
+++ b/yargs.js
@@ -1036,21 +1036,24 @@ function Yargs (processArgs, cwd, parentRequire) {
       }
 
       // Handle 'help' and 'version' options
-      Object.keys(argv).forEach(function (key) {
-        if (key === helpOpt && argv[key]) {
-          if (exitProcess) setBlocking(true)
+      // if we haven't already output help!
+      if (!hasOutput) {
+        Object.keys(argv).forEach(function (key) {
+          if (key === helpOpt && argv[key]) {
+            if (exitProcess) setBlocking(true)
 
-          skipValidation = true
-          self.showHelp('log')
-          self.exit(0)
-        } else if (key === versionOpt && argv[key]) {
-          if (exitProcess) setBlocking(true)
+            skipValidation = true
+            self.showHelp('log')
+            self.exit(0)
+          } else if (key === versionOpt && argv[key]) {
+            if (exitProcess) setBlocking(true)
 
-          skipValidation = true
-          usage.showVersion()
-          self.exit(0)
-        }
-      })
+            skipValidation = true
+            usage.showVersion()
+            self.exit(0)
+          }
+        })
+      }
 
       // Check if any of the options to skip validation were provided
       if (!skipValidation && options.skipValidation.length > 0) {


### PR DESCRIPTION
we were accidentally printing the help text twice, if recommendations were made and `exit = false`.

```bash
Commands:
  goat

Options:
  --help  Show help                                                                        [boolean]

Did you mean goat?
Commands:
  goat

Options:
  --help  Show help                                                                        [boolean]
```

Let's not do this, it looks weird!

fixes #822 