### PR TITLE
chore: upgrade yargs-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1938,7 +1938,7 @@ parsing tricks
 stop parsing
 ------------
 
-Use `--` to stop parsing flags and stuff the remainder into `argv._`.
+Use `--` to stop parsing flags and stuff the remainder into `argv['--']`.
 
     $ node examples/reflect.js -a 1 -b 2 -- -c 3 -d 4
     { _: [ '-c', '3', '-d', '4' ],

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,4 +1,5 @@
 const objFilter = require('./obj-filter')
+const specialKeys = ['$0', '--', '_']
 
 // validation-type-stuff, missing params,
 // bad implications, custom checks.
@@ -131,7 +132,7 @@ module.exports = function (yargs, usage, y18n) {
     })
 
     Object.keys(argv).forEach(function (key) {
-      if (key !== '$0' && key !== '_' &&
+      if (specialKeys.indexOf(key) === -1 &&
         !descriptions.hasOwnProperty(key) &&
         !demandedOptions.hasOwnProperty(key) &&
         !positionalMap.hasOwnProperty(key) &&
@@ -167,7 +168,7 @@ module.exports = function (yargs, usage, y18n) {
     if (!Object.keys(options.choices).length) return
 
     Object.keys(argv).forEach(function (key) {
-      if (key !== '$0' && key !== '_' &&
+      if (specialKeys.indexOf(key) === -1 &&
         options.choices.hasOwnProperty(key)) {
         [].concat(argv[key]).forEach(function (value) {
           // TODO case-insensitive configurability

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "string-width": "^1.0.2",
     "which-module": "^1.0.0",
     "y18n": "^3.2.1",
-    "yargs-parser": "^5.0.0"
+    "yargs-parser": "^6.0.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1985,6 +1985,16 @@ describe('yargs dsl tests', function () {
       expect(err).to.exist
     })
   })
+
+  describe('stop parsing', () => {
+    it('populates "--" with unparsed arguments after "--"', () => {
+      const argv = yargs.parse('--foo 33 --bar=99 -- --grep=foobar')
+      argv.foo.should.equal(33)
+      argv.bar.should.equal(99)
+      argv['--'].length.should.equal(1)
+      argv['--'][0].should.equal('--grep=foobar')
+    })
+  })
 })
 
 describe('yargs context', function () {


### PR DESCRIPTION
BREAKING CHANGE: environment variables will now override config files, '--' is now populated rather than '_' when parsing is stopped.