### PR TITLE
Fix #849 - make choices correctly observe demandOption setting

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -172,7 +172,8 @@ module.exports = function (yargs, usage, y18n) {
         options.choices.hasOwnProperty(key)) {
         [].concat(argv[key]).forEach(function (value) {
           // TODO case-insensitive configurability
-          if (options.choices[key].indexOf(value) === -1) {
+          if (options.choices[key].indexOf(value) === -1 &&
+              value !== undefined) {
             invalid[key] = (invalid[key] || []).concat(value)
           }
         })

--- a/test/validation.js
+++ b/test/validation.js
@@ -584,6 +584,90 @@ describe('validation tests', function () {
         })
         .argv
     })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('allows demandOption with value true in options shorthand for hidden option', function (done) {
+      yargs('one -c 1')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'c': {
+                demandOption: true,
+                choices: ['1', '2']
+              }
+            })
+        }, function (argv) {
+          expect.fail()
+        })
+        .fail(function (msg) {
+          msg.should.equal('Invalid values:\n  Argument: c, Given: 1, Choices: "1", "2"')
+          return done()
+        })
+        .argv
+    })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('allows demandOption with value false in options shorthand for hidden option', function () {
+      yargs('one')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'c': {
+                demandOption: false,
+                choices: ['1', '2']
+              }
+            })
+        }, function (argv) {
+          argv._[0].should.equal('one')
+        })
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+    })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('allows demandOption with value true in options shorthand for non-hidden option', function (done) {
+      yargs('one -c 1')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'c': {
+                describe: 'C',
+                demandOption: true,
+                choices: ['1', '2']
+              }
+            })
+        }, function (argv) {
+          expect.fail()
+        })
+        .fail(function (msg) {
+          msg.should.equal('Invalid values:\n  Argument: c, Given: 1, Choices: "1", "2"')
+          return done()
+        })
+        .argv
+    })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('allows demandOption with value false in options shorthand for non-hidden option', function () {
+      yargs('one')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'c': {
+                describe: 'C',
+                demandOption: false,
+                choices: ['1', '2']
+              }
+            })
+        }, function (argv) {
+          argv._[0].should.equal('one')
+        })
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+    })
   })
 
   describe('demandCommand', function () {

--- a/test/validation.js
+++ b/test/validation.js
@@ -586,8 +586,29 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('allows demandOption with value true in options shorthand for hidden option', function (done) {
-      yargs('one -c 1')
+    it('allows demandOption with value true in options shorthand for hidden option', function () {
+      yargs('one -a 10 marsupial')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'a': {
+                demandOption: true,
+                choices: [10, 20]
+              }
+            })
+        }, function (argv) {
+          argv._[0].should.equal('one')
+          argv.a.should.equal(10)
+        })
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+    })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('should fail demandOption with value true in options shorthand for hidden option', function (done) {
+      yargs('one -a 10 marsupial')
         .command('one', 'level one', function (yargs) {
           yargs
             .options({
@@ -600,7 +621,7 @@ describe('validation tests', function () {
           expect.fail()
         })
         .fail(function (msg) {
-          msg.should.equal('Invalid values:\n  Argument: c, Given: 1, Choices: "1", "2"')
+          msg.should.equal('Missing required argument: c')
           return done()
         })
         .argv
@@ -612,9 +633,9 @@ describe('validation tests', function () {
         .command('one', 'level one', function (yargs) {
           yargs
             .options({
-              'c': {
+              'a': {
                 demandOption: false,
-                choices: ['1', '2']
+                choices: [10, 20]
               }
             })
         }, function (argv) {
@@ -627,8 +648,30 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('allows demandOption with value true in options shorthand for non-hidden option', function (done) {
-      yargs('one -c 1')
+    it('allows demandOption with value true in options shorthand for non-hidden option', function () {
+      yargs('one -a 10 marsupial')
+        .command('one', 'level one', function (yargs) {
+          yargs
+            .options({
+              'a': {
+                describe: 'A',
+                demandOption: true,
+                choices: [10, 20]
+              }
+            })
+        }, function (argv) {
+          argv._[0].should.equal('one')
+          argv.a.should.equal(10)
+        })
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
+    })
+
+    // addresses: https://github.com/yargs/yargs/issues/849
+    it('should fail demandOption with value true in options shorthand for non-hidden option', function (done) {
+      yargs('one -a 10 marsupial')
         .command('one', 'level one', function (yargs) {
           yargs
             .options({
@@ -642,7 +685,7 @@ describe('validation tests', function () {
           expect.fail()
         })
         .fail(function (msg) {
-          msg.should.equal('Invalid values:\n  Argument: c, Given: 1, Choices: "1", "2"')
+          msg.should.equal('Missing required argument: c')
           return done()
         })
         .argv
@@ -654,10 +697,10 @@ describe('validation tests', function () {
         .command('one', 'level one', function (yargs) {
           yargs
             .options({
-              'c': {
-                describe: 'C',
+              'a': {
+                describe: 'A',
                 demandOption: false,
-                choices: ['1', '2']
+                choices: [10, 20]
               }
             })
         }, function (argv) {

--- a/yargs.js
+++ b/yargs.js
@@ -594,7 +594,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         self.normalize(key)
       }
 
-      if ('choices' in opt) {
+      if ('choices' in opt && (opt.demandOption || (!('demandOption' in opt) && (opt.describe || opt.description || opt.desc)))) {
         self.choices(key, opt.choices)
       }
 

--- a/yargs.js
+++ b/yargs.js
@@ -594,7 +594,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         self.normalize(key)
       }
 
-      if ('choices' in opt && (opt.demandOption || (!('demandOption' in opt) && (opt.describe || opt.description || opt.desc)))) {
+      if ('choices' in opt) {
         self.choices(key, opt.choices)
       }
 


### PR DESCRIPTION
Addresses #849.

Handles `options` map containing `choices` and a combination of `demandOption` and/or `describe`|`description`|`desc`. If `demandOption` is set to `false`, any `choices` values specified will not be required (`undefined` is okay).