### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### BREAKING CHANGES
 
-* environment variables now override config files in order of precedence.
-* '--' is now populated rather than '_' when parsing is stopped.
 * extends functionality now always loads the JSON provided, rather than reading from a specific key
 * Node 4+ is now required; this will allow us to start updating our dependencies.
 * the first argument to strict() is now used to enable/disable its functionality, rather than controlling whether or not it is global.

--- a/README.md
+++ b/README.md
@@ -1938,7 +1938,7 @@ parsing tricks
 stop parsing
 ------------
 
-Use `--` to stop parsing flags and stuff the remainder into `argv['--']`.
+Use `--` to stop parsing flags and stuff the remainder into `argv._`.
 
     $ node examples/reflect.js -a 1 -b 2 -- -c 3 -d 4
     { _: [ '-c', '3', '-d', '4' ],

--- a/package.json
+++ b/package.json
@@ -12,19 +12,19 @@
     "LICENSE"
   ],
   "dependencies": {
-    "camelcase": "^3.0.0",
+    "camelcase": "^4.1.0",
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
     "get-caller-file": "^1.0.1",
-    "os-locale": "^1.4.0",
-    "read-pkg-up": "^1.0.1",
+    "os-locale": "^2.0.0",
+    "read-pkg-up": "^2.0.0",
     "require-directory": "^2.1.1",
     "require-main-filename": "^1.0.1",
     "set-blocking": "^2.0.0",
-    "string-width": "^1.0.2",
-    "which-module": "^1.0.0",
+    "string-width": "^2.0.0",
+    "which-module": "^2.0.0",
     "y18n": "^3.2.1",
-    "yargs-parser": "^6.0.1"
+    "yargs-parser": "^7.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -38,7 +38,7 @@
     "nyc": "^10.3.0",
     "rimraf": "^2.5.0",
     "standard": "^8.6.0",
-    "standard-version": "^3.0.0",
+    "standard-version": "^4.0.0",
     "which": "^1.2.9",
     "yargs-test-extends": "^1.0.1"
   },
@@ -70,12 +70,5 @@
   "license": "MIT",
   "engine": {
     "node": ">=0.10"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "string-width",
-      "read-pkg-up",
-      "camelcase"
-    ]
   }
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1987,12 +1987,12 @@ describe('yargs dsl tests', function () {
   })
 
   describe('stop parsing', () => {
-    it('populates "--" with unparsed arguments after "--"', () => {
+    it('populates argv._ with unparsed arguments after "--"', () => {
       const argv = yargs.parse('--foo 33 --bar=99 -- --grep=foobar')
       argv.foo.should.equal(33)
       argv.bar.should.equal(99)
-      argv['--'].length.should.equal(1)
-      argv['--'][0].should.equal('--grep=foobar')
+      argv._.length.should.equal(1)
+      argv._[0].should.equal('--grep=foobar')
     })
   })
 })


### PR DESCRIPTION
we can upgrade a ton of dependencies now that we require Node 4.

NOTE: we've reverted one of the breaking changes that was planned for `8.x`, based on a discussion at work today.