### PR TITLE
feat: use process.argv0 where possible

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -32,21 +32,25 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   if (!cwd) cwd = process.cwd()
 
-  self.$0 = process.argv
-    .slice(0, 2)
-    .map(function (x, i) {
-      // ignore the node bin, specify this in your
-      // bin file with #!/usr/bin/env node
-      if (i === 0 && /\b(node|iojs)(\.exe)?$/.test(x)) return
-      var b = rebase(cwd, x)
-      return x.match(/^(\/|([a-zA-Z]:)?\\)/) && b.length < x.length ? b : x
-    })
-    .join(' ').trim()
+  if (process.argv0) {
+    self.$0 = process.argv0
+  } else {
+    self.$0 = process.argv
+      .slice(0, 2)
+      .map(function (x, i) {
+        // ignore the node bin, specify this in your
+        // bin file with #!/usr/bin/env node
+        if (i === 0 && /\b(node|iojs)(\.exe)?$/.test(x)) return
+        var b = rebase(cwd, x)
+        return x.match(/^(\/|([a-zA-Z]:)?\\)/) && b.length < x.length ? b : x
+      })
+      .join(' ').trim()
 
-  if (process.env._ !== undefined && process.argv[1] === process.env._) {
-    self.$0 = process.env._.replace(
-      path.dirname(process.execPath) + '/', ''
-    )
+    if (process.env._ !== undefined && process.argv[1] === process.env._) {
+      self.$0 = process.env._.replace(
+        path.dirname(process.execPath) + '/', ''
+      )
+    }
   }
 
   // use context object to keep track of resets, subcommand execution, etc


### PR DESCRIPTION
This commit adds support for using `process.argv0` where it is available (node 6.4+) as it is much more accurate in getting the command line that the user actually typed, rather than the binary name of the script being called (`process.argv[0]`).

The tests are failing right now because I haven't changed them - I wanted to float this feature to everyone before putting time in to change the tests. Please let me know your thoughts!

Hat-tip to @zkat for doing all the hard research 👍 ✨ 