### PR TITLE
Change engine node version to >=4

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   ],
   "license": "MIT",
   "engine": {
-    "node": ">=0.10"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
One of the breaking changes of `v8.0.0` was requiring node 4 This updates the `engine.node` field in `package.json` which had the wrong value of `>=0.10`