### PR TITLE
Fix #899

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -310,9 +310,8 @@ module.exports = function (yargs, usage, y18n) {
     var args = Object.getOwnPropertyNames(argv)
 
     args.forEach(function (arg) {
-      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && // if there is a conflict defined for this key
-          argv[arg] && argv[conflicting[arg]]) // and both conflicting keys have been specified
-          {
+    // if there is a conflict defined for this key and both conflicting keys have been specified
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && argv[arg] && argv[conflicting[arg]]) {
         usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
       }
     })

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -310,7 +310,9 @@ module.exports = function (yargs, usage, y18n) {
     var args = Object.getOwnPropertyNames(argv)
 
     args.forEach(function (arg) {
-      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1) {
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && // if there is a conflict defined for this key
+          argv[arg] && argv[conflicting[arg]]) // and both conflicting keys have been specified
+          {
         usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
       }
     })

--- a/test/validation.js
+++ b/test/validation.js
@@ -158,6 +158,40 @@ describe('validation tests', function () {
         .argv
     })
 
+    it('should not fail if no conflicting arguments are provided and the .command()' +
+     'syntax is used (first conflicting option specified)', function () {
+      yargs(['command', '-f', '-c'])
+            .command('command')
+            .option('f', {
+              describe: 'a foo'
+            })
+            .option('b', {
+              describe: 'a bar'
+            })
+            .conflicts('f', 'b')
+            .fail(function (msg) {
+              expect.fail()
+            })
+            .argv
+    })
+
+    it('should not fail if no conflicting arguments are provided and the .command()' +
+     'syntax is used (second conflicting option specified)', function () {
+      yargs(['command', '-b', '-c'])
+            .command('command')
+            .option('f', {
+              describe: 'a foo'
+            })
+            .option('b', {
+              describe: 'a bar'
+            })
+            .conflicts('f', 'b')
+            .fail(function (msg) {
+              expect.fail()
+            })
+            .argv
+    })
+
     it('allows an object to be provided defining conflicting option pairs', function (done) {
       yargs(['-t', '-s'])
         .conflicts({


### PR DESCRIPTION
See description of the problem in #899 

I had to put in some code to ensure that the conflicting keys are actually specified before failing the command. I'm guessing there is some difference in how you build the argv object  depending on whether the `.command()` syntax was used which was causing this discrepancy

I added two new tests for this scenario. Hopefully I didn't break anything. Let me know your thoughts