### PR TITLE
fix: defaulting keys to 'undefined' interfered with conflicting key logic

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -310,9 +310,8 @@ module.exports = function (yargs, usage, y18n) {
     var args = Object.getOwnPropertyNames(argv)
 
     args.forEach(function (arg) {
-      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && // if there is a conflict defined for this key
-          argv[arg] && argv[conflicting[arg]]) // and both conflicting keys have been specified
-          {
+    // if there is a conflict defined for this key and both conflicting keys have been specified
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && argv[arg] && argv[conflicting[arg]]) {
         usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
       }
     })

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -310,7 +310,9 @@ module.exports = function (yargs, usage, y18n) {
     var args = Object.getOwnPropertyNames(argv)
 
     args.forEach(function (arg) {
-      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1) {
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && // if there is a conflict defined for this key
+          argv[arg] && argv[conflicting[arg]]) // and both conflicting keys have been specified
+          {
         usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
       }
     })

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -308,10 +308,10 @@ module.exports = function (yargs, usage, y18n) {
 
   self.conflicting = function (argv) {
     var args = Object.getOwnPropertyNames(argv)
-
     args.forEach(function (arg) {
-    // if there is a conflict defined for this key and both conflicting keys have been specified
-      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && argv[arg] && argv[conflicting[arg]]) {
+      // we default keys to 'undefined' that have been configured, we should not
+      // apply conflicting check unless they are a value other than 'undefined'.
+      if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && argv[arg] !== undefined && argv[conflicting[arg]] !== undefined) {
         usage.fail(__('Arguments %s and %s are mutually exclusive', arg, conflicting[arg]))
       }
     })

--- a/test/validation.js
+++ b/test/validation.js
@@ -158,6 +158,40 @@ describe('validation tests', function () {
         .argv
     })
 
+    it('should not fail if no conflicting arguments are provided and the .command()' +
+     'syntax is used (first conflicting option specified)', function () {
+      yargs(['command', '-f', '-c'])
+            .command('command')
+            .option('f', {
+              describe: 'a foo'
+            })
+            .option('b', {
+              describe: 'a bar'
+            })
+            .conflicts('f', 'b')
+            .fail(function (msg) {
+              expect.fail()
+            })
+            .argv
+    })
+
+    it('should not fail if no conflicting arguments are provided and the .command()' +
+     'syntax is used (second conflicting option specified)', function () {
+      yargs(['command', '-b', '-c'])
+            .command('command')
+            .option('f', {
+              describe: 'a foo'
+            })
+            .option('b', {
+              describe: 'a bar'
+            })
+            .conflicts('f', 'b')
+            .fail(function (msg) {
+              expect.fail()
+            })
+            .argv
+    })
+
     it('allows an object to be provided defining conflicting option pairs', function (done) {
       yargs(['-t', '-s'])
         .conflicts({

--- a/test/validation.js
+++ b/test/validation.js
@@ -158,38 +158,36 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('should not fail if no conflicting arguments are provided and the .command()' +
-     'syntax is used (first conflicting option specified)', function () {
+    it('should not fail if argument with conflict is provided, but not the argument it conflicts with', function () {
       yargs(['command', '-f', '-c'])
-            .command('command')
-            .option('f', {
-              describe: 'a foo'
-            })
-            .option('b', {
-              describe: 'a bar'
-            })
-            .conflicts('f', 'b')
-            .fail(function (msg) {
-              expect.fail()
-            })
-            .argv
+        .command('command')
+        .option('f', {
+          describe: 'a foo'
+        })
+        .option('b', {
+          describe: 'a bar'
+        })
+        .conflicts('f', 'b')
+        .fail(function (msg) {
+          expect.fail()
+        })
+        .argv
     })
 
-    it('should not fail if no conflicting arguments are provided and the .command()' +
-     'syntax is used (second conflicting option specified)', function () {
+    it('should not fail if conflicting argument is provided, without argument with conflict', function () {
       yargs(['command', '-b', '-c'])
-            .command('command')
-            .option('f', {
-              describe: 'a foo'
-            })
-            .option('b', {
-              describe: 'a bar'
-            })
-            .conflicts('f', 'b')
-            .fail(function (msg) {
-              expect.fail()
-            })
-            .argv
+          .command('command')
+          .option('f', {
+            describe: 'a foo'
+          })
+          .option('b', {
+            describe: 'a bar'
+          })
+          .conflicts('f', 'b')
+          .fail(function (msg) {
+            expect.fail()
+          })
+          .argv
     })
 
     it('allows an object to be provided defining conflicting option pairs', function (done) {
@@ -229,6 +227,28 @@ describe('validation tests', function () {
             return done()
           })
           .argv
+    })
+
+    it('should fail if alias of conflicting argument is provided', function (done) {
+      yargs(['-f', '--batman=99'])
+        .conflicts('f', 'b')
+        .alias('b', 'batman')
+        .fail(function (msg) {
+          msg.should.equal('Arguments f and b are mutually exclusive')
+          return done()
+        })
+        .argv
+    })
+
+    it('should fail if alias of argument with conflict is provided', function (done) {
+      yargs(['--foo', '-b'])
+        .conflicts('f', 'b')
+        .alias('foo', 'f')
+        .fail(function (msg) {
+          msg.should.equal('Arguments f and b are mutually exclusive')
+          return done()
+        })
+        .argv
     })
   })
 


### PR DESCRIPTION
made a couple slight tweaks to @dogboydog's work in https://github.com/yargs/yargs/pull/905

👋 @dogboydog thanks for the great work in #905, I just made a couple small tweaks to the tests and made it so we check for `undefined` rather than any `falsy` value, this way a conflicting key can be set to `false` and it will still trigger the conflict check.

fixes #899 