### PR TITLE
feat: enable .help() and .version() by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ require('yargs') // eslint-disable-line
     alias: 'v',
     default: false
   })
-  .help()
   .argv
 ```
+
+Run the example above with `--help` to see the help for the application.
 
 ## Table of Contents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -762,20 +762,16 @@ var yargs = require('yargs')(['--help'])
 -----------------------------------------
 .help([option | boolean])
 -----------------------------------------
-.help([option, [description | boolean]])
------------------------------------------
-.help([option, [description, [boolean]]])
+.help([option, [description]])
 -----------------------------------------
 
-Add an option (e.g. `--help`) and implicit command that displays the usage
-string and exits the process.
+Configure an (e.g. `--help`) and implicit command that displays the usage
+string and exits the process. By default yargs enables help on the `--help` option.
 
 If present, the `description` parameter customizes the description of
 the help option in the usage string.
 
-If a boolean argument is provided, it will enable or disable the use of an
-implicit command. The implicit command is enabled by default, but it can be
-disabled by passing `false`.
+If the boolean argument `false` is provided, it will disable `--help`.
 
 Note that any multi-char aliases (e.g. `help`) used for the help option will
 also be used for the implicit command. If there are no multi-char aliases (e.g.
@@ -787,13 +783,11 @@ If invoked without parameters, `.help()` will use `--help` as the option and
 Example:
 
 ```js
-var yargs = require("yargs")(['--help'])
+var yargs = require("yargs")(['--info'])
   .usage("$0 -operand1 number -operand2 number -operation [add|subtract]")
