### PR TITLE
fix: positional arguments now work if no handler is provided to inner command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
 after_success: npm run coverage
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "6"
   - "node"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
     - nodejs_version: "4"
     - nodejs_version: "6"
+    - nodejs_version: "7"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/command.js
+++ b/lib/command.js
@@ -15,6 +15,8 @@ module.exports = function (yargs, usage, validation) {
   var defaultCommand
   self.addHandler = function (cmd, description, builder, handler) {
     var aliases = []
+    handler = handler || function () {}
+
     if (Array.isArray(cmd)) {
       aliases = cmd.slice(1)
       cmd = cmd[0]

--- a/test/command.js
+++ b/test/command.js
@@ -409,7 +409,7 @@ describe('Command', function () {
       var handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
-      expect(handlers.foo.handler).to.equal(undefined)
+      expect(typeof handlers.foo.handler).to.equal('function')
       var commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.describe, isDefault, aliases])
     })
@@ -1337,6 +1337,20 @@ describe('Command', function () {
         expect(err).to.equal(null)
         commandCalled.should.equal(false)
         argv._.should.eql(['bar', 'foo'])
+      })
+  })
+
+  // see: https://github.com/yargs/yargs/issues/861 phew! that's an edge-case.
+  it('should allow positional arguments for inner commands in strict mode, when no handler is provided', () => {
+    yargs()
+      .command('foo', 'outer command', (yargs) => {
+        yargs.command('bar [optional]', 'inner command')
+      })
+      .strict()
+      .parse('foo bar 33', function (err, argv) {
+        expect(err).to.equal(null)
+        argv.optional.should.equal(33)
+        argv._.should.eql(['foo', 'bar'])
       })
   })
 })


### PR DESCRIPTION
#861 turned out to be due to an edge-case when using inner-commands with no handler; a reasonable fix seems to be to simply default handlers to a noop function when no handler is provided.

fixes #861 