-  .help()
+  .help('info')
   .argv
 ```
-
-Later on, `argv` can be retrieved with `yargs.argv`.
 
 <a name="implies"></a>.implies(x, y)
 --------------
@@ -1254,25 +1248,21 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
-<a name="version"></a>.version([option], [description], [version])
+<a name="version"></a>
+.version()
+----------------------------------------
+.version([version|boolean])
+----------------------------------------
+.version([option], [description], [version])
 ----------------------------------------
 
 Add an option (e.g. `--version`) that displays the version number (given by the
-`version` parameter) and exits the process.
+`version` parameter) and exits the process. By default yargs enables version for the `--version` option.
 
 If no arguments are passed to `version` (`.version()`), yargs will parse the `package.json`
-of your module and use its `version` value. The default value of `option` is `--version`.
+of your module and use its `version` value.
 
-You can provide a `function` for version, rather than a string.
-This is useful if you want to use a version stored in a location other than package.json:
-
-```js
-var argv = require('yargs')
-  .version(function() {
-    return require('../lib/version').version;
-  })
-  .argv;
-```
+If the boolean argument `false` is provided, it will disable `--version`.
 
 <a name="wrap"></a>.wrap(columns)
 --------------

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -444,8 +444,7 @@ module.exports = function (yargs, y18n) {
 
   self.showVersion = function () {
     const logger = yargs._getLoggerInstance()
-    if (typeof version === 'function') logger.log(version())
-    else logger.log(version)
+    logger.log(version)
   }
 
   self.reset = function (localLookup) {

--- a/test/command.js
+++ b/test/command.js
@@ -501,7 +501,7 @@ describe('Command', function () {
   describe('commandDir', function () {
     it('supports relative dirs', function () {
       var r = checkOutput(function () {
-        return yargs('--help').help().wrap(null)
+        return yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir')
           .argv
       })
@@ -512,14 +512,15 @@ describe('Command', function () {
         'Commands:',
         '  dream [command] [opts]  Go to sleep and dream',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
 
     it('supports nested subcommands', function () {
       var r = checkOutput(function () {
-        return yargs('dream --help').help().wrap(null)
+        return yargs('dream --help').wrap(null)
           .commandDir('fixtures/cmddir')
           .argv
       }, [ './command' ])
@@ -533,6 +534,7 @@ describe('Command', function () {
         '  within-a-dream [command] [opts]  Dream within a dream',
         'Options:',
         '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --shared   Is the dream shared with others?  [boolean]',
         '  --extract  Attempt extraction?  [boolean]',
         ''
@@ -541,7 +543,7 @@ describe('Command', function () {
 
     it('supports a "recurse" boolean option', function () {
       var r = checkOutput(function () {
-        return yargs('--help').help().wrap(null)
+        return yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir', { recurse: true })
           .argv
       })
@@ -555,7 +557,8 @@ describe('Command', function () {
         '  within-a-dream [command] [opts]  Dream within a dream',
         '  dream [command] [opts]           Go to sleep and dream',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -565,7 +568,7 @@ describe('Command', function () {
       var pathToFile
       var filename
       var r = checkOutput(function () {
-        return yargs('--help').help().wrap(null)
+        return yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir', {
             visit: function (_commandObject, _pathToFile, _filename) {
               commandObject = _commandObject
@@ -587,14 +590,15 @@ describe('Command', function () {
       r.should.have.property('logs')
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
 
     it('detects and ignores cyclic dir references', function () {
       var r = checkOutput(function () {
-        return yargs('cyclic --help').help().wrap(null)
+        return yargs('cyclic --help').wrap(null)
           .commandDir('fixtures/cmddir_cyclic')
           .argv
       }, [ './command' ])
@@ -604,14 +608,15 @@ describe('Command', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         './command cyclic',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
 
     it('derives \'command\' string from filename when not exported', function () {
       var r = checkOutput(function () {
-        return yargs('--help').help().wrap(null)
+        return yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir_noname')
           .argv
       })
@@ -622,7 +627,8 @@ describe('Command', function () {
         'Commands:',
         '  nameless  Command name derived from module filename',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -648,35 +654,35 @@ describe('Command', function () {
 
       var helpCmd = checkOutput(function () {
         return yargs('help cmd')
-          .help().wrap(null)
+          .wrap(null)
           .command(cmd)
           .argv
       }, [ './command' ])
 
       var cmdHelp = checkOutput(function () {
         return yargs('cmd help')
-          .help().wrap(null)
+          .wrap(null)
           .command(cmd)
           .argv
       }, [ './command' ])
 
       var helpCmdSub = checkOutput(function () {
         return yargs('help cmd sub')
-          .help().wrap(null)
+          .wrap(null)
           .command(cmd)
           .argv
       }, [ './command' ])
 
       var cmdHelpSub = checkOutput(function () {
         return yargs('cmd help sub')
-          .help().wrap(null)
+          .wrap(null)
           .command(cmd)
           .argv
       }, [ './command' ])
 
       var cmdSubHelp = checkOutput(function () {
         return yargs('cmd sub help')
-          .help().wrap(null)
+          .wrap(null)
           .command(cmd)
           .argv
       }, [ './command' ])
@@ -686,14 +692,16 @@ describe('Command', function () {
         'Commands:',
         '  sub  Run the subcommand',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ]
 
       var expectedSub = [
         './command cmd sub',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ]
 
@@ -765,7 +773,6 @@ describe('Command', function () {
       .command('foo', 'the foo command', {}, function (argv) {
         counter++
       })
-      .help()
     y.parse(['foo'], function () {})
     y.parse(['foo'], function () {
       counter.should.equal(2)
@@ -1158,7 +1165,6 @@ describe('Command', function () {
         yargs()
           .command('command [snuh]', 'a command')
           .describe('foo', 'an awesome argument')
-          .help()
           .parse('command --help', function (err, argv, output) {
             if (err) return done(err)
             output.should.not.match(/Commands:/)
@@ -1204,7 +1210,6 @@ describe('Command', function () {
           .group('snuh', 'Bad Variable Names:')
           .describe('foo', 'foo option')
           .describe('snuh', 'snuh positional')
-          .help()
           .parse('command --help', function (err, argv, output) {
             if (err) return done(err)
             output.should.match(/Bad Variable Names:\W*--foo/)

--- a/test/completion.js
+++ b/test/completion.js
@@ -77,7 +77,8 @@ describe('Completion', function () {
                 describe: 'bar option'
               }
             })
-            .help('help')
+            .help(true)
+            .version(false)
           })
           .completion()
           .argv
@@ -91,6 +92,8 @@ describe('Completion', function () {
     it('completes options for the correct command', function () {
       var r = checkUsage(function () {
         return yargs(['./completion', '--get-yargs-completions', 'cmd2', '--o'])
+          .help(false)
+          .version(false)
           .command('cmd1', 'first command', function (subYargs) {
             subYargs.options({
               opt1: {
@@ -129,6 +132,8 @@ describe('Completion', function () {
     it('works if command has no options', function () {
       var r = checkUsage(function () {
         return yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
+          .help(false)
+          .version(false)
           .command('foo', 'foo command', function (subYargs) {
             subYargs.completion().argv
           })

--- a/test/usage.js
+++ b/test/usage.js
@@ -30,6 +30,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -x NUM -y NUM',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  -x  [required]',
           '  -y  [required]',
           'Missing required argument: y'
@@ -53,6 +55,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -w NUM -m NUM',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  -w  [required]',
           '  -m  [required]',
           'Missing required argument: m'
@@ -76,6 +80,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -w NUM -m NUM',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  -w  [required]',
           '  -m  [required]',
           'Not enough non-option arguments: got 0, need at least 1'
@@ -117,6 +123,8 @@ describe('usage tests', function () {
           r.errors.join('\n').split(/\n+/).should.deep.equal([
             'Usage: ./usage -x NUM -y NUM',
             'Options:',
+            '  --help     Show help  [boolean]',
+            '  --version  Show version number  [boolean]',
             '  -x  [required]',
             '  -y  [required]',
             'Missing required argument: y'
@@ -139,6 +147,8 @@ describe('usage tests', function () {
           r.errors.join('\n').split(/\n+/).should.deep.equal([
             'Usage: ./usage -w NUM -m NUM',
             'Options:',
+            '  --help     Show help  [boolean]',
+            '  --version  Show version number  [boolean]',
             '  -w  [required]',
             '  -m  [required]',
             'Missing required argument: m'
@@ -163,6 +173,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -w NUM -m NUM',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  -w  [required]',
           '  -m  [required]',
           'Not enough non-option arguments: got 0, need at least 1'
@@ -185,6 +197,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage -x NUM -y NUM',
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  -x  [required]',
         '  -y  [required]',
         'Missing required arguments: x, y',
@@ -222,6 +236,9 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: foo',
+        'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -251,6 +268,9 @@ describe('usage tests', function () {
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           'Too many non-option arguments: got 4, maximum of 3'
         ])
       })
@@ -266,6 +286,9 @@ describe('usage tests', function () {
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           'Not enough non-option arguments: got 1, need at least 2'
         ])
       })
@@ -281,6 +304,9 @@ describe('usage tests', function () {
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           'pork chop sandwiches'
         ])
       })
@@ -336,6 +362,9 @@ describe('usage tests', function () {
     r.result.should.have.property('_').with.length(0)
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Usage: ./usage -x NUM -y NUM',
+      'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       'You forgot about -y'
     ])
     r.should.have.property('logs').with.length(0)
@@ -362,6 +391,9 @@ describe('usage tests', function () {
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Usage: ./usage -x NUM -y NUM',
+      'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       'You forgot about -y'
     ])
   })
@@ -405,6 +437,9 @@ describe('usage tests', function () {
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).join('\n').should.equal(
       'Usage: ./usage -x NUM -y NUM\n' +
+      'Options:\n' +
+      '  --help     Show help  [boolean]\n' +
+      '  --version  Show version number  [boolean]\n' +
       'Argument check failed: ' + checker.toString()
     )
   })
@@ -429,6 +464,9 @@ describe('usage tests', function () {
         })
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -x NUM -y NUM',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           'You forgot about -y'
         ])
         r.should.have.property('logs').with.length(0)
@@ -562,6 +600,9 @@ describe('usage tests', function () {
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Usage: ./usage [x] [y] [z] {OPTIONS}',
+      'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       'Not enough non-option arguments: got 2, need at least 3'
     ])
   })
@@ -582,6 +623,9 @@ describe('usage tests', function () {
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Usage: ./usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
+      'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       'src and dest files are both required'
     ])
   })
@@ -626,6 +670,8 @@ describe('usage tests', function () {
     })
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       '  -f, --foo  [default: 5]',
       'Not enough non-option arguments: got 0, need at least 1'
     ])
@@ -667,6 +713,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage [options]',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
           'Missing argument value: foo'
@@ -693,6 +741,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage [options]',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
           'Missing argument values: foo, bar'
@@ -722,6 +772,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage [options]',
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
           'Missing argument value: foo'
@@ -770,6 +822,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage [options]',
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --foo, -f  [required]',
         '  --bar, -b  [required]',
         'Unknown argument: baz'
@@ -803,6 +857,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage [options]',
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --foo, -f  foo option',
         '  --bar, -b  bar option',
         'Unknown argument: baz'
@@ -837,6 +893,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage [options]',
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --foo, -f  foo option',
         '  --bar, -b  bar option',
         'Unknown arguments: baz, q'
@@ -884,6 +942,8 @@ describe('usage tests', function () {
     r.should.have.property('exit').and.be.ok
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
+      '  --help     Show help  [boolean]',
+      '  --version  Show version number  [boolean]',
       '  -y  [required]',
       'Examples:',
       '  ./usage something       description',
@@ -912,8 +972,10 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option  [required]',
-          '  -y  another option',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
+          '  -x         an option  [required]',
+          '  -y         another option',
           '',
           'Missing required argument: x'
         ])
@@ -941,8 +1003,10 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option  [required]',
-          '  -y  another option',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
+          '  -x         an option  [required]',
+          '  -y         another option',
           '',
           'Missing required argument: x'
         ])
@@ -974,7 +1038,6 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs(['--help'])
           .demand(['y'])
-          .help('help')
           .wrap(null)
           .argv
       })
@@ -985,7 +1048,8 @@ describe('usage tests', function () {
       r.should.have.property('exit').and.be.ok
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  -y  [required]',
         ''
       ])
@@ -995,7 +1059,6 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs(['--help'])
           .usage('Usage: $0 options')
-          .help('help')
           .describe('some-opt', 'Some option')
           .default('some-opt', 2)
           .wrap(null)
@@ -1010,6 +1073,7 @@ describe('usage tests', function () {
         'Usage: ./usage options',
         'Options:',
         '  --help      Show help  [boolean]',
+        '  --version   Show version number  [boolean]',
         '  --some-opt  Some option  [default: 2]',
         ''
       ])
@@ -1020,7 +1084,6 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['--help'])
             .usage('Usage: $0 options')
-            .help('help')
             .alias('help', 'h')
             .describe('some-opt', 'Some option')
             .demand('some-opt')
@@ -1039,6 +1102,7 @@ describe('usage tests', function () {
           'Usage: ./usage options',
           'Options:',
           '  --help, -h  Show help  [boolean]',
+          '  --version   Show version number  [boolean]',
           '  --some-opt  Some option  [required]',
           ''
         ])
@@ -1050,7 +1114,6 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['--help', '--some-opt'])
             .usage('Usage: $0 options')
-            .help('help')
             .alias('help', 'h')
             .describe('some-opt', 'Some option')
             .demand('some-opt')
@@ -1070,6 +1133,7 @@ describe('usage tests', function () {
           'Usage: ./usage options',
           'Options:',
           '  --help, -h  Show help  [boolean]',
+          '  --version   Show version number  [boolean]',
           '  --some-opt  Some option  [required]',
           ''
         ])
@@ -1103,24 +1167,10 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.0')
     })
 
-    it('should allow a function to be provided, rather than a number', function () {
-      var r = checkUsage(function () {
-        return yargs(['--version'])
-        .version('version', function () {
-          return require('./fixtures/config').version
-        })
-        .wrap(null)
-        .argv
-      })
-      r.logs[0].should.eql('1.0.2')
-    })
-
     it("should default to 'version' as version option", function () {
       var r = checkUsage(function () {
         return yargs(['--version'])
-        .version(function () {
-          return require('./fixtures/config').version
-        })
+        .version('1.0.2')
         .wrap(null)
         .argv
       })
@@ -1177,12 +1227,12 @@ describe('usage tests', function () {
 
       var r = checkUsage(function () {
         return yargs(['--foo'])
-        .usage('Usage: $0 [options]')
-        .options(opts)
-        .demand(['foo', 'bar'])
-        .showHelpOnFail(false, 'Specify --help for available options')
-        .wrap(null)
-        .argv
+          .usage('Usage: $0 [options]')
+          .options(opts)
+          .demand(['foo', 'bar'])
+          .showHelpOnFail(false, 'Specify --help for available options')
+          .wrap(null)
+          .argv
       })
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
@@ -1309,7 +1359,7 @@ describe('usage tests', function () {
       })
 
       // should split example usage onto multiple lines.
-      r.errors[0].split('\n').length.should.equal(8)
+      r.errors[0].split('\n').length.should.equal(11)
 
       // should wrap within appropriate boundaries.
       r.errors[0].split('\n').forEach(function (line, i) {
@@ -1370,6 +1420,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version   Show version number                                      [boolean]',
         '  -f, --file  ' + noColorAddedDescr + '                      [string] [required]',
         '  -h, --help  Show help                                                [boolean]',
         ''
@@ -1394,6 +1445,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version   Show version number                                      [boolean]',
         '  -f, --file  ' + yellowDescription + '                      [string] [required]',
         '  -h, --help  Show help                                                [boolean]',
         ''
@@ -1417,6 +1469,8 @@ describe('usage tests', function () {
         '  upload    upload something',
         '  download  download something from somewhere',
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  -y  [required]',
         'Missing required argument: y'
       ])
@@ -1436,6 +1490,8 @@ describe('usage tests', function () {
         'Commands:',
         'upload', 'upload', 'something',
         'Options:',
+        '--help', 'Show', 'help', '[boolean]',
+        '--version', 'Show', 'version', 'number', '[boolean]',
         '-y', '[required]',
         'Missing', 'required', 'argument:', 'y'
       ])
@@ -1455,6 +1511,8 @@ describe('usage tests', function () {
         'Commands:',
         'upload', 'upload', 'something',
         'Options:',
+        '--help', 'Show', 'help', '[boolean]',
+        '--version', 'Show', 'version', 'number', '[boolean]',
         '-y', '[required]',
         'Missing', 'required', 'argument:', 'y'
       ])
@@ -1474,14 +1532,12 @@ describe('usage tests', function () {
       var generalHelp = checkUsage(function () {
         return yargs('--help')
           .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
-          .help()
           .wrap(null)
           .argv
       })
       var commandHelp = checkUsage(function () {
         return yargs('upload --help')
           .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
-          .help()
           .wrap(null)
           .argv
       })
@@ -1491,15 +1547,17 @@ describe('usage tests', function () {
         '  upload <dest>  Upload cwd to remote destination',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
         './usage upload <dest>',
         '',
         'Options:',
-        '  --help   Show help  [boolean]',
-        '  --force  Force overwrite of remote directory contents  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --force    Force overwrite of remote directory contents  [boolean]',
         ''
       ])
     })
@@ -1520,14 +1578,12 @@ describe('usage tests', function () {
       var generalHelp = checkUsage(function () {
         return yargs('--help')
           .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
-          .help()
           .wrap(null)
           .argv
       })
       var commandHelp = checkUsage(function () {
         return yargs('upload --help')
           .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
-          .help()
           .wrap(null)
           .argv
       })
@@ -1537,16 +1593,18 @@ describe('usage tests', function () {
         '  upload <dest>  Upload cwd to remote destination',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
         './usage upload <dest>',
         '',
         'Options:',
-        '  --help   Show help                 [boolean]',
-        '  --force  Force overwrite of remote directory',
-        '           contents                  [boolean]',
+        '  --help     Show help               [boolean]',
+        '  --version  Show version number     [boolean]',
+        '  --force    Force overwrite of remote',
+        '             directory contents      [boolean]',
         ''
       ])
     })
@@ -1576,6 +1634,9 @@ describe('usage tests', function () {
         '',
         'Global Flags:',
         '  -h  Show help  [boolean]',
+        '',
+        'Options:',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1616,7 +1677,8 @@ describe('usage tests', function () {
         '  -i  [boolean]',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
@@ -1650,7 +1712,8 @@ describe('usage tests', function () {
         '  -q  [boolean]',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
@@ -1692,7 +1755,8 @@ describe('usage tests', function () {
         '  -q  [boolean]',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
@@ -1706,7 +1770,7 @@ describe('usage tests', function () {
             },
             handler: function (argv) {}
           })
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
@@ -1715,7 +1779,8 @@ describe('usage tests', function () {
         '  upload  upload something',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1729,7 +1794,7 @@ describe('usage tests', function () {
             },
             handler: function (argv) {}
           })
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
@@ -1737,7 +1802,8 @@ describe('usage tests', function () {
         'Usage: program upload <something> [opts]',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1748,13 +1814,14 @@ describe('usage tests', function () {
           .command('upload', 'upload something', function (yargs) {
             return yargs.usage(null)
           }, function (argv) {})
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1765,7 +1832,7 @@ describe('usage tests', function () {
           .command('one <sub>', 'level one, requires subcommand', function (yargs) {
             return yargs.command('two [next]', 'level two', {}, function (argv) {})
           }, function (argv) {})
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
@@ -1773,7 +1840,8 @@ describe('usage tests', function () {
         './usage one two [next]',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1784,7 +1852,7 @@ describe('usage tests', function () {
           .command('one <sub>', 'level one, requires subcommand', function (yargs) {
             return yargs.command('two [next]', 'level two', function (yargs) { return yargs }, function (argv) {})
           }, function (argv) {})
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
@@ -1792,7 +1860,8 @@ describe('usage tests', function () {
         './usage one two [next]',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1801,7 +1870,7 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs('help')
           .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
-          .help().wrap(null)
+          .wrap(null)
           .argv
       })
 
@@ -1810,7 +1879,8 @@ describe('usage tests', function () {
         '  copy <src> [dest]  Copy something  [aliases: cp, dupe]',
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -1819,7 +1889,7 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs('help')
           .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
-          .help().wrap(80)
+          .wrap(80)
           .argv
       })
 
@@ -1828,7 +1898,8 @@ describe('usage tests', function () {
         '  copy <src> [dest]  Copy something                          [aliases: cp, dupe]',
         '',
         'Options:',
-        '  --help  Show help                                                    [boolean]',
+        '  --help     Show help                                                 [boolean]',
+        '  --version  Show version number                                       [boolean]',
         ''
       ])
     })
@@ -1846,6 +1917,8 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  -y  [required]',
         'for more info view the manual at http://example.com',
         'Missing required argument: y'
@@ -1863,6 +1936,8 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  -y  [required]',
         'Try \'./usage --long-help\' for more information',
         'Missing required argument: y'
@@ -2049,6 +2124,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
         '  -f, --foo  foo option',
         ''
@@ -2067,6 +2143,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
         '  -f, --foo  [required]',
         ''
@@ -2086,6 +2163,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
         '  -f, --foo  bar  [string]',
         ''
@@ -2106,6 +2184,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
         '  -f, --foo  bar  [number]',
         ''
@@ -2129,6 +2208,8 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --foo, -f  foo option',
         ''
       ])
@@ -2149,6 +2230,8 @@ describe('usage tests', function () {
       r.errors.length.should.eql(0)
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '  --foo, -f  foo option',
         ''
       ])
@@ -2166,6 +2249,8 @@ describe('usage tests', function () {
       function testHandler (msg) {
         msg.split(/\n+/).should.deep.equal([
           'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           ''
         ])
@@ -2283,16 +2368,16 @@ describe('usage tests', function () {
             describe: 'percentage of confidence',
             choices: [0, 25, 50, 75, 100]
           })
-          .help('help')
           .wrap(null)
           .argv
       })
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
+        '  --help        Show help  [boolean]',
+        '  --version     Show version number  [boolean]',
         '  --answer      does this look good?  [choices: "yes", "no", "maybe"]',
         '  --confidence  percentage of confidence  [choices: 0, 25, 50, 75, 100]',
-        '  --help        Show help  [boolean]',
         ''
       ])
     })
@@ -2307,14 +2392,14 @@ describe('usage tests', function () {
           .option('confidence', {
             choices: [0, 25, 50, 75, 100]
           })
-          .help('help')
           .wrap(null)
           .argv
       })
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -2364,7 +2449,6 @@ describe('usage tests', function () {
             default: 'Bruce Wayne'
           })
           .group('batman', 'Heroes:')
-          .help('help')
           .wrap(null)
           .argv
       })
@@ -2374,7 +2458,8 @@ describe('usage tests', function () {
         "  --batman  not the world's happiest guy  [string] [default: \"Bruce Wayne\"]",
         '',
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -2396,6 +2481,9 @@ describe('usage tests', function () {
         'Heroes:',
         "  --batman  not the world's happiest guy  [string] [default: \"Bruce Wayne\"]",
         '  -h        Show help  [boolean]',
+        '',
+        'Options:',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -2403,9 +2491,9 @@ describe('usage tests', function () {
     it('displays alias keys appropriately within a grouping', function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
-          .help('help')
           .alias('h', 'help')
           .group('help', 'Magic Variable:')
+          .group('version', 'Magic Variable:')
           .wrap(null)
           .argv
       })
@@ -2413,14 +2501,14 @@ describe('usage tests', function () {
       r.logs[0].split('\n').should.deep.equal([
         'Magic Variable:',
         '  -h, --help  Show help  [boolean]',
+        '  --version   Show version number  [boolean]',
         ''
       ])
     })
 
     it('allows a group to be provided as the only information about an option', function () {
       var r = checkUsage(function () {
-        return yargs(['-h'])
-          .help('h')
+        return yargs(['--help'])
           .group('batman', 'Heroes:')
           .wrap(null)
           .argv
@@ -2431,7 +2519,8 @@ describe('usage tests', function () {
         '  --batman',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -2448,7 +2537,8 @@ describe('usage tests', function () {
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  -h         Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         '',
         'Heroes:',
         '  --batman',
@@ -2474,15 +2564,15 @@ describe('usage tests', function () {
         '  --batman  [string]',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
 
     it('only displays a duplicated option once per group', function () {
       var r = checkUsage(function () {
-        return yargs(['-h'])
-          .help('h')
+        return yargs(['--help'])
           .group(['batman', 'batman'], 'Heroes:')
           .group('robin', 'Heroes:')
           .option('robin', {
@@ -2498,7 +2588,8 @@ describe('usage tests', function () {
         '  --robin',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ])
     })
@@ -2515,6 +2606,9 @@ describe('usage tests', function () {
       })
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --help     Show help                                                 [boolean]',
+        '  --version  Show version number                                       [boolean]',
         'Examples:',
         '  안녕하세요 선생님 안녕 친구야  인사하는 어린이 착한 어린이',
         ''
@@ -2529,7 +2623,6 @@ describe('usage tests', function () {
           .command(['list [pattern]', 'ls', '*'], 'List key-value pairs for pattern', {}, function () {})
           .command('get <key>', 'Get value for key', {}, function () {})
           .command('set <key> [value]', 'Set value for key', {}, function () {})
-          .help()
           .argv
       })
 
@@ -2540,7 +2633,8 @@ describe('usage tests', function () {
         '  set <key> [value]  Set value for key',
         '',
         'Options:',
-        '  --help  Show help                                                    [boolean]',
+        '  --help     Show help                                                 [boolean]',
+        '  --version  Show version number                                       [boolean]',
         ''
       ])
     })

--- a/test/validation.js
+++ b/test/validation.js
@@ -574,6 +574,7 @@ describe('validation tests', function () {
         return yargs(['--help'])
           .config('settings')
           .help('help')
+          .version(false)
           .wrap(null)
           .argv
       })
@@ -592,6 +593,7 @@ describe('validation tests', function () {
         return yargs(['--help'])
             .config()
             .help('help')
+            .version(false)
             .wrap(null)
             .argv
       })
@@ -610,6 +612,7 @@ describe('validation tests', function () {
         return yargs(['--help'])
           .config('settings', 'pork chop sandwiches')
           .help('help')
+          .version(false)
           .wrap(null)
           .argv
       })
@@ -636,6 +639,7 @@ describe('validation tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
+        '  --version   Show version number  [boolean]',
         '  --settings  path to config file',
         '  --help      Show help  [boolean]',
         'someone set us up the bomb'
@@ -649,15 +653,15 @@ describe('validation tests', function () {
           .config('settings', 'path to config file', function (configPath) {
             throw Error('someone set us up the bomb')
           })
-          .help('help')
           .wrap(null)
           .argv
       })
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --settings  path to config file',
         '  --help      Show help  [boolean]',
+        '  --version   Show version number  [boolean]',
+        '  --settings  path to config file',
         'someone set us up the bomb'
       ])
     })
@@ -729,6 +733,8 @@ describe('validation tests', function () {
           .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
           .demandCommand(0, 1, 'src and dest files are both required', 'too many arguments are provided')
           .wrap(null)
+          .help(false)
+          .version(false)
           .argv
       })
       r.should.have.property('result')

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -211,7 +211,6 @@ describe('yargs dsl tests', function () {
       // create a command line with all the things.
       // so that we can confirm they're reset.
       var y = yargs(['--help'])
-        .help('help')
         .command('foo', 'bar', function () {})
         .default('foo', 'bar')
         .describe('foo', 'foo variable')
@@ -233,11 +232,11 @@ describe('yargs dsl tests', function () {
 
       var emptyOptions = {
         array: [],
-        boolean: ['help'],
+        boolean: ['help', 'version'],
         string: [],
         alias: {},
         default: {},
-        key: {help: true},
+        key: {help: true, version: true},
         narg: {},
         defaultDescription: {},
         choices: {},
@@ -260,7 +259,10 @@ describe('yargs dsl tests', function () {
       }
 
       expect(y.getOptions()).to.deep.equal(emptyOptions)
-      expect(y.getUsageInstance().getDescriptions()).to.deep.equal({help: '__yargsString__:Show help'})
+      expect(y.getUsageInstance().getDescriptions()).to.deep.equal({
+        help: '__yargsString__:Show help',
+        version: '__yargsString__:Show version number'
+      })
       expect(y.getValidationInstance().getImplied()).to.deep.equal({})
       expect(y.getValidationInstance().getConflicting()).to.deep.equal({})
       expect(y.getCommandInstance().getCommandHandlers()).to.deep.equal({})
@@ -378,7 +380,8 @@ describe('yargs dsl tests', function () {
         '  snuh  snuh command',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
@@ -402,7 +405,8 @@ describe('yargs dsl tests', function () {
         '  blerg  handle blerg things',
         '',
         'Options:',
-        '  -h  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h         Show help  [boolean]',
         ''
       ])
     })
@@ -1051,7 +1055,6 @@ describe('yargs dsl tests', function () {
           .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
           .command('robin <egg>', 'robin command', function () {}, function (_argv) {})
           .wrap(null)
-          .help()
 
         var output1 = null
         parser.parse('batman help', function (_err, _argv, output) {
@@ -1066,7 +1069,8 @@ describe('yargs dsl tests', function () {
           'ndm batman <api-token>',
           '',
           'Options:',
-          '  --help  Show help  [boolean]',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           ''
         ])
 
@@ -1074,7 +1078,8 @@ describe('yargs dsl tests', function () {
           'ndm robin <egg>',
           '',
           'Options:',
-          '  --help  Show help  [boolean]',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           ''
         ])
       })
@@ -1084,7 +1089,6 @@ describe('yargs dsl tests', function () {
           .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
           .command('robin <egg>', 'robin command', function () {}, function (_argv) {})
           .wrap(null)
-          .help()
 
         var error1 = null
         var output1 = null
@@ -1104,7 +1108,8 @@ describe('yargs dsl tests', function () {
           'ndm batman <api-token>',
           '',
           'Options:',
-          '  --help  Show help  [boolean]',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '',
           'Not enough non-option arguments: got 0, need at least 1'
         ])
@@ -1114,7 +1119,8 @@ describe('yargs dsl tests', function () {
           'ndm robin <egg>',
           '',
           'Options:',
-          '  --help  Show help  [boolean]',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           ''
         ])
       })
@@ -1127,6 +1133,7 @@ describe('yargs dsl tests', function () {
         var parser = yargs()
           .demand(1, 'Must call a command')
           .strict()
+          .wrap(null)
           .command('one <x>', 'The one and only command')
         // first call parse with command, which calls reset
         parser.parse('one two', function (_, argv) {
@@ -1142,6 +1149,10 @@ describe('yargs dsl tests', function () {
         output.split('\n').should.deep.equal([
           'Commands:',
           '  one <x>  The one and only command',
+          '',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
           '',
           'Must call a command'
         ])
@@ -1568,19 +1579,18 @@ describe('yargs dsl tests', function () {
     it('enables `--help` option and `help` command without arguments', function () {
       var option = checkOutput(function () {
         return yargs('--help')
-          .help()
           .wrap(null)
           .argv
       })
       var command = checkOutput(function () {
         return yargs('help')
-          .help()
           .wrap(null)
           .argv
       })
       var expected = [
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
         ''
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
@@ -1602,32 +1612,12 @@ describe('yargs dsl tests', function () {
       })
       var expected = [
         'Options:',
-        '  --help  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --help     Show help  [boolean]',
         ''
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
-    })
-
-    it('enables only `--help` option with `false` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--help')
-          .help(false)
-          .wrap(null)
-          .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('help')
-          .help(false)
-          .wrap(null)
-          .argv
-      })
-      option.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  --help  Show help  [boolean]',
-        ''
-      ])
-      command.result.should.have.property('_').and.deep.equal(['help'])
     })
 
     it('enables given string as help option and command with string argument', function () {
@@ -1651,62 +1641,13 @@ describe('yargs dsl tests', function () {
       })
       var expected = [
         'Options:',
-        '  --info  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --info     Show help  [boolean]',
         ''
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
       helpOption.result.should.have.property('help').and.be.true
-    })
-
-    it('enables given string as help option and command with string argument and `true` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
-          .help('info', true)
-          .wrap(null)
-          .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
-          .help('info', true)
-          .wrap(null)
-          .argv
-      })
-      var helpOption = checkOutput(function () {
-        return yargs('--help')
-          .help('info', true)
-          .wrap(null)
-          .argv
-      })
-      var expected = [
-        'Options:',
-        '  --info  Show help  [boolean]',
-        ''
-      ]
-      option.logs[0].split('\n').should.deep.equal(expected)
-      command.logs[0].split('\n').should.deep.equal(expected)
-      helpOption.result.should.have.property('help').and.be.true
-    })
-
-    it('enables given string as help option only with string argument and `false` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
-          .help('info', false)
-          .wrap(null)
-          .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
-          .help('info', false)
-          .wrap(null)
-          .argv
-      })
-      option.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  --info  Show help  [boolean]',
-        ''
-      ])
-      command.result.should.have.property('_').and.deep.equal(['info'])
     })
 
     it('enables given string as help option and command with custom description with two string arguments', function () {
@@ -1724,7 +1665,8 @@ describe('yargs dsl tests', function () {
       })
       var expected = [
         'Options:',
-        '  --info  Display info  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --info     Display info  [boolean]',
         ''
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
@@ -1746,32 +1688,12 @@ describe('yargs dsl tests', function () {
       })
       var expected = [
         'Options:',
-        '  --info  Display info  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --info     Display info  [boolean]',
         ''
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
-    })
-
-    it('enables given string as help option only and custom description with two string arguments and `false` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
-          .help('info', 'Display info', false)
-          .wrap(null)
-          .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
-          .help('info', 'Display info', false)
-          .wrap(null)
-          .argv
-      })
-      option.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  --info  Display info  [boolean]',
-        ''
-      ])
-      command.result.should.have.property('_').and.deep.equal(['info'])
     })
   })
 
@@ -1791,6 +1713,7 @@ describe('yargs dsl tests', function () {
       })
       info.logs[0].split('\n').should.deep.equal([
         'Options:',
+        '  --version           Show version number  [boolean]',
         '  -h, --help, --info  Show help  [boolean]',
         ''
       ])
@@ -1812,7 +1735,8 @@ describe('yargs dsl tests', function () {
       })
       var expected = [
         'Options:',
-        '  -h, -?  Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -h, -?     Show help  [boolean]',
         ''
       ]
       h.logs[0].split('\n').should.deep.equal(expected)


### PR DESCRIPTION
Almost 100% of my applications written with yargs have this boilerplate:

```
const argv = require('yargs')
    .help()
    .version()
    .argv
```

I figured, why the heck don't we just enable `.version` and `.help` by default? (probably should have done this years ago).

BREAKING CHANGE: version and help keys are now enabled by default, and show up in help output; the implicit help command can no longer be enabled/disabled independently from the help command itself (which can now be disabled).