### PR TITLE
refactor: ES6ify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 // classic singleton yargs API, to use yargs
 // without running as a singleton do:
 // require('yargs/yargs')(process.argv.slice(2))
@@ -21,7 +22,7 @@ function Argv (processArgs, cwd) {
     to get a parsed version of process.argv.
 */
 function singletonify (inst) {
-  Object.keys(inst).forEach(function (key) {
+  Object.keys(inst).forEach((key) => {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
     } else {

--- a/lib/apply-extends.js
+++ b/lib/apply-extends.js
@@ -1,12 +1,14 @@
-var fs = require('fs')
-var path = require('path')
-var YError = require('./yerror')
 
-var previouslyVisitedConfigs = []
+'use strict'
+const fs = require('fs')
+const path = require('path')
+const YError = require('./yerror')
+
+let previouslyVisitedConfigs = []
 
 function checkForCircularExtends (path) {
   if (previouslyVisitedConfigs.indexOf(path) > -1) {
-    throw new YError("Circular extended configurations: '" + path + "'.")
+    throw new YError(`Circular extended configurations: '${path}'.`)
   }
 }
 
@@ -15,12 +17,12 @@ function getPathToDefaultConfig (cwd, pathToExtend) {
 }
 
 function applyExtends (config, cwd) {
-  var defaultConfig = {}
+  let defaultConfig = {}
 
   if (config.hasOwnProperty('extends')) {
     if (typeof config.extends !== 'string') return defaultConfig
-    var isPath = /\.json$/.test(config.extends)
-    var pathToDefault = null
+    const isPath = /\.json$/.test(config.extends)
+    let pathToDefault = null
     if (!isPath) {
       try {
         pathToDefault = require.resolve(config.extends)

--- a/lib/argsert.js
+++ b/lib/argsert.js
@@ -1,20 +1,21 @@
+'use strict'
 const command = require('./command')()
 const YError = require('./yerror')
 
 const positionName = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']
 
-module.exports = function (expected, callerArguments, length) {
+module.exports = function argsert (expected, callerArguments, length) {
   // TODO: should this eventually raise an exception.
   try {
     // preface the argument description with "cmd", so
     // that we can run it through yargs' command parser.
-    var position = 0
-    var parsed = {demanded: [], optional: []}
+    let position = 0
+    let parsed = {demanded: [], optional: []}
     if (typeof expected === 'object') {
       length = callerArguments
       callerArguments = expected
     } else {
-      parsed = command.parseCommand('cmd ' + expected)
+      parsed = command.parseCommand(`cmd ${expected}`)
     }
     const args = [].slice.call(callerArguments)
 
@@ -22,33 +23,27 @@ module.exports = function (expected, callerArguments, length) {
     length = length || args.length
 
     if (length < parsed.demanded.length) {
-      throw new YError('Not enough arguments provided. Expected ' + parsed.demanded.length +
-        ' but received ' + args.length + '.')
+      throw new YError(`Not enough arguments provided. Expected ${parsed.demanded.length} but received ${args.length}.`)
     }
 
     const totalCommands = parsed.demanded.length + parsed.optional.length
     if (length > totalCommands) {
-      throw new YError('Too many arguments provided. Expected max ' + totalCommands +
-        ' but received ' + length + '.')
+      throw new YError(`Too many arguments provided. Expected max ${totalCommands} but received ${length}.`)
     }
 
-    parsed.demanded.forEach(function (demanded) {
+    parsed.demanded.forEach((demanded) => {
       const arg = args.shift()
       const observedType = guessType(arg)
-      const matchingTypes = demanded.cmd.filter(function (type) {
-        return type === observedType || type === '*'
-      })
+      const matchingTypes = demanded.cmd.filter(type => type === observedType || type === '*')
       if (matchingTypes.length === 0) argumentTypeError(observedType, demanded.cmd, position, false)
       position += 1
     })
 
-    parsed.optional.forEach(function (optional) {
+    parsed.optional.forEach((optional) => {
       if (args.length === 0) return
       const arg = args.shift()
       const observedType = guessType(arg)
-      const matchingTypes = optional.cmd.filter(function (type) {
-        return type === observedType || type === '*'
-      })
+      const matchingTypes = optional.cmd.filter(type => type === observedType || type === '*')
       if (matchingTypes.length === 0) argumentTypeError(observedType, optional.cmd, position, true)
       position += 1
     })
@@ -67,6 +62,5 @@ function guessType (arg) {
 }
 
 function argumentTypeError (observedType, allowedTypes, position, optional) {
-  throw new YError('Invalid ' + (positionName[position] || 'manyith') + ' argument.' +
-    ' Expected ' + allowedTypes.join(' or ') + ' but received ' + observedType + '.')
+  throw new YError(`Invalid ${positionName[position] || 'manyith'} argument. Expected ${allowedTypes.join(' or ')} but received ${observedType}.`)
 }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,3 +1,4 @@
+'use strict'
 const path = require('path')
 const inspect = require('util').inspect
 const camelCase = require('camelcase')
@@ -7,21 +8,21 @@ const DEFAULT_MARKER = '*'
 // handles parsing positional arguments,
 // and populating argv with said positional
 // arguments.
-module.exports = function (yargs, usage, validation) {
+module.exports = function command (yargs, usage, validation) {
   const self = {}
 
-  var handlers = {}
-  var aliasMap = {}
-  var defaultCommand
-  self.addHandler = function (cmd, description, builder, handler) {
-    var aliases = []
-    handler = handler || function () {}
+  let handlers = {}
+  let aliasMap = {}
+  let defaultCommand
+  self.addHandler = function addHandler (cmd, description, builder, handler) {
+    let aliases = []
+    handler = handler || (() => {})
 
     if (Array.isArray(cmd)) {
       aliases = cmd.slice(1)
       cmd = cmd[0]
     } else if (typeof cmd === 'object') {
-      var command = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
+      let command = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
       if (cmd.aliases) command = [].concat(command).concat(cmd.aliases)
       self.addHandler(command, extractDesc(cmd), cmd.builder, cmd.handler)
       return
@@ -34,16 +35,14 @@ module.exports = function (yargs, usage, validation) {
     }
 
     // parse positionals out of cmd string
-    var parsedCommand = self.parseCommand(cmd)
+    const parsedCommand = self.parseCommand(cmd)
 
     // remove positional args from aliases only
-    aliases = aliases.map(function (alias) {
-      return self.parseCommand(alias).cmd
-    })
+    aliases = aliases.map(alias => self.parseCommand(alias).cmd)
 
     // check for default and filter out '*''
-    var isDefault = false
-    var parsedAliases = [parsedCommand.cmd].concat(aliases).filter(function (c) {
+    let isDefault = false
+    const parsedAliases = [parsedCommand.cmd].concat(aliases).filter((c) => {
       if (c === DEFAULT_MARKER) {
         isDefault = true
         return false
@@ -55,7 +54,7 @@ module.exports = function (yargs, usage, validation) {
     if (isDefault && parsedAliases.length === 0) {
       defaultCommand = {
         original: cmd.replace(DEFAULT_MARKER, '').trim(),
-        handler: handler,
+        handler,
         builder: builder || {},
         demanded: parsedCommand.demanded,
         optional: parsedCommand.optional
@@ -71,7 +70,7 @@ module.exports = function (yargs, usage, validation) {
     }
 
     // populate aliasMap
-    aliases.forEach(function (alias) {
+    aliases.forEach((alias) => {
       aliasMap[alias] = parsedCommand.cmd
     })
 
@@ -81,7 +80,7 @@ module.exports = function (yargs, usage, validation) {
 
     handlers[parsedCommand.cmd] = {
       original: cmd,
-      handler: handler,
+      handler,
       builder: builder || {},
       demanded: parsedCommand.demanded,
       optional: parsedCommand.optional
@@ -90,16 +89,16 @@ module.exports = function (yargs, usage, validation) {
     if (isDefault) defaultCommand = handlers[parsedCommand.cmd]
   }
 
-  self.addDirectory = function (dir, context, req, callerFile, opts) {
+  self.addDirectory = function addDirectory (dir, context, req, callerFile, opts) {
     opts = opts || {}
     // disable recursion to support nested directories of subcommands
     if (typeof opts.recurse !== 'boolean') opts.recurse = false
     // exclude 'json', 'coffee' from require-directory defaults
     if (!Array.isArray(opts.extensions)) opts.extensions = ['js']
     // allow consumer to define their own visitor function
-    const parentVisit = typeof opts.visit === 'function' ? opts.visit : function (o) { return o }
+    const parentVisit = typeof opts.visit === 'function' ? opts.visit : o => o
     // call addHandler via visitor function
-    opts.visit = function (obj, joined, filename) {
+    opts.visit = function visit (obj, joined, filename) {
       const visited = parentVisit(obj, joined, filename)
       // allow consumer to skip modules with their own visitor
       if (visited) {
@@ -119,7 +118,7 @@ module.exports = function (yargs, usage, validation) {
   // if module was not require()d and no name given, throw error
   function moduleName (obj) {
     const mod = require('which-module')(obj)
-    if (!mod) throw new Error('No command name given for module: ' + inspect(obj))
+    if (!mod) throw new Error(`No command name given for module: ${inspect(obj)}`)
     return commandFromFilename(mod.filename)
   }
 
@@ -129,64 +128,58 @@ module.exports = function (yargs, usage, validation) {
   }
 
   function extractDesc (obj) {
-    for (var keys = ['describe', 'description', 'desc'], i = 0, l = keys.length, test; i < l; i++) {
+    for (let keys = ['describe', 'description', 'desc'], i = 0, l = keys.length, test; i < l; i++) {
       test = obj[keys[i]]
       if (typeof test === 'string' || typeof test === 'boolean') return test
     }
     return false
   }
 
-  self.parseCommand = function (cmd) {
-    var extraSpacesStrippedCommand = cmd.replace(/\s{2,}/g, ' ')
-    var splitCommand = extraSpacesStrippedCommand.split(/\s+(?![^[]*]|[^<]*>)/)
-    var bregex = /\.*[\][<>]/g
-    var parsedCommand = {
+  self.parseCommand = function parseCommand (cmd) {
+    const extraSpacesStrippedCommand = cmd.replace(/\s{2,}/g, ' ')
+    const splitCommand = extraSpacesStrippedCommand.split(/\s+(?![^[]*]|[^<]*>)/)
+    const bregex = /\.*[\][<>]/g
+    const parsedCommand = {
       cmd: (splitCommand.shift()).replace(bregex, ''),
       demanded: [],
       optional: []
     }
-    splitCommand.forEach(function (cmd, i) {
-      var variadic = false
+    splitCommand.forEach((cmd, i) => {
+      let variadic = false
       cmd = cmd.replace(/\s/g, '')
       if (/\.+[\]>]/.test(cmd) && i === splitCommand.length - 1) variadic = true
       if (/^\[/.test(cmd)) {
         parsedCommand.optional.push({
           cmd: cmd.replace(bregex, '').split('|'),
-          variadic: variadic
+          variadic
         })
       } else {
         parsedCommand.demanded.push({
           cmd: cmd.replace(bregex, '').split('|'),
-          variadic: variadic
+          variadic
         })
       }
     })
     return parsedCommand
   }
 
-  self.getCommands = function () {
-    return Object.keys(handlers).concat(Object.keys(aliasMap))
-  }
+  self.getCommands = () => Object.keys(handlers).concat(Object.keys(aliasMap))
 
-  self.getCommandHandlers = function () {
-    return handlers
-  }
+  self.getCommandHandlers = () => handlers
 
-  self.hasDefaultCommand = function () {
-    return !!defaultCommand
-  }
+  self.hasDefaultCommand = () => !!defaultCommand
 
-  self.runCommand = function (command, yargs, parsed, commandIndex) {
-    var aliases = parsed.aliases
-    var commandHandler = handlers[command] || handlers[aliasMap[command]] || defaultCommand
-    var currentContext = yargs.getContext()
-    var numFiles = currentContext.files.length
-    var parentCommands = currentContext.commands.slice()
+  self.runCommand = function runCommand (command, yargs, parsed, commandIndex) {
+    let aliases = parsed.aliases
+    const commandHandler = handlers[command] || handlers[aliasMap[command]] || defaultCommand
+    const currentContext = yargs.getContext()
+    let numFiles = currentContext.files.length
+    const parentCommands = currentContext.commands.slice()
 
     // what does yargs look like after the buidler is run?
-    var innerArgv = parsed.argv
-    var innerYargs = null
-    var positionalMap = {}
+    let innerArgv = parsed.argv
+    let innerYargs = null
+    let positionalMap = {}
 
     if (command) currentContext.commands.push(command)
     if (typeof commandHandler.builder === 'function') {
@@ -199,7 +192,7 @@ module.exports = function (yargs, usage, validation) {
       // options object below.
       if (yargs.parsed === false) {
         if (typeof yargs.getUsageInstance().getUsage() === 'undefined') {
-          yargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
+          yargs.usage(`$0 ${parentCommands.length ? `${parentCommands.join(' ')} ` : ''}${commandHandler.original}`)
         }
         innerArgv = innerYargs ? innerYargs._parseArgs(null, null, true, commandIndex) : yargs._parseArgs(null, null, true, commandIndex)
       } else {
@@ -212,8 +205,8 @@ module.exports = function (yargs, usage, validation) {
       // as a short hand, an object can instead be provided, specifying
       // the options that a command takes.
       innerYargs = yargs.reset(parsed.aliases)
-      innerYargs.usage('$0 ' + (parentCommands.length ? parentCommands.join(' ') + ' ' : '') + commandHandler.original)
-      Object.keys(commandHandler.builder).forEach(function (key) {
+      innerYargs.usage(`$0 ${parentCommands.length ? `${parentCommands.join(' ')} ` : ''}${commandHandler.original}`)
+      Object.keys(commandHandler.builder).forEach((key) => {
         innerYargs.option(key, commandHandler.builder[key])
       })
       innerArgv = innerYargs._parseArgs(null, null, true, commandIndex)
@@ -244,19 +237,19 @@ module.exports = function (yargs, usage, validation) {
   // onto argv.
   function populatePositionals (commandHandler, argv, context, yargs) {
     argv._ = argv._.slice(context.commands.length) // nuke the current commands
-    var demanded = commandHandler.demanded.slice(0)
-    var optional = commandHandler.optional.slice(0)
-    var positionalMap = {}
+    const demanded = commandHandler.demanded.slice(0)
+    const optional = commandHandler.optional.slice(0)
+    const positionalMap = {}
 
     validation.positionalCount(demanded.length, argv._.length)
 
     while (demanded.length) {
-      var demand = demanded.shift()
+      const demand = demanded.shift()
       populatePositional(demand, argv, yargs, positionalMap)
     }
 
     while (optional.length) {
-      var maybe = optional.shift()
+      const maybe = optional.shift()
       populatePositional(maybe, argv, yargs, positionalMap)
     }
 
@@ -270,9 +263,9 @@ module.exports = function (yargs, usage, validation) {
     // "positional" consists of the positional.cmd, an array representing
     // the positional's name and aliases, and positional.variadic
     // indicating whether or not it is a variadic array.
-    var variadics = null
-    var value = null
-    for (var i = 0, cmd; (cmd = positional.cmd[i]) !== undefined; i++) {
+    let variadics = null
+    let value = null
+    for (let i = 0, cmd; (cmd = positional.cmd[i]) !== undefined; i++) {
       if (positional.variadic) {
         if (variadics) argv[cmd] = variadics.slice(0)
         else argv[cmd] = variadics = argv._.splice(0)
@@ -289,7 +282,7 @@ module.exports = function (yargs, usage, validation) {
 
   // TODO move positional arg logic to yargs-parser and remove this duplication
   function postProcessPositional (yargs, argv, key) {
-    var coerce = yargs.getOptions().coerce[key]
+    const coerce = yargs.getOptions().coerce[key]
     if (typeof coerce === 'function') {
       try {
         argv[key] = coerce(argv[key])
@@ -307,7 +300,7 @@ module.exports = function (yargs, usage, validation) {
     }
   }
 
-  self.reset = function () {
+  self.reset = () => {
     handlers = {}
     aliasMap = {}
     defaultCommand = undefined
@@ -318,14 +311,14 @@ module.exports = function (yargs, usage, validation) {
   // the state of commands such that
   // we can apply .parse() multiple times
   // with the same yargs instance.
-  var frozen
-  self.freeze = function () {
+  let frozen
+  self.freeze = () => {
     frozen = {}
     frozen.handlers = handlers
     frozen.aliasMap = aliasMap
     frozen.defaultCommand = defaultCommand
   }
-  self.unfreeze = function () {
+  self.unfreeze = () => {
     handlers = frozen.handlers
     aliasMap = frozen.aliasMap
     defaultCommand = frozen.defaultCommand

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -1,16 +1,17 @@
+'use strict'
 const fs = require('fs')
 const path = require('path')
 
 // add bash completions to your
 //  yargs-powered applications.
-module.exports = function (yargs, usage, command) {
+module.exports = function completion (yargs, usage, command) {
   const self = {
     completionKey: 'get-yargs-completions'
   }
 
   // get a list of completion commands.
   // 'args' is the array of strings from the line to be completed
-  self.getCompletion = function (args, done) {
+  self.getCompletion = function getCompletion (args, done) {
     const completions = []
     const current = args.length ? args[args.length - 1] : ''
     const argv = yargs.parse(args, true)
@@ -20,14 +21,14 @@ module.exports = function (yargs, usage, command) {
     // to completion().
     if (completionFunction) {
       if (completionFunction.length < 3) {
-        var result = completionFunction(current, argv)
+        const result = completionFunction(current, argv)
 
         // promise based completion function.
         if (typeof result.then === 'function') {
-          return result.then(function (list) {
-            process.nextTick(function () { done(list) })
-          }).catch(function (err) {
-            process.nextTick(function () { throw err })
+          return result.then((list) => {
+            process.nextTick(() => { done(list) })
+          }).catch((err) => {
+            process.nextTick(() => { throw err })
           })
         }
 
@@ -35,14 +36,14 @@ module.exports = function (yargs, usage, command) {
         return done(result)
       } else {
         // asynchronous completion function
-        return completionFunction(current, argv, function (completions) {
+        return completionFunction(current, argv, (completions) => {
           done(completions)
         })
       }
     }
 
-    var handlers = command.getCommandHandlers()
-    for (var i = 0, ii = args.length; i < ii; ++i) {
+    const handlers = command.getCommandHandlers()
+    for (let i = 0, ii = args.length; i < ii; ++i) {
       if (handlers[args[i]] && handlers[args[i]].builder) {
         const builder = handlers[args[i]].builder
         if (typeof builder === 'function') {
@@ -54,7 +55,7 @@ module.exports = function (yargs, usage, command) {
     }
 
     if (!current.match(/^-/)) {
-      usage.getCommands().forEach(function (command) {
+      usage.getCommands().forEach((command) => {
         if (args.indexOf(command[0]) === -1) {
           completions.push(command[0])
         }
@@ -62,14 +63,12 @@ module.exports = function (yargs, usage, command) {
     }
 
     if (current.match(/^-/)) {
-      Object.keys(yargs.getOptions().key).forEach(function (key) {
+      Object.keys(yargs.getOptions().key).forEach((key) => {
         // If the key and its aliases aren't in 'args', add the key to 'completions'
-        var keyAndAliases = [key].concat(aliases[key] || [])
-        var notInArgs = keyAndAliases.every(function (val) {
-          return args.indexOf('--' + val) === -1
-        })
+        const keyAndAliases = [key].concat(aliases[key] || [])
+        const notInArgs = keyAndAliases.every(val => args.indexOf(`--${val}`) === -1)
         if (notInArgs) {
-          completions.push('--' + key)
+          completions.push(`--${key}`)
         }
       })
     }
@@ -78,15 +77,15 @@ module.exports = function (yargs, usage, command) {
   }
 
   // generate the completion script to add to your .bashrc.
-  self.generateCompletionScript = function ($0) {
-    var script = fs.readFileSync(
+  self.generateCompletionScript = function generateCompletionScript ($0) {
+    let script = fs.readFileSync(
       path.resolve(__dirname, '../completion.sh.hbs'),
       'utf-8'
     )
-    var name = path.basename($0)
+    const name = path.basename($0)
 
     // add ./to applications not yet installed as bin.
-    if ($0.match(/\.js$/)) $0 = './' + $0
+    if ($0.match(/\.js$/)) $0 = `./${$0}`
 
     script = script.replace(/{{app_name}}/g, name)
     return script.replace(/{{app_path}}/g, $0)
@@ -95,8 +94,8 @@ module.exports = function (yargs, usage, command) {
   // register a function to perform your own custom
   // completions., this function can be either
   // synchrnous or asynchronous.
-  var completionFunction = null
-  self.registerFunction = function (fn) {
+  let completionFunction = null
+  self.registerFunction = (fn) => {
     completionFunction = fn
   }
 

--- a/lib/levenshtein.js
+++ b/lib/levenshtein.js
@@ -10,22 +10,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 // levenshtein distance algorithm, pulled from Andrei Mackenzie's MIT licensed.
 // gist, which can be found here: https://gist.github.com/andrei-m/982927
-
+'use strict'
 // Compute the edit distance between the two given strings
-module.exports = function (a, b) {
+module.exports = function levenshtein (a, b) {
   if (a.length === 0) return b.length
   if (b.length === 0) return a.length
 
-  var matrix = []
+  const matrix = []
 
   // increment along the first column of each row
-  var i
+  let i
   for (i = 0; i <= b.length; i++) {
     matrix[i] = [i]
   }
 
   // increment each column in the first row
-  var j
+  let j
   for (j = 0; j <= a.length; j++) {
     matrix[0][j] = j
   }

--- a/lib/obj-filter.js
+++ b/lib/obj-filter.js
@@ -1,7 +1,8 @@
-module.exports = function (original, filter) {
+'use strict'
+module.exports = function objFilter (original, filter) {
   const obj = {}
-  filter = filter || function (k, v) { return true }
-  Object.keys(original || {}).forEach(function (key) {
+  filter = filter || ((k, v) => true)
+  Object.keys(original || {}).forEach((key) => {
     if (filter(key, original[key])) {
       obj[key] = original[key]
     }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,3 +1,4 @@
+'use strict'
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
 const stringWidth = require('string-width')
@@ -5,19 +6,19 @@ const objFilter = require('./obj-filter')
 const setBlocking = require('set-blocking')
 const YError = require('./yerror')
 
-module.exports = function (yargs, y18n) {
+module.exports = function usage (yargs, y18n) {
   const __ = y18n.__
   const self = {}
 
   // methods for ouputting/building failure message.
-  var fails = []
-  self.failFn = function (f) {
+  const fails = []
+  self.failFn = function failFn (f) {
     fails.push(f)
   }
 
-  var failMessage = null
-  var showHelpOnFail = true
-  self.showHelpOnFail = function (enabled, message) {
+  let failMessage = null
+  let showHelpOnFail = true
+  self.showHelpOnFail = function showHelpOnFailFn (enabled, message) {
     if (typeof enabled === 'string') {
       message = enabled
       enabled = true
@@ -29,12 +30,12 @@ module.exports = function (yargs, y18n) {
     return self
   }
 
-  var failureOutput = false
-  self.fail = function (msg, err) {
+  let failureOutput = false
+  self.fail = function fail (msg, err) {
     const logger = yargs._getLoggerInstance()
 
     if (fails.length) {
-      for (var i = fails.length - 1; i >= 0; --i) {
+      for (let i = fails.length - 1; i >= 0; --i) {
         fails[i](msg, err, self)
       }
     } else {
@@ -63,56 +64,50 @@ module.exports = function (yargs, y18n) {
   }
 
   // methods for ouputting/building help (usage) message.
-  var usage
-  self.usage = function (msg) {
+  let usage
+  self.usage = (msg) => {
     usage = msg
   }
-  self.getUsage = function () {
-    return usage
-  }
+  self.getUsage = () => usage
 
-  var examples = []
-  self.example = function (cmd, description) {
+  let examples = []
+  self.example = (cmd, description) => {
     examples.push([cmd, description || ''])
   }
 
-  var commands = []
-  self.command = function (cmd, description, isDefault, aliases) {
+  let commands = []
+  self.command = function command (cmd, description, isDefault, aliases) {
     // the last default wins, so cancel out any previously set default
     if (isDefault) {
-      commands = commands.map(function (cmdArray) {
+      commands = commands.map((cmdArray) => {
         cmdArray[2] = false
         return cmdArray
       })
     }
     commands.push([cmd, description || '', isDefault, aliases])
   }
-  self.getCommands = function () {
-    return commands
-  }
+  self.getCommands = () => commands
 
-  var descriptions = {}
-  self.describe = function (key, desc) {
+  let descriptions = {}
+  self.describe = function describe (key, desc) {
     if (typeof key === 'object') {
-      Object.keys(key).forEach(function (k) {
+      Object.keys(key).forEach((k) => {
         self.describe(k, key[k])
       })
     } else {
       descriptions[key] = desc
     }
   }
-  self.getDescriptions = function () {
-    return descriptions
-  }
+  self.getDescriptions = () => descriptions
 
-  var epilog
-  self.epilog = function (msg) {
+  let epilog
+  self.epilog = (msg) => {
     epilog = msg
   }
 
-  var wrapSet = false
-  var wrap
-  self.wrap = function (cols) {
+  let wrapSet = false
+  let wrap
+  self.wrap = (cols) => {
     wrapSet = true
     wrap = cols
   }
@@ -126,41 +121,39 @@ module.exports = function (yargs, y18n) {
     return wrap
   }
 
-  var deferY18nLookupPrefix = '__yargsString__:'
-  self.deferY18nLookup = function (str) {
-    return deferY18nLookupPrefix + str
-  }
+  const deferY18nLookupPrefix = '__yargsString__:'
+  self.deferY18nLookup = str => deferY18nLookupPrefix + str
 
-  var defaultGroup = 'Options:'
-  self.help = function () {
+  const defaultGroup = 'Options:'
+  self.help = function help () {
     normalizeAliases()
 
     // handle old demanded API
-    var demandedOptions = yargs.getDemandedOptions()
-    var demandedCommands = yargs.getDemandedCommands()
-    var groups = yargs.getGroups()
-    var options = yargs.getOptions()
-    var keys = Object.keys(
+    const demandedOptions = yargs.getDemandedOptions()
+    const demandedCommands = yargs.getDemandedCommands()
+    const groups = yargs.getGroups()
+    const options = yargs.getOptions()
+    let keys = Object.keys(
       Object.keys(descriptions)
       .concat(Object.keys(demandedOptions))
       .concat(Object.keys(demandedCommands))
       .concat(Object.keys(options.default))
-      .reduce(function (acc, key) {
+      .reduce((acc, key) => {
         if (key !== '_') acc[key] = true
         return acc
       }, {})
     )
 
-    var theWrap = getWrap()
-    var ui = require('cliui')({
+    const theWrap = getWrap()
+    const ui = require('cliui')({
       width: theWrap,
       wrap: !!theWrap
     })
 
     // the usage string.
     if (usage) {
-      var u = usage.replace(/\$0/g, yargs.$0)
-      ui.div(u + '\n')
+      const u = usage.replace(/\$0/g, yargs.$0)
+      ui.div(`${u}\n`)
     }
 
     // your application's commands, i.e., non-option
@@ -168,15 +161,15 @@ module.exports = function (yargs, y18n) {
     if (commands.length) {
       ui.div(__('Commands:'))
 
-      commands.forEach(function (command) {
+      commands.forEach((command) => {
         ui.span(
           {text: command[0], padding: [0, 2, 0, 2], width: maxWidth(commands, theWrap) + 4},
           {text: command[1]}
         )
-        var hints = []
-        if (command[2]) hints.push('[' + __('default:').slice(0, -1) + ']') // TODO hacking around i18n here
+        const hints = []
+        if (command[2]) hints.push(`[${__('default:').slice(0, -1)}]`) // TODO hacking around i18n here
         if (command[3] && command[3].length) {
-          hints.push('[' + __('aliases:') + ' ' + command[3].join(', ') + ']')
+          hints.push(`[${__('aliases:')} ${command[3].join(', ')}]`)
         }
         if (hints.length) {
           ui.div({text: hints.join(' '), padding: [0, 0, 0, 2], align: 'right'})
@@ -190,14 +183,10 @@ module.exports = function (yargs, y18n) {
 
     // perform some cleanup on the keys array, making it
     // only include top-level keys not their aliases.
-    var aliasKeys = (Object.keys(options.alias) || [])
+    const aliasKeys = (Object.keys(options.alias) || [])
       .concat(Object.keys(yargs.parsed.newAliases) || [])
 
-    keys = keys.filter(function (key) {
-      return !yargs.parsed.newAliases[key] && aliasKeys.every(function (alias) {
-        return (options.alias[alias] || []).indexOf(key) === -1
-      })
-    })
+    keys = keys.filter(key => !yargs.parsed.newAliases[key] && aliasKeys.every(alias => (options.alias[alias] || []).indexOf(key) === -1))
 
     // populate 'Options:' group with any keys that have not
     // explicitly had a group set.
@@ -205,51 +194,49 @@ module.exports = function (yargs, y18n) {
     addUngroupedKeys(keys, options.alias, groups)
 
     // display 'Options:' table along with any custom tables:
-    Object.keys(groups).forEach(function (groupName) {
+    Object.keys(groups).forEach((groupName) => {
       if (!groups[groupName].length) return
 
       ui.div(__(groupName))
 
       // if we've grouped the key 'f', but 'f' aliases 'foobar',
       // normalizedKeys should contain only 'foobar'.
-      var normalizedKeys = groups[groupName].map(function (key) {
+      const normalizedKeys = groups[groupName].map((key) => {
         if (~aliasKeys.indexOf(key)) return key
-        for (var i = 0, aliasKey; (aliasKey = aliasKeys[i]) !== undefined; i++) {
+        for (let i = 0, aliasKey; (aliasKey = aliasKeys[i]) !== undefined; i++) {
           if (~(options.alias[aliasKey] || []).indexOf(key)) return aliasKey
         }
         return key
       })
 
       // actually generate the switches string --foo, -f, --bar.
-      var switches = normalizedKeys.reduce(function (acc, key) {
+      const switches = normalizedKeys.reduce((acc, key) => {
         acc[key] = [ key ].concat(options.alias[key] || [])
-          .map(function (sw) {
-            return (sw.length > 1 ? '--' : '-') + sw
-          })
+          .map(sw => (sw.length > 1 ? '--' : '-') + sw)
           .join(', ')
 
         return acc
       }, {})
 
-      normalizedKeys.forEach(function (key) {
-        var kswitch = switches[key]
-        var desc = descriptions[key] || ''
-        var type = null
+      normalizedKeys.forEach((key) => {
+        const kswitch = switches[key]
+        let desc = descriptions[key] || ''
+        let type = null
 
         if (~desc.lastIndexOf(deferY18nLookupPrefix)) desc = __(desc.substring(deferY18nLookupPrefix.length))
 
-        if (~options.boolean.indexOf(key)) type = '[' + __('boolean') + ']'
-        if (~options.count.indexOf(key)) type = '[' + __('count') + ']'
-        if (~options.string.indexOf(key)) type = '[' + __('string') + ']'
-        if (~options.normalize.indexOf(key)) type = '[' + __('string') + ']'
-        if (~options.array.indexOf(key)) type = '[' + __('array') + ']'
-        if (~options.number.indexOf(key)) type = '[' + __('number') + ']'
+        if (~options.boolean.indexOf(key)) type = `[${__('boolean')}]`
+        if (~options.count.indexOf(key)) type = `[${__('count')}]`
+        if (~options.string.indexOf(key)) type = `[${__('string')}]`
+        if (~options.normalize.indexOf(key)) type = `[${__('string')}]`
+        if (~options.array.indexOf(key)) type = `[${__('array')}]`
+        if (~options.number.indexOf(key)) type = `[${__('number')}]`
 
-        var extra = [
+        const extra = [
           type,
-          (key in demandedOptions) ? '[' + __('required') + ']' : null,
-          options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
-            self.stringifiedValues(options.choices[key]) + ']' : null,
+          (key in demandedOptions) ? `[${__('required')}]` : null,
+          options.choices && options.choices[key] ? `[${__('choices:')} ${
+            self.stringifiedValues(options.choices[key])}]` : null,
           defaultString(options.default[key], options.defaultDescription[key])
         ].filter(Boolean).join(' ')
 
@@ -269,11 +256,11 @@ module.exports = function (yargs, y18n) {
     if (examples.length) {
       ui.div(__('Examples:'))
 
-      examples.forEach(function (example) {
+      examples.forEach((example) => {
         example[0] = example[0].replace(/\$0/g, yargs.$0)
       })
 
-      examples.forEach(function (example) {
+      examples.forEach((example) => {
         if (example[1] === '') {
           ui.div(
             {
@@ -299,8 +286,8 @@ module.exports = function (yargs, y18n) {
 
     // the usage string.
     if (epilog) {
-      var e = epilog.replace(/\$0/g, yargs.$0)
-      ui.div(e + '\n')
+      const e = epilog.replace(/\$0/g, yargs.$0)
+      ui.div(`${e}\n`)
     }
 
     return ui.toString()
@@ -309,17 +296,15 @@ module.exports = function (yargs, y18n) {
   // return the maximum width of a string
   // in the left-hand column of a table.
   function maxWidth (table, theWrap) {
-    var width = 0
+    let width = 0
 
     // table might be of the form [leftColumn],
     // or {key: leftColumn}
     if (!Array.isArray(table)) {
-      table = Object.keys(table).map(function (key) {
-        return [table[key]]
-      })
+      table = Object.keys(table).map(key => [table[key]])
     }
 
-    table.forEach(function (v) {
+    table.forEach((v) => {
       width = Math.max(stringWidth(v[0]), width)
     })
 
@@ -334,11 +319,11 @@ module.exports = function (yargs, y18n) {
   // are copied to the keys being aliased.
   function normalizeAliases () {
     // handle old demanded API
-    var demandedOptions = yargs.getDemandedOptions()
-    var options = yargs.getOptions()
+    const demandedOptions = yargs.getDemandedOptions()
+    const options = yargs.getOptions()
 
-    ;(Object.keys(options.alias) || []).forEach(function (key) {
-      options.alias[key].forEach(function (alias) {
+    ;(Object.keys(options.alias) || []).forEach((key) => {
+      options.alias[key].forEach((alias) => {
         // copy descriptions.
         if (descriptions[alias]) self.describe(key, descriptions[alias])
         // copy demanded.
@@ -357,43 +342,41 @@ module.exports = function (yargs, y18n) {
   // given a set of keys, place any keys that are
   // ungrouped under the 'Options:' grouping.
   function addUngroupedKeys (keys, aliases, groups) {
-    var groupedKeys = []
-    var toCheck = null
-    Object.keys(groups).forEach(function (group) {
+    let groupedKeys = []
+    let toCheck = null
+    Object.keys(groups).forEach((group) => {
       groupedKeys = groupedKeys.concat(groups[group])
     })
 
-    keys.forEach(function (key) {
+    keys.forEach((key) => {
       toCheck = [key].concat(aliases[key])
-      if (!toCheck.some(function (k) {
-        return groupedKeys.indexOf(k) !== -1
-      })) {
+      if (!toCheck.some(k => groupedKeys.indexOf(k) !== -1)) {
         groups[defaultGroup].push(key)
       }
     })
     return groupedKeys
   }
 
-  self.showHelp = function (level) {
+  self.showHelp = (level) => {
     const logger = yargs._getLoggerInstance()
     if (!level) level = 'error'
-    var emit = typeof level === 'function' ? level : logger[level]
+    const emit = typeof level === 'function' ? level : logger[level]
     emit(self.help())
   }
 
-  self.functionDescription = function (fn) {
-    var description = fn.name ? require('decamelize')(fn.name, '-') : __('generated-value')
+  self.functionDescription = (fn) => {
+    const description = fn.name ? require('decamelize')(fn.name, '-') : __('generated-value')
     return ['(', description, ')'].join('')
   }
 
-  self.stringifiedValues = function (values, separator) {
-    var string = ''
-    var sep = separator || ', '
-    var array = [].concat(values)
+  self.stringifiedValues = function stringifiedValues (values, separator) {
+    let string = ''
+    const sep = separator || ', '
+    const array = [].concat(values)
 
     if (!values || !array.length) return string
 
-    array.forEach(function (value) {
+    array.forEach((value) => {
       if (string.length) string += sep
       string += JSON.stringify(value)
     })
@@ -404,7 +387,7 @@ module.exports = function (yargs, y18n) {
   // format the default-value-string displayed in
   // the right-hand column.
   function defaultString (value, defaultDescription) {
-    var string = '[' + __('default:') + ' '
+    let string = `[${__('default:')} `
 
     if (value === undefined && !defaultDescription) return null
 
@@ -413,7 +396,7 @@ module.exports = function (yargs, y18n) {
     } else {
       switch (typeof value) {
         case 'string':
-          string += '"' + value + '"'
+          string += `"${value}"`
           break
         case 'object':
           string += JSON.stringify(value)
@@ -423,12 +406,12 @@ module.exports = function (yargs, y18n) {
       }
     }
 
-    return string + ']'
+    return `${string}]`
   }
 
   // guess the width of the console window, max-width 80.
   function windowWidth () {
-    var maxWidth = 80
+    const maxWidth = 80
     if (typeof process === 'object' && process.stdout && process.stdout.columns) {
       return Math.min(maxWidth, process.stdout.columns)
     } else {
@@ -437,17 +420,17 @@ module.exports = function (yargs, y18n) {
   }
 
   // logic for displaying application version.
-  var version = null
-  self.version = function (ver) {
+  let version = null
+  self.version = (ver) => {
     version = ver
   }
 
-  self.showVersion = function () {
+  self.showVersion = () => {
     const logger = yargs._getLoggerInstance()
     logger.log(version)
   }
 
-  self.reset = function (localLookup) {
+  self.reset = function reset (localLookup) {
     // do not reset wrap here
     // do not reset fails here
     failMessage = null
@@ -456,14 +439,12 @@ module.exports = function (yargs, y18n) {
     epilog = undefined
     examples = []
     commands = []
-    descriptions = objFilter(descriptions, function (k, v) {
-      return !localLookup[k]
-    })
+    descriptions = objFilter(descriptions, (k, v) => !localLookup[k])
     return self
   }
 
-  var frozen
-  self.freeze = function () {
+  let frozen
+  self.freeze = function freeze () {
     frozen = {}
     frozen.failMessage = failMessage
     frozen.failureOutput = failureOutput
@@ -473,7 +454,7 @@ module.exports = function (yargs, y18n) {
     frozen.commands = commands
     frozen.descriptions = descriptions
   }
-  self.unfreeze = function () {
+  self.unfreeze = function unfreeze () {
     failMessage = frozen.failMessage
     failureOutput = frozen.failureOutput
     usage = frozen.usage

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,16 +1,17 @@
+'use strict'
 const objFilter = require('./obj-filter')
 const specialKeys = ['$0', '--', '_']
 
 // validation-type-stuff, missing params,
 // bad implications, custom checks.
-module.exports = function (yargs, usage, y18n) {
+module.exports = function validation (yargs, usage, y18n) {
   const __ = y18n.__
   const __n = y18n.__n
   const self = {}
 
   // validate appropriate # of non-option
   // arguments were provided, i.e., '_'.
-  self.nonOptionCount = function (argv) {
+  self.nonOptionCount = function nonOptionCount (argv) {
     const demandedCommands = yargs.getDemandedCommands()
     // don't count currently executing commands
     const _s = argv._.length - yargs.getContext().commands.length
@@ -44,7 +45,7 @@ module.exports = function (yargs, usage, y18n) {
 
   // validate the appropriate # of <required>
   // positional arguments were provided:
-  self.positionalCount = function (required, observed) {
+  self.positionalCount = function positionalCount (required, observed) {
     if (observed < required) {
       usage.fail(
         __('Not enough non-option arguments: got %s, need at least %s', observed, required)
@@ -54,14 +55,14 @@ module.exports = function (yargs, usage, y18n) {
 
   // make sure that any args that require an
   // value (--foo=bar), have a value.
-  self.missingArgumentValue = function (argv) {
+  self.missingArgumentValue = function missingArgumentValue (argv) {
     const defaultValues = [true, false, '']
     const options = yargs.getOptions()
 
     if (options.requiresArg.length > 0) {
       const missingRequiredArgs = []
 
-      options.requiresArg.forEach(function (key) {
+      options.requiresArg.forEach((key) => {
         const value = argv[key]
 
         // if a value is explicitly requested,
@@ -85,11 +86,11 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   // make sure all the required arguments are present.
-  self.requiredArguments = function (argv) {
+  self.requiredArguments = function requiredArguments (argv) {
     const demandedOptions = yargs.getDemandedOptions()
-    var missing = null
+    let missing = null
 
-    Object.keys(demandedOptions).forEach(function (key) {
+    Object.keys(demandedOptions).forEach((key) => {
       if (!argv.hasOwnProperty(key) || typeof argv[key] === 'undefined') {
         missing = missing || {}
         missing[key] = demandedOptions[key]
@@ -98,14 +99,14 @@ module.exports = function (yargs, usage, y18n) {
 
     if (missing) {
       const customMsgs = []
-      Object.keys(missing).forEach(function (key) {
+      Object.keys(missing).forEach((key) => {
         const msg = missing[key]
         if (msg && customMsgs.indexOf(msg) < 0) {
           customMsgs.push(msg)
         }
       })
 
-      const customMsg = customMsgs.length ? '\n' + customMsgs.join('\n') : ''
+      const customMsg = customMsgs.length ? `\n${customMsgs.join('\n')}` : ''
 
       usage.fail(__n(
         'Missing required argument: %s',
@@ -117,7 +118,7 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   // check for unknown arguments (strict-mode).
-  self.unknownArguments = function (argv, aliases, positionalMap) {
+  self.unknownArguments = function unknownArguments (argv, aliases, positionalMap) {
     const aliasLookup = {}
     const descriptions = usage.getDescriptions()
     const demandedOptions = yargs.getDemandedOptions()
@@ -125,13 +126,13 @@ module.exports = function (yargs, usage, y18n) {
     const unknown = []
     const currentContext = yargs.getContext()
 
-    Object.keys(aliases).forEach(function (key) {
-      aliases[key].forEach(function (alias) {
+    Object.keys(aliases).forEach((key) => {
+      aliases[key].forEach((alias) => {
         aliasLookup[alias] = key
       })
     })
 
-    Object.keys(argv).forEach(function (key) {
+    Object.keys(argv).forEach((key) => {
       if (specialKeys.indexOf(key) === -1 &&
         !descriptions.hasOwnProperty(key) &&
         !demandedOptions.hasOwnProperty(key) &&
@@ -143,7 +144,7 @@ module.exports = function (yargs, usage, y18n) {
     })
 
     if (commandKeys.length > 0) {
-      argv._.slice(currentContext.commands.length).forEach(function (key) {
+      argv._.slice(currentContext.commands.length).forEach((key) => {
         if (commandKeys.indexOf(key) === -1) {
           unknown.push(key)
         }
@@ -161,16 +162,16 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   // validate arguments limited to enumerated choices
-  self.limitedChoices = function (argv) {
+  self.limitedChoices = function limitedChoices (argv) {
     const options = yargs.getOptions()
     const invalid = {}
 
     if (!Object.keys(options.choices).length) return
 
-    Object.keys(argv).forEach(function (key) {
+    Object.keys(argv).forEach((key) => {
       if (specialKeys.indexOf(key) === -1 &&
         options.choices.hasOwnProperty(key)) {
-        [].concat(argv[key]).forEach(function (value) {
+        [].concat(argv[key]).forEach((value) => {
           // TODO case-insensitive configurability
           if (options.choices[key].indexOf(value) === -1 &&
               value !== undefined) {
@@ -184,31 +185,31 @@ module.exports = function (yargs, usage, y18n) {
 
     if (!invalidKeys.length) return
 
-    var msg = __('Invalid values:')
-    invalidKeys.forEach(function (key) {
-      msg += '\n  ' + __(
+    let msg = __('Invalid values:')
+    invalidKeys.forEach((key) => {
+      msg += `\n  ${__(
         'Argument: %s, Given: %s, Choices: %s',
         key,
         usage.stringifiedValues(invalid[key]),
         usage.stringifiedValues(options.choices[key])
-      )
+      )}`
     })
     usage.fail(msg)
   }
 
   // custom checks, added using the `check` option on yargs.
-  var checks = []
-  self.check = function (f, global) {
+  let checks = []
+  self.check = function check (f, global) {
     checks.push({
       func: f,
-      global: global
+      global
     })
   }
 
-  self.customChecks = function (argv, aliases) {
-    for (var i = 0, f; (f = checks[i]) !== undefined; i++) {
-      var func = f.func
-      var result = null
+  self.customChecks = function customChecks (argv, aliases) {
+    for (let i = 0, f; (f = checks[i]) !== undefined; i++) {
+      const func = f.func
+      let result = null
       try {
         result = func(argv, aliases)
       } catch (err) {
@@ -225,10 +226,10 @@ module.exports = function (yargs, usage, y18n) {
   }
 
   // check implications, argument foo implies => argument bar.
-  var implied = {}
-  self.implies = function (key, value) {
+  let implied = {}
+  self.implies = function implies (key, value) {
     if (typeof key === 'object') {
-      Object.keys(key).forEach(function (k) {
+      Object.keys(key).forEach((k) => {
         self.implies(k, key[k])
       })
     } else {
@@ -236,17 +237,17 @@ module.exports = function (yargs, usage, y18n) {
       implied[key] = value
     }
   }
-  self.getImplied = function () {
+  self.getImplied = function getImplied () {
     return implied
   }
 
-  self.implications = function (argv) {
+  self.implications = function implications (argv) {
     const implyFail = []
 
-    Object.keys(implied).forEach(function (key) {
-      var num
+    Object.keys(implied).forEach((key) => {
+      let num
       const origKey = key
-      var value = implied[key]
+      let value = implied[key]
 
       // convert string '1' to number 1
       num = Number(key)
@@ -282,20 +283,20 @@ module.exports = function (yargs, usage, y18n) {
     })
 
     if (implyFail.length) {
-      var msg = __('Implications failed:') + '\n'
+      let msg = `${__('Implications failed:')}\n`
 
-      implyFail.forEach(function (key) {
-        msg += ('  ' + key + ' -> ' + implied[key])
+      implyFail.forEach((key) => {
+        msg += (`  ${key} -> ${implied[key]}`)
       })
 
       usage.fail(msg)
     }
   }
 
-  var conflicting = {}
-  self.conflicts = function (key, value) {
+  let conflicting = {}
+  self.conflicts = function conflicts (key, value) {
     if (typeof key === 'object') {
-      Object.keys(key).forEach(function (k) {
+      Object.keys(key).forEach((k) => {
         self.conflicts(k, key[k])
       })
     } else {
@@ -303,13 +304,11 @@ module.exports = function (yargs, usage, y18n) {
       conflicting[key] = value
     }
   }
-  self.getConflicting = function () {
-    return conflicting
-  }
+  self.getConflicting = () => conflicting
 
-  self.conflicting = function (argv) {
-    var args = Object.getOwnPropertyNames(argv)
-    args.forEach(function (arg) {
+  self.conflicting = function conflictingFn (argv) {
+    const args = Object.getOwnPropertyNames(argv)
+    args.forEach((arg) => {
       // we default keys to 'undefined' that have been configured, we should not
       // apply conflicting check unless they are a value other than 'undefined'.
       if (conflicting[arg] && args.indexOf(conflicting[arg]) !== -1 && argv[arg] !== undefined && argv[conflicting[arg]] !== undefined) {
@@ -318,15 +317,15 @@ module.exports = function (yargs, usage, y18n) {
     })
   }
 
-  self.recommendCommands = function (cmd, potentialCommands) {
+  self.recommendCommands = function recommendCommands (cmd, potentialCommands) {
     const distance = require('./levenshtein')
     const threshold = 3 // if it takes more than three edits, let's move on.
-    potentialCommands = potentialCommands.sort(function (a, b) { return b.length - a.length })
+    potentialCommands = potentialCommands.sort((a, b) => b.length - a.length)
 
-    var recommended = null
-    var bestDistance = Infinity
-    for (var i = 0, candidate; (candidate = potentialCommands[i]) !== undefined; i++) {
-      var d = distance(cmd, candidate)
+    let recommended = null
+    let bestDistance = Infinity
+    for (let i = 0, candidate; (candidate = potentialCommands[i]) !== undefined; i++) {
+      const d = distance(cmd, candidate)
       if (d <= threshold && d < bestDistance) {
         bestDistance = d
         recommended = candidate
@@ -335,27 +334,21 @@ module.exports = function (yargs, usage, y18n) {
     if (recommended) usage.fail(__('Did you mean %s?', recommended))
   }
 
-  self.reset = function (localLookup) {
-    implied = objFilter(implied, function (k, v) {
-      return !localLookup[k]
-    })
-    conflicting = objFilter(conflicting, function (k, v) {
-      return !localLookup[k]
-    })
-    checks = checks.filter(function (c) {
-      return c.global
-    })
+  self.reset = function reset (localLookup) {
+    implied = objFilter(implied, (k, v) => !localLookup[k])
+    conflicting = objFilter(conflicting, (k, v) => !localLookup[k])
+    checks = checks.filter(c => c.global)
     return self
   }
 
-  var frozen
-  self.freeze = function () {
+  let frozen
+  self.freeze = function freeze () {
     frozen = {}
     frozen.implied = implied
     frozen.checks = checks
     frozen.conflicting = conflicting
   }
-  self.unfreeze = function () {
+  self.unfreeze = function unfreeze () {
     implied = frozen.implied
     checks = frozen.checks
     conflicting = frozen.conflicting

--- a/lib/yerror.js
+++ b/lib/yerror.js
@@ -1,3 +1,4 @@
+'use strict'
 function YError (msg) {
   this.name = 'YError'
   this.message = msg || 'yargs error'

--- a/test/argsert.js
+++ b/test/argsert.js
@@ -1,3 +1,4 @@
+'use strict'
 /* global describe, it */
 
 const argsert = require('../lib/argsert')
@@ -5,17 +6,17 @@ const checkOutput = require('./helpers/utils').checkOutput
 
 require('chai').should()
 
-describe('Argsert', function () {
-  it('does not warn if optional argument is not provided', function () {
-    var o = checkOutput(function () {
+describe('Argsert', () => {
+  it('does not warn if optional argument is not provided', () => {
+    const o = checkOutput(function () {
       argsert('[object]', [].slice.call(arguments))
     })
 
     o.warnings.length.should.equal(0)
   })
 
-  it('warn if wrong type is provided for optional argument', function () {
-    var o = checkOutput(function () {
+  it('warn if wrong type is provided for optional argument', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('[object|number]', [].slice.call(arguments))
       }
@@ -26,8 +27,8 @@ describe('Argsert', function () {
     o.warnings[0].should.match(/Invalid first argument. Expected object or number but received string./)
   })
 
-  it('does not warn if optional argument is valid', function () {
-    var o = checkOutput(function () {
+  it('does not warn if optional argument is valid', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('[object]', [].slice.call(arguments))
       }
@@ -38,16 +39,16 @@ describe('Argsert', function () {
     o.warnings.length.should.equal(0)
   })
 
-  it('warns if required argument is not provided', function () {
-    var o = checkOutput(function () {
+  it('warns if required argument is not provided', () => {
+    const o = checkOutput(function () {
       argsert('<object>', [].slice.call(arguments))
     })
 
     o.warnings[0].should.match(/Not enough arguments provided. Expected 1 but received 0./)
   })
 
-  it('warns if required argument is of wrong type', function () {
-    var o = checkOutput(function () {
+  it('warns if required argument is of wrong type', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('<object>', [].slice.call(arguments))
       }
@@ -58,8 +59,8 @@ describe('Argsert', function () {
     o.warnings[0].should.match(/Invalid first argument. Expected object but received string./)
   })
 
-  it('supports a combination of required and optional arguments', function () {
-    var o = checkOutput(function () {
+  it('supports a combination of required and optional arguments', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('<array> <string|object> [string|object]', [].slice.call(arguments))
       }
@@ -70,8 +71,8 @@ describe('Argsert', function () {
     o.warnings.length.should.equal(0)
   })
 
-  it('warns if too many arguments are provided', function () {
-    var o = checkOutput(function () {
+  it('warns if too many arguments are provided', () => {
+    const o = checkOutput(() => {
       function foo (expected) {
         argsert('<array> [batman]', [].slice.call(arguments))
       }
@@ -82,8 +83,8 @@ describe('Argsert', function () {
     o.warnings[0].should.match(/Too many arguments provided. Expected max 2 but received 3./)
   })
 
-  it('configures function to accept 0 parameters, if only arguments object is provided', function () {
-    var o = checkOutput(function () {
+  it('configures function to accept 0 parameters, if only arguments object is provided', () => {
+    const o = checkOutput(() => {
       function foo (expected) {
         argsert([].slice.call(arguments))
       }
@@ -94,8 +95,8 @@ describe('Argsert', function () {
     o.warnings[0].should.match(/Too many arguments provided. Expected max 0 but received 1./)
   })
 
-  it('allows for any type if * is provided', function () {
-    var o = checkOutput(function () {
+  it('allows for any type if * is provided', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('<*>', [].slice.call(arguments))
       }
@@ -106,8 +107,8 @@ describe('Argsert', function () {
     o.warnings.length.should.equal(0)
   })
 
-  it('should ignore trailing undefined values', function () {
-    var o = checkOutput(function () {
+  it('should ignore trailing undefined values', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('<*>', [].slice.call(arguments))
       }
@@ -118,8 +119,8 @@ describe('Argsert', function () {
     o.warnings.length.should.equal(0)
   })
 
-  it('should not ignore undefined values that are not trailing', function () {
-    var o = checkOutput(function () {
+  it('should not ignore undefined values that are not trailing', () => {
+    const o = checkOutput(() => {
       function foo (opts) {
         argsert('<*>', [].slice.call(arguments))
       }
@@ -130,8 +131,8 @@ describe('Argsert', function () {
     o.warnings[0].should.match(/Too many arguments provided. Expected max 1 but received 4./)
   })
 
-  it('supports null as special type', function () {
-    var o = checkOutput(function () {
+  it('supports null as special type', () => {
+    const o = checkOutput(() => {
       function foo (arg) {
         argsert('<null>', [].slice.call(arguments))
       }

--- a/test/before.js
+++ b/test/before.js
@@ -1,1 +1,2 @@
+'use strict'
 process.env.LC_ALL = 'en_US'

--- a/test/command.js
+++ b/test/command.js
@@ -1,23 +1,24 @@
+'use strict'
 /* global describe, it, beforeEach */
-var yargs = require('../')
-var expect = require('chai').expect
-var checkOutput = require('./helpers/utils').checkOutput
+const yargs = require('../')
+const expect = require('chai').expect
+const checkOutput = require('./helpers/utils').checkOutput
 
 require('chai').should()
 
-describe('Command', function () {
-  beforeEach(function () {
+const noop = () => {}
+
+describe('Command', () => {
+  beforeEach(() => {
     yargs.reset()
   })
 
-  describe('positional arguments', function () {
-    it('parses command string and populates optional and required positional arguments', function () {
-      var y = yargs([])
-        .command('foo <bar> [awesome]', 'my awesome command', function (yargs) {
-          return yargs
-        })
-      var command = y.getCommandInstance()
-      var handlers = command.getCommandHandlers()
+  describe('positional arguments', () => {
+    it('parses command string and populates optional and required positional arguments', () => {
+      const y = yargs([])
+        .command('foo <bar> [awesome]', 'my awesome command', yargs => yargs)
+      const command = y.getCommandInstance()
+      const handlers = command.getCommandHandlers()
       handlers.foo.demanded.should.include({
         cmd: ['bar'],
         variadic: false
@@ -28,9 +29,9 @@ describe('Command', function () {
       })
     })
 
-    it('populates inner argv with positional arguments', function (done) {
+    it('populates inner argv with positional arguments', (done) => {
       yargs('foo hello world')
-        .command('foo <bar> [awesome]', 'my awesome command', function () {}, function (argv) {
+        .command('foo <bar> [awesome]', 'my awesome command', noop, (argv) => {
           argv._.should.include('foo')
           argv.bar.should.equal('hello')
           argv.awesome.should.equal('world')
@@ -39,8 +40,8 @@ describe('Command', function () {
         .argv
     })
 
-    it('populates outer argv with positional arguments', function () {
-      var argv = yargs('foo hello world')
+    it('populates outer argv with positional arguments', () => {
+      const argv = yargs('foo hello world')
         .command('foo <bar> [awesome]')
         .argv
 
@@ -49,8 +50,8 @@ describe('Command', function () {
       argv.awesome.should.equal('world')
     })
 
-    it('populates argv with camel-case variants of arguments when possible', function () {
-      var argv = yargs('foo hello world')
+    it('populates argv with camel-case variants of arguments when possible', () => {
+      const argv = yargs('foo hello world')
         .command('foo <foo-bar> [baz-qux]')
         .argv
 
@@ -61,8 +62,8 @@ describe('Command', function () {
       argv['baz-qux'].should.equal('world')
     })
 
-    it('populates argv with camel-case variants of variadic args when possible', function () {
-      var argv = yargs('foo hello world !')
+    it('populates argv with camel-case variants of variadic args when possible', () => {
+      const argv = yargs('foo hello world !')
         .command('foo <foo-bar> [baz-qux..]')
         .argv
 
@@ -73,28 +74,26 @@ describe('Command', function () {
       argv['baz-qux'].should.deep.equal(['world', '!'])
     })
 
-    it('populates subcommand\'s inner argv with positional arguments', function () {
+    it('populates subcommand\'s inner argv with positional arguments', () => {
       yargs('foo bar hello world')
-        .command('foo', 'my awesome command', function (yargs) {
-          return yargs.command(
+        .command('foo', 'my awesome command', yargs => yargs.command(
             'bar <greeting> [recipient]',
             'subcommands are cool',
-            function () {},
-            function (argv) {
+            noop,
+            (argv) => {
               argv._.should.deep.equal(['foo', 'bar'])
               argv.greeting.should.equal('hello')
               argv.recipient.should.equal('world')
             }
-          )
-        })
+          ))
         .argv
     })
 
-    it('ignores positional args for aliases', function () {
-      var y = yargs([])
+    it('ignores positional args for aliases', () => {
+      const y = yargs([])
         .command(['foo [awesome]', 'wat <yo>'], 'my awesome command')
-      var command = y.getCommandInstance()
-      var handlers = command.getCommandHandlers()
+      const command = y.getCommandInstance()
+      const handlers = command.getCommandHandlers()
       handlers.foo.optional.should.include({
         cmd: ['awesome'],
         variadic: false
@@ -105,9 +104,9 @@ describe('Command', function () {
     })
   })
 
-  describe('variadic', function () {
-    it('allows required arguments to be variadic', function () {
-      var argv = yargs('foo /root file1 file2 file3')
+  describe('variadic', () => {
+    it('allows required arguments to be variadic', () => {
+      const argv = yargs('foo /root file1 file2 file3')
         .command('foo <root> <files..>')
         .argv
 
@@ -115,8 +114,8 @@ describe('Command', function () {
       argv.files.should.deep.equal(['file1', 'file2', 'file3'])
     })
 
-    it('allows optional arguments to be variadic', function () {
-      var argv = yargs('foo /root file1 file2 file3')
+    it('allows optional arguments to be variadic', () => {
+      const argv = yargs('foo /root file1 file2 file3')
         .command('foo <root> [files..]')
         .argv
 
@@ -124,18 +123,18 @@ describe('Command', function () {
       argv.files.should.deep.equal(['file1', 'file2', 'file3'])
     })
 
-    it('fails if required arguments are missing', function (done) {
+    it('fails if required arguments are missing', (done) => {
       yargs('foo /root')
         .command('foo <root> <files..>')
-        .fail(function (err) {
+        .fail((err) => {
           err.should.match(/Not enough non-option arguments/)
           return done()
         })
         .argv
     })
 
-    it('does not fail if zero optional arguments are provided', function () {
-      var argv = yargs('foo /root')
+    it('does not fail if zero optional arguments are provided', () => {
+      const argv = yargs('foo /root')
         .command('foo <root> [files...]')
         .argv
 
@@ -143,8 +142,8 @@ describe('Command', function () {
       argv.files.should.deep.equal([])
     })
 
-    it('only allows the last argument to be variadic', function () {
-      var argv = yargs('foo /root file1 file2')
+    it('only allows the last argument to be variadic', () => {
+      const argv = yargs('foo /root file1 file2')
         .command('foo <root..> <file>')
         .argv
 
@@ -154,11 +153,11 @@ describe('Command', function () {
     })
   })
 
-  describe('missing positional arguments', function () {
-    it('fails if a required argument is missing', function (done) {
-      var argv = yargs('foo hello')
+  describe('missing positional arguments', () => {
+    it('fails if a required argument is missing', (done) => {
+      const argv = yargs('foo hello')
         .command('foo <bar> <awesome>')
-        .fail(function (err) {
+        .fail((err) => {
           err.should.match(/got 1, need at least 2/)
           return done()
         })
@@ -167,8 +166,8 @@ describe('Command', function () {
       argv.bar.should.equal('hello')
     })
 
-    it('does not fail if optional argument is missing', function () {
-      var argv = yargs('foo hello')
+    it('does not fail if optional argument is missing', () => {
+      const argv = yargs('foo hello')
         .command('foo <bar> [awesome]')
         .argv
 
@@ -177,200 +176,200 @@ describe('Command', function () {
     })
   })
 
-  describe('API', function () {
-    it('accepts string, string as first 2 arguments', function () {
-      var cmd = 'foo'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var isDefault = false
-      var aliases = []
+  describe('API', () => {
+    it('accepts string, string as first 2 arguments', () => {
+      const cmd = 'foo'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(cmd, desc)
-      var commands = y.getUsageInstance().getCommands()
+      const y = yargs([]).command(cmd, desc)
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([cmd, desc, isDefault, aliases])
     })
 
-    it('accepts array, string as first 2 arguments', function () {
-      var aliases = ['bar', 'baz']
-      var cmd = 'foo <qux>'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var isDefault = false
+    it('accepts array, string as first 2 arguments', () => {
+      const aliases = ['bar', 'baz']
+      const cmd = 'foo <qux>'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const isDefault = false
 
-      var y = yargs([]).command([cmd].concat(aliases), desc)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const y = yargs([]).command([cmd].concat(aliases), desc)
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands[0].should.deep.equal([cmd, desc, isDefault, aliases])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
     })
 
-    it('accepts string, boolean as first 2 arguments', function () {
-      var cmd = 'foo'
-      var desc = false
+    it('accepts string, boolean as first 2 arguments', () => {
+      const cmd = 'foo'
+      const desc = false
 
-      var y = yargs([]).command(cmd, desc)
-      var commands = y.getUsageInstance().getCommands()
+      const y = yargs([]).command(cmd, desc)
+      const commands = y.getUsageInstance().getCommands()
       commands.should.deep.equal([])
     })
 
-    it('accepts array, boolean as first 2 arguments', function () {
-      var aliases = ['bar', 'baz']
-      var cmd = 'foo <qux>'
-      var desc = false
+    it('accepts array, boolean as first 2 arguments', () => {
+      const aliases = ['bar', 'baz']
+      const cmd = 'foo <qux>'
+      const desc = false
 
-      var y = yargs([]).command([cmd].concat(aliases), desc)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const y = yargs([]).command([cmd].concat(aliases), desc)
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands.should.deep.equal([])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
     })
 
-    it('accepts function as 3rd argument', function () {
-      var cmd = 'foo'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var builder = function (yargs) { return yargs }
+    it('accepts function as 3rd argument', () => {
+      const cmd = 'foo'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const builder = yargs => yargs
 
-      var y = yargs([]).command(cmd, desc, builder)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(cmd, desc, builder)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(cmd)
       handlers.foo.builder.should.equal(builder)
     })
 
-    it('accepts options object as 3rd argument', function () {
-      var cmd = 'foo'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var builder = {
+    it('accepts options object as 3rd argument', () => {
+      const cmd = 'foo'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const builder = {
         hello: { default: 'world' }
       }
 
-      var y = yargs([]).command(cmd, desc, builder)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(cmd, desc, builder)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(cmd)
       handlers.foo.builder.should.equal(builder)
     })
 
-    it('accepts module (with builder function and handler function) as 3rd argument', function () {
-      var cmd = 'foo'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var module = {
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+    it('accepts module (with builder function and handler function) as 3rd argument', () => {
+      const cmd = 'foo'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const module = {
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
 
-      var y = yargs([]).command(cmd, desc, module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(cmd, desc, module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(cmd)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
     })
 
-    it('accepts module (with builder object and handler function) as 3rd argument', function () {
-      var cmd = 'foo'
-      var desc = 'i\'m not feeling very creative at the moment'
-      var module = {
+    it('accepts module (with builder object and handler function) as 3rd argument', () => {
+      const cmd = 'foo'
+      const desc = 'i\'m not feeling very creative at the moment'
+      const module = {
         builder: {
           hello: { default: 'world' }
         },
-        handler: function (argv) {}
+        handler (argv) {}
       }
 
-      var y = yargs([]).command(cmd, desc, module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(cmd, desc, module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(cmd)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
     })
 
-    it('accepts module (describe key, builder function) as 1st argument', function () {
-      var module = {
+    it('accepts module (describe key, builder function) as 1st argument', () => {
+      const module = {
         command: 'foo',
         describe: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
-      var aliases = []
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.describe, isDefault, aliases])
     })
 
-    it('accepts module (description key, builder function) as 1st argument', function () {
-      var module = {
+    it('accepts module (description key, builder function) as 1st argument', () => {
+      const module = {
         command: 'foo',
         description: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
-      var aliases = []
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.description, isDefault, aliases])
     })
 
-    it('accepts module (desc key, builder function) as 1st argument', function () {
-      var module = {
+    it('accepts module (desc key, builder function) as 1st argument', () => {
+      const module = {
         command: 'foo',
         desc: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
-      var aliases = []
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.desc, isDefault, aliases])
     })
 
-    it('accepts module (false describe, builder function) as 1st argument', function () {
-      var module = {
+    it('accepts module (false describe, builder function) as 1st argument', () => {
+      const module = {
         command: 'foo',
         describe: false,
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands.should.deep.equal([])
     })
 
-    it('accepts module (missing describe, builder function) as 1st argument', function () {
-      var module = {
+    it('accepts module (missing describe, builder function) as 1st argument', () => {
+      const module = {
         command: 'foo',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands.should.deep.equal([])
     })
 
-    it('accepts module (describe key, builder object) as 1st argument', function () {
-      var module = {
+    it('accepts module (describe key, builder object) as 1st argument', () => {
+      const module = {
         command: 'foo',
         describe: 'i\'m not feeling very creative at the moment',
         builder: {
@@ -378,22 +377,22 @@ describe('Command', function () {
             default: 'world'
           }
         },
-        handler: function (argv) {}
+        handler (argv) {}
       }
-      var isDefault = false
-      var aliases = []
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.describe, isDefault, aliases])
     })
 
-    it('accepts module (missing handler function) as 1st argument', function () {
-      var module = {
+    it('accepts module (missing handler function) as 1st argument', () => {
+      const module = {
         command: 'foo',
         describe: 'i\'m not feeling very creative at the moment',
         builder: {
@@ -402,109 +401,107 @@ describe('Command', function () {
           }
         }
       }
-      var isDefault = false
-      var aliases = []
+      const isDefault = false
+      const aliases = []
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       expect(typeof handlers.foo.handler).to.equal('function')
-      var commands = y.getUsageInstance().getCommands()
+      const commands = y.getUsageInstance().getCommands()
       commands[0].should.deep.equal([module.command, module.describe, isDefault, aliases])
     })
 
-    it('accepts module (with command array) as 1st argument', function () {
-      var module = {
+    it('accepts module (with command array) as 1st argument', () => {
+      const module = {
         command: ['foo <qux>', 'bar', 'baz'],
         describe: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
+      const isDefault = false
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command[0])
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands[0].should.deep.equal([module.command[0], module.describe, isDefault, ['bar', 'baz']])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
     })
 
-    it('accepts module (with command string and aliases array) as 1st argument', function () {
-      var module = {
+    it('accepts module (with command string and aliases array) as 1st argument', () => {
+      const module = {
         command: 'foo <qux>',
         aliases: ['bar', 'baz'],
         describe: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
+      const isDefault = false
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands[0].should.deep.equal([module.command, module.describe, isDefault, module.aliases])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz'])
     })
 
-    it('accepts module (with command array and aliases array) as 1st argument', function () {
-      var module = {
+    it('accepts module (with command array and aliases array) as 1st argument', () => {
+      const module = {
         command: ['foo <qux>', 'bar'],
         aliases: ['baz', 'nat'],
         describe: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
+      const isDefault = false
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command[0])
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands[0].should.deep.equal([module.command[0], module.describe, isDefault, ['bar', 'baz', 'nat']])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar', 'baz', 'nat'])
     })
 
-    it('accepts module (with command string and aliases string) as 1st argument', function () {
-      var module = {
+    it('accepts module (with command string and aliases string) as 1st argument', () => {
+      const module = {
         command: 'foo <qux>',
         aliases: 'bar',
         describe: 'i\'m not feeling very creative at the moment',
-        builder: function (yargs) { return yargs },
-        handler: function (argv) {}
+        builder (yargs) { return yargs },
+        handler (argv) {}
       }
-      var isDefault = false
+      const isDefault = false
 
-      var y = yargs([]).command(module)
-      var handlers = y.getCommandInstance().getCommandHandlers()
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
       handlers.foo.original.should.equal(module.command)
       handlers.foo.builder.should.equal(module.builder)
       handlers.foo.handler.should.equal(module.handler)
-      var usageCommands = y.getUsageInstance().getCommands()
+      const usageCommands = y.getUsageInstance().getCommands()
       usageCommands[0].should.deep.equal([module.command, module.describe, isDefault, ['bar']])
-      var cmdCommands = y.getCommandInstance().getCommands()
+      const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar'])
     })
   })
 
-  describe('commandDir', function () {
-    it('supports relative dirs', function () {
-      var r = checkOutput(function () {
-        return yargs('--help').wrap(null)
+  describe('commandDir', () => {
+    it('supports relative dirs', () => {
+      const r = checkOutput(() => yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir')
-          .argv
-      })
+          .argv)
       r.should.have.property('exit').and.be.true
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
@@ -518,12 +515,10 @@ describe('Command', function () {
       ])
     })
 
-    it('supports nested subcommands', function () {
-      var r = checkOutput(function () {
-        return yargs('dream --help').wrap(null)
+    it('supports nested subcommands', () => {
+      const r = checkOutput(() => yargs('dream --help').wrap(null)
           .commandDir('fixtures/cmddir')
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
       r.should.have.property('exit').and.be.true
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
@@ -541,12 +536,10 @@ describe('Command', function () {
       ])
     })
 
-    it('supports a "recurse" boolean option', function () {
-      var r = checkOutput(function () {
-        return yargs('--help').wrap(null)
+    it('supports a "recurse" boolean option', () => {
+      const r = checkOutput(() => yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir', { recurse: true })
-          .argv
-      })
+          .argv)
       r.should.have.property('exit').and.be.true
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
@@ -563,22 +556,20 @@ describe('Command', function () {
       ])
     })
 
-    it('supports a "visit" function option', function () {
-      var commandObject
-      var pathToFile
-      var filename
-      var r = checkOutput(function () {
-        return yargs('--help').wrap(null)
+    it('supports a "visit" function option', () => {
+      let commandObject
+      let pathToFile
+      let filename
+      const r = checkOutput(() => yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir', {
-            visit: function (_commandObject, _pathToFile, _filename) {
+            visit (_commandObject, _pathToFile, _filename) {
               commandObject = _commandObject
               pathToFile = _pathToFile
               filename = _filename
               return false // exclude command
             }
           })
-          .argv
-      })
+          .argv)
       commandObject.should.have.property('command').and.equal('dream [command] [opts]')
       commandObject.should.have.property('desc').and.equal('Go to sleep and dream')
       commandObject.should.have.property('builder')
@@ -596,12 +587,10 @@ describe('Command', function () {
       ])
     })
 
-    it('detects and ignores cyclic dir references', function () {
-      var r = checkOutput(function () {
-        return yargs('cyclic --help').wrap(null)
+    it('detects and ignores cyclic dir references', () => {
+      const r = checkOutput(() => yargs('cyclic --help').wrap(null)
           .commandDir('fixtures/cmddir_cyclic')
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
       r.should.have.property('exit').and.be.true
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
@@ -614,12 +603,10 @@ describe('Command', function () {
       ])
     })
 
-    it('derives \'command\' string from filename when not exported', function () {
-      var r = checkOutput(function () {
-        return yargs('--help').wrap(null)
+    it('derives \'command\' string from filename when not exported', () => {
+      const r = checkOutput(() => yargs('--help').wrap(null)
           .commandDir('fixtures/cmddir_noname')
-          .argv
-      })
+          .argv)
       r.should.have.property('exit').and.be.true
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
@@ -634,60 +621,50 @@ describe('Command', function () {
     })
   })
 
-  describe('help command', function () {
-    it('displays command help appropriately', function () {
-      var sub = {
+  describe('help command', () => {
+    it('displays command help appropriately', () => {
+      const sub = {
         command: 'sub',
         desc: 'Run the subcommand',
         builder: {},
-        handler: function (argv) {}
+        handler (argv) {}
       }
 
-      var cmd = {
+      const cmd = {
         command: 'cmd <sub>',
         desc: 'Try a command',
-        builder: function (yargs) {
+        builder (yargs) {
           return yargs.command(sub)
         },
-        handler: function (argv) {}
+        handler (argv) {}
       }
 
-      var helpCmd = checkOutput(function () {
-        return yargs('help cmd')
+      const helpCmd = checkOutput(() => yargs('help cmd')
           .wrap(null)
           .command(cmd)
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
 
-      var cmdHelp = checkOutput(function () {
-        return yargs('cmd help')
+      const cmdHelp = checkOutput(() => yargs('cmd help')
           .wrap(null)
           .command(cmd)
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
 
-      var helpCmdSub = checkOutput(function () {
-        return yargs('help cmd sub')
+      const helpCmdSub = checkOutput(() => yargs('help cmd sub')
           .wrap(null)
           .command(cmd)
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
 
-      var cmdHelpSub = checkOutput(function () {
-        return yargs('cmd help sub')
+      const cmdHelpSub = checkOutput(() => yargs('cmd help sub')
           .wrap(null)
           .command(cmd)
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
 
-      var cmdSubHelp = checkOutput(function () {
-        return yargs('cmd sub help')
+      const cmdSubHelp = checkOutput(() => yargs('cmd sub help')
           .wrap(null)
           .command(cmd)
-          .argv
-      }, [ './command' ])
+          .argv, [ './command' ])
 
-      var expectedCmd = [
+      const expectedCmd = [
         './command cmd <sub>',
         'Commands:',
         '  sub  Run the subcommand',
@@ -697,7 +674,7 @@ describe('Command', function () {
         ''
       ]
 
-      var expectedSub = [
+      const expectedSub = [
         './command cmd sub',
         'Options:',
         '  --help     Show help  [boolean]',
@@ -714,15 +691,13 @@ describe('Command', function () {
   })
 
   // see: https://github.com/yargs/yargs/pull/553
-  it('preserves top-level envPrefix', function () {
+  it('preserves top-level envPrefix', () => {
     process.env.FUN_DIP_STICK = 'yummy'
     process.env.FUN_DIP_POWDER = 'true'
     yargs('eat')
       .env('FUN_DIP')
       .global('stick') // this does not actually need to be global
-      .command('eat', 'Adult supervision recommended', function (yargs) {
-        return yargs.boolean('powder').exitProcess(false)
-      }, function (argv) {
+      .command('eat', 'Adult supervision recommended', yargs => yargs.boolean('powder').exitProcess(false), (argv) => {
         argv.should.have.property('powder').and.be.true
         argv.should.have.property('stick').and.equal('yummy')
       })
@@ -731,13 +706,13 @@ describe('Command', function () {
   })
 
   // addresses https://github.com/yargs/yargs/issues/514.
-  it('respects order of positional arguments when matching commands', function () {
-    var output = []
+  it('respects order of positional arguments when matching commands', () => {
+    const output = []
     yargs('bar foo')
-      .command('foo', 'foo command', function (yargs) {
+      .command('foo', 'foo command', (yargs) => {
         output.push('foo')
       })
-      .command('bar', 'bar command', function (yargs) {
+      .command('bar', 'bar command', (yargs) => {
         output.push('bar')
       })
       .argv
@@ -747,18 +722,18 @@ describe('Command', function () {
   })
 
   // addresses https://github.com/yargs/yargs/issues/558
-  it('handles positional arguments if command is invoked using .parse()', function () {
-    var y = yargs([])
+  it('handles positional arguments if command is invoked using .parse()', () => {
+    const y = yargs([])
       .command('foo <second>', 'the foo command', {})
-    var argv = y.parse(['foo', 'bar'])
+    const argv = y.parse(['foo', 'bar'])
     argv.second.should.equal('bar')
   })
 
   // addresses https://github.com/yargs/yargs/issues/710
-  it('invokes command handler repeatedly if parse() is called multiple times', function () {
-    var counter = 0
-    var y = yargs([])
-      .command('foo', 'the foo command', {}, function (argv) {
+  it('invokes command handler repeatedly if parse() is called multiple times', () => {
+    let counter = 0
+    const y = yargs([])
+      .command('foo', 'the foo command', {}, (argv) => {
         counter++
       })
     y.parse(['foo'])
@@ -767,47 +742,45 @@ describe('Command', function () {
   })
 
   // addresses: https://github.com/yargs/yargs/issues/776
-  it('allows command handler to be invoked repeatedly when help is enabled', function (done) {
-    var counter = 0
-    var y = yargs([])
-      .command('foo', 'the foo command', {}, function (argv) {
+  it('allows command handler to be invoked repeatedly when help is enabled', (done) => {
+    let counter = 0
+    const y = yargs([])
+      .command('foo', 'the foo command', {}, (argv) => {
         counter++
       })
-    y.parse(['foo'], function () {})
-    y.parse(['foo'], function () {
+    y.parse(['foo'], noop)
+    y.parse(['foo'], () => {
       counter.should.equal(2)
       return done()
     })
   })
 
   // addresses https://github.com/yargs/yargs/issues/522
-  it('does not require builder function to return', function () {
-    var argv = yargs('yo')
-      .command('yo [someone]', 'Send someone a yo', function (yargs) {
+  it('does not require builder function to return', () => {
+    const argv = yargs('yo')
+      .command('yo [someone]', 'Send someone a yo', (yargs) => {
         yargs.default('someone', 'Pat')
-      }, function (argv) {
+      }, (argv) => {
         argv.should.have.property('someone').and.equal('Pat')
       })
       .argv
     argv.should.have.property('someone').and.equal('Pat')
   })
 
-  it('allows builder function to parse argv without returning', function () {
-    var argv = yargs('yo Jude')
-      .command('yo <someone>', 'Send someone a yo', function (yargs) {
+  it('allows builder function to parse argv without returning', () => {
+    const argv = yargs('yo Jude')
+      .command('yo <someone>', 'Send someone a yo', (yargs) => {
         yargs.argv
-      }, function (argv) {
+      }, (argv) => {
         argv.should.have.property('someone').and.equal('Jude')
       })
       .argv
     argv.should.have.property('someone').and.equal('Jude')
   })
 
-  it('allows builder function to return parsed argv', function () {
-    var argv = yargs('yo Leslie')
-      .command('yo <someone>', 'Send someone a yo', function (yargs) {
-        return yargs.argv
-      }, function (argv) {
+  it('allows builder function to return parsed argv', () => {
+    const argv = yargs('yo Leslie')
+      .command('yo <someone>', 'Send someone a yo', yargs => yargs.argv, (argv) => {
         argv.should.have.property('someone').and.equal('Leslie')
       })
       .argv
@@ -815,13 +788,11 @@ describe('Command', function () {
   })
 
   // addresses https://github.com/yargs/yargs/issues/540
-  it('ignores extra spaces in command string', function () {
-    var y = yargs([])
-      .command('foo  [awesome]', 'my awesome command', function (yargs) {
-        return yargs
-      })
-    var command = y.getCommandInstance()
-    var handlers = command.getCommandHandlers()
+  it('ignores extra spaces in command string', () => {
+    const y = yargs([])
+      .command('foo  [awesome]', 'my awesome command', yargs => yargs)
+    const command = y.getCommandInstance()
+    const handlers = command.getCommandHandlers()
     handlers.foo.demanded.should.not.include({
       cmd: '',
       variadic: false
@@ -829,10 +800,10 @@ describe('Command', function () {
     handlers.foo.demanded.should.have.lengthOf(0)
   })
 
-  it('executes a command via alias', function () {
-    var commandCalled = false
-    var argv = yargs('hi world')
-      .command(['hello <someone>', 'hi'], 'Say hello', {}, function (argv) {
+  it('executes a command via alias', () => {
+    let commandCalled = false
+    const argv = yargs('hi world')
+      .command(['hello <someone>', 'hi'], 'Say hello', {}, (argv) => {
         commandCalled = true
         argv.should.have.property('someone').and.equal('world')
       })
@@ -841,9 +812,9 @@ describe('Command', function () {
     commandCalled.should.be.true
   })
 
-  describe('positional aliases', function () {
-    it('allows an alias to be defined for a required positional argument', function () {
-      var argv = yargs('yo bcoe 113993')
+  describe('positional aliases', () => {
+    it('allows an alias to be defined for a required positional argument', () => {
+      const argv = yargs('yo bcoe 113993')
         .command('yo <user | email> [ssn]', 'Send someone a yo')
         .argv
       argv.user.should.equal('bcoe')
@@ -851,10 +822,10 @@ describe('Command', function () {
       argv.ssn.should.equal(113993)
     })
 
-    it('allows an alias to be defined for an optional positional argument', function () {
-      var argv
+    it('allows an alias to be defined for an optional positional argument', () => {
+      let argv
       yargs('yo 113993')
-        .command('yo [ssn|sin]', 'Send someone a yo', {}, function (_argv) {
+        .command('yo [ssn|sin]', 'Send someone a yo', {}, (_argv) => {
           argv = _argv
         })
         .argv
@@ -862,10 +833,10 @@ describe('Command', function () {
       argv.sin.should.equal(113993)
     })
 
-    it('allows variadic and positional arguments to be combined', function () {
-      var parser = yargs
+    it('allows variadic and positional arguments to be combined', () => {
+      const parser = yargs
         .command('yo <user|email> [ ssns | sins... ]', 'Send someone a yo')
-      var argv = parser.parse('yo bcoe 113993 112888')
+      const argv = parser.parse('yo bcoe 113993 112888')
       argv.user.should.equal('bcoe')
       argv.email.should.equal('bcoe')
       argv.ssns.should.deep.equal([113993, 112888])
@@ -873,11 +844,11 @@ describe('Command', function () {
     })
   })
 
-  describe('global parsing hints', function () {
-    describe('config', function () {
-      it('does not load config for command if global is false', function (done) {
+  describe('global parsing hints', () => {
+    describe('config', () => {
+      it('does not load config for command if global is false', (done) => {
         yargs('command --foo ./package.json')
-          .command('command', 'a command', {}, function (argv) {
+          .command('command', 'a command', {}, (argv) => {
             expect(argv.license).to.equal(undefined)
             return done()
           })
@@ -886,9 +857,9 @@ describe('Command', function () {
           .argv
       })
 
-      it('loads config for command by default', function (done) {
+      it('loads config for command by default', (done) => {
         yargs('command --foo ./package.json')
-          .command('command', 'a command', {}, function (argv) {
+          .command('command', 'a command', {}, (argv) => {
             argv.license.should.equal('MIT')
             return done()
           })
@@ -897,10 +868,10 @@ describe('Command', function () {
       })
     })
 
-    describe('validation', function () {
-      it('resets implies logic for command if global is false', function (done) {
+    describe('validation', () => {
+      it('resets implies logic for command if global is false', (done) => {
         yargs('command --foo 99')
-          .command('command', 'a command', {}, function (argv) {
+          .command('command', 'a command', {}, (argv) => {
             argv.foo.should.equal(99)
             return done()
           })
@@ -909,10 +880,10 @@ describe('Command', function () {
           .argv
       })
 
-      it('applies conflicts logic for command by default', function (done) {
+      it('applies conflicts logic for command by default', (done) => {
         yargs('command --foo --bar')
-          .command('command', 'a command', {}, function (argv) {})
-          .fail(function (msg) {
+          .command('command', 'a command', {}, (argv) => {})
+          .fail((msg) => {
             msg.should.match(/mutually exclusive/)
             return done()
           })
@@ -920,9 +891,9 @@ describe('Command', function () {
           .argv
       })
 
-      it('resets conflicts logic for command if global is false', function (done) {
+      it('resets conflicts logic for command if global is false', (done) => {
         yargs('command --foo --bar')
-          .command('command', 'a command', {}, function (argv) {
+          .command('command', 'a command', {}, (argv) => {
             argv.foo.should.equal(true)
             argv.bar.should.equal(true)
             return done()
@@ -932,10 +903,10 @@ describe('Command', function () {
           .argv
       })
 
-      it('applies custom checks globally by default', function (done) {
+      it('applies custom checks globally by default', (done) => {
         yargs('command blerg --foo')
           .command('command <snuh>', 'a command')
-          .check(function (argv) {
+          .check((argv) => {
             argv.snuh.should.equal('blerg')
             argv.foo.should.equal(true)
             argv._.should.include('command')
@@ -945,11 +916,11 @@ describe('Command', function () {
           .argv
       })
 
-      it('resets custom check if global is false', function () {
-        var checkCalled = false
+      it('resets custom check if global is false', () => {
+        let checkCalled = false
         yargs('command blerg --foo')
           .command('command <snuh>', 'a command')
-          .check(function (argv) {
+          .check((argv) => {
             checkCalled = true
             return true
           }, false)
@@ -957,10 +928,10 @@ describe('Command', function () {
         checkCalled.should.equal(false)
       })
 
-      it('applies demandOption globally', function (done) {
+      it('applies demandOption globally', (done) => {
         yargs('command blerg --foo')
           .command('command <snuh>', 'a command')
-          .fail(function (msg) {
+          .fail((msg) => {
             msg.should.match(/Missing required argument: bar/)
             return done()
           })
@@ -969,11 +940,11 @@ describe('Command', function () {
       })
     })
 
-    describe('strict', function () {
-      it('defaults to false when not called', function () {
-        var commandCalled = false
+    describe('strict', () => {
+      it('defaults to false when not called', () => {
+        let commandCalled = false
         yargs('hi')
-          .command('hi', 'The hi command', function (innerYargs) {
+          .command('hi', 'The hi command', (innerYargs) => {
             commandCalled = true
             innerYargs.getStrict().should.be.false
           })
@@ -982,10 +953,10 @@ describe('Command', function () {
         commandCalled.should.be.true
       })
 
-      it('can be enabled just for a command', function () {
-        var commandCalled = false
+      it('can be enabled just for a command', () => {
+        let commandCalled = false
         yargs('hi')
-          .command('hi', 'The hi command', function (innerYargs) {
+          .command('hi', 'The hi command', (innerYargs) => {
             commandCalled = true
             innerYargs.strict().getStrict().should.be.true
           })
@@ -994,11 +965,11 @@ describe('Command', function () {
         commandCalled.should.be.true
       })
 
-      it('applies strict globally by default', function () {
-        var commandCalled = false
+      it('applies strict globally by default', () => {
+        let commandCalled = false
         yargs('hi')
           .strict()
-          .command('hi', 'The hi command', function (innerYargs) {
+          .command('hi', 'The hi command', (innerYargs) => {
             commandCalled = true
             innerYargs.getStrict().should.be.true
           })
@@ -1008,34 +979,34 @@ describe('Command', function () {
       })
 
       // address regression introduced in #766, thanks @nexdrew!
-      it('does not fail strict check due to postional command arguments', function (done) {
+      it('does not fail strict check due to postional command arguments', (done) => {
         yargs()
           .strict()
           .command('hi <name>', 'The hi command')
-          .parse('hi ben', function (err, argv, output) {
+          .parse('hi ben', (err, argv, output) => {
             expect(err).to.equal(null)
             return done()
           })
       })
 
       // address https://github.com/yargs/yargs/issues/795
-      it('does not fail strict check due to postional command arguments in nested commands', function (done) {
+      it('does not fail strict check due to postional command arguments in nested commands', (done) => {
         yargs()
           .strict()
-          .command('hi', 'The hi command', function (yargs) {
-            yargs.command('ben <age>', 'ben command', function () {}, function () {})
+          .command('hi', 'The hi command', (yargs) => {
+            yargs.command('ben <age>', 'ben command', noop, noop)
           })
-          .parse('hi ben 99', function (err, argv, output) {
+          .parse('hi ben 99', (err, argv, output) => {
             expect(err).to.equal(null)
             return done()
           })
       })
 
-      it('allows a command to override global`', function () {
-        var commandCalled = false
+      it('allows a command to override global`', () => {
+        let commandCalled = false
         yargs('hi')
          .strict()
-         .command('hi', 'The hi command', function (innerYargs) {
+         .command('hi', 'The hi command', (innerYargs) => {
            commandCalled = true
            innerYargs.strict(false).getStrict().should.be.false
          })
@@ -1044,14 +1015,14 @@ describe('Command', function () {
         commandCalled.should.be.true
       })
 
-      it('does not fire command if validation fails', function (done) {
-        var commandRun = false
+      it('does not fire command if validation fails', (done) => {
+        let commandRun = false
         yargs()
           .strict()
-          .command('hi <name>', 'The hi command', function () {}, function (argv) {
+          .command('hi <name>', 'The hi command', noop, (argv) => {
             commandRun = true
           })
-          .parse('hi ben --hello=world', function (err, argv, output) {
+          .parse('hi ben --hello=world', (err, argv, output) => {
             commandRun.should.equal(false)
             err.message.should.equal('Unknown argument: hello')
             return done()
@@ -1059,8 +1030,8 @@ describe('Command', function () {
       })
     })
 
-    describe('types', function () {
-      it('applies array type globally', function () {
+    describe('types', () => {
+      it('applies array type globally', () => {
         const argv = yargs('command --foo 1 2')
           .command('command', 'a command')
           .array('foo')
@@ -1068,7 +1039,7 @@ describe('Command', function () {
         argv.foo.should.eql([1, 2])
       })
 
-      it('allows global setting to be disabled for array type', function () {
+      it('allows global setting to be disabled for array type', () => {
         const argv = yargs('command --foo 1 2')
           .command('command', 'a command')
           .array('foo')
@@ -1077,11 +1048,11 @@ describe('Command', function () {
         argv.foo.should.eql(1)
       })
 
-      it('applies choices type globally', function (done) {
+      it('applies choices type globally', (done) => {
         yargs('command --foo 99')
           .command('command', 'a command')
           .choices('foo', [33, 88])
-          .fail(function (msg) {
+          .fail((msg) => {
             msg.should.match(/Choices: 33, 88/)
             return done()
           })
@@ -1089,10 +1060,10 @@ describe('Command', function () {
       })
     })
 
-    describe('aliases', function () {
-      it('defaults to applying aliases globally', function (done) {
+    describe('aliases', () => {
+      it('defaults to applying aliases globally', (done) => {
         yargs('command blerg --foo 22')
-          .command('command <snuh>', 'a command', {}, function (argv) {
+          .command('command <snuh>', 'a command', {}, (argv) => {
             argv.foo.should.equal(22)
             argv.bar.should.equal(22)
             argv.snuh.should.equal('blerg')
@@ -1102,9 +1073,9 @@ describe('Command', function () {
           .argv
       })
 
-      it('allows global application of alias to be disabled', function (done) {
+      it('allows global application of alias to be disabled', (done) => {
         yargs('command blerg --foo 22')
-          .command('command <snuh>', 'a command', {}, function (argv) {
+          .command('command <snuh>', 'a command', {}, (argv) => {
             argv.foo.should.equal(22)
             expect(argv.bar).to.equal(undefined)
             argv.snuh.should.equal('blerg')
@@ -1118,39 +1089,37 @@ describe('Command', function () {
       })
     })
 
-    describe('coerce', function () {
-      it('defaults to applying coerce rules globally', function (done) {
+    describe('coerce', () => {
+      it('defaults to applying coerce rules globally', (done) => {
         yargs('command blerg --foo 22')
-          .command('command <snuh>', 'a command', {}, function (argv) {
+          .command('command <snuh>', 'a command', {}, (argv) => {
             argv.foo.should.equal(44)
             argv.snuh.should.equal('blerg')
             return done()
           })
-          .coerce('foo', function (arg) {
-            return arg * 2
-          })
+          .coerce('foo', arg => arg * 2)
           .argv
       })
 
       // addresses https://github.com/yargs/yargs/issues/794
-      it('should bubble errors thrown by coerce function inside commands', function (done) {
+      it('should bubble errors thrown by coerce function inside commands', (done) => {
         yargs
-          .command('foo', 'the foo command', function (yargs) {
-            yargs.coerce('x', function (arg) {
+          .command('foo', 'the foo command', (yargs) => {
+            yargs.coerce('x', (arg) => {
               throw Error('yikes an error')
             })
           })
-          .parse('foo -x 99', function (err) {
+          .parse('foo -x 99', (err) => {
             err.message.should.match(/yikes an error/)
             return done()
           })
       })
     })
 
-    describe('defaults', function () {
-      it('applies defaults globally', function (done) {
+    describe('defaults', () => {
+      it('applies defaults globally', (done) => {
         yargs('command --foo 22')
-          .command('command [snuh]', 'a command', {}, function (argv) {
+          .command('command [snuh]', 'a command', {}, (argv) => {
             argv.foo.should.equal(22)
             argv.snuh.should.equal(55)
             return done()
@@ -1160,12 +1129,12 @@ describe('Command', function () {
       })
     })
 
-    describe('describe', function () {
-      it('flags an option as global if a description is set', function (done) {
+    describe('describe', () => {
+      it('flags an option as global if a description is set', (done) => {
         yargs()
           .command('command [snuh]', 'a command')
           .describe('foo', 'an awesome argument')
-          .parse('command --help', function (err, argv, output) {
+          .parse('command --help', (err, argv, output) => {
             if (err) return done(err)
             output.should.not.match(/Commands:/)
             output.should.match(/an awesome argument/)
@@ -1174,13 +1143,13 @@ describe('Command', function () {
       })
     })
 
-    describe('help', function () {
-      it('applies help globally', function (done) {
+    describe('help', () => {
+      it('applies help globally', (done) => {
         yargs()
           .command('command [snuh]', 'a command')
           .describe('foo', 'an awesome argument')
           .help('hellllllp')
-          .parse('command --hellllllp', function (err, argv, output) {
+          .parse('command --hellllllp', (err, argv, output) => {
             if (err) return done(err)
             output.should.match(/--hellllllp {2}Show help/)
             return done()
@@ -1188,13 +1157,13 @@ describe('Command', function () {
       })
     })
 
-    describe('version', function () {
-      it('applies version globally', function (done) {
+    describe('version', () => {
+      it('applies version globally', (done) => {
         yargs()
           .command('command [snuh]', 'a command')
           .describe('foo', 'an awesome argument')
           .version('ver', 'show version', '9.9.9')
-          .parse('command --ver', function (err, argv, output) {
+          .parse('command --ver', (err, argv, output) => {
             if (err) return done(err)
             output.should.equal('9.9.9')
             return done()
@@ -1202,15 +1171,15 @@ describe('Command', function () {
       })
     })
 
-    describe('groups', function () {
-      it('should apply custom option groups globally', function (done) {
+    describe('groups', () => {
+      it('should apply custom option groups globally', (done) => {
         yargs()
           .command('command [snuh]', 'a command')
           .group('foo', 'Bad Variable Names:')
           .group('snuh', 'Bad Variable Names:')
           .describe('foo', 'foo option')
           .describe('snuh', 'snuh positional')
-          .parse('command --help', function (err, argv, output) {
+          .parse('command --help', (err, argv, output) => {
             if (err) return done(err)
             output.should.match(/Bad Variable Names:\W*--foo/)
             return done()
@@ -1219,20 +1188,20 @@ describe('Command', function () {
     })
   })
 
-  describe('default commands', function () {
-    it('executes default command if no positional arguments given', function (done) {
+  describe('default commands', () => {
+    it('executes default command if no positional arguments given', (done) => {
       yargs('--foo bar')
-        .command('*', 'default command', function () {}, function (argv) {
+        .command('*', 'default command', noop, (argv) => {
           argv.foo.should.equal('bar')
           return done()
         })
         .argv
     })
 
-    it('does not execute default command if another command is provided', function (done) {
+    it('does not execute default command if another command is provided', (done) => {
       yargs('run bcoe --foo bar')
-        .command('*', 'default command', function () {}, function (argv) {})
-        .command('run <name>', 'run command', function () {}, function (argv) {
+        .command('*', 'default command', noop, (argv) => {})
+        .command('run <name>', 'run command', noop, (argv) => {
           argv.name.should.equal('bcoe')
           argv.foo.should.equal('bar')
           return done()
@@ -1240,9 +1209,9 @@ describe('Command', function () {
         .argv
     })
 
-    it('allows default command to be set as alias', function (done) {
+    it('allows default command to be set as alias', (done) => {
       yargs('bcoe --foo bar')
-        .command(['start <name>', '*'], 'start command', function () {}, function (argv) {
+        .command(['start <name>', '*'], 'start command', noop, (argv) => {
           argv._.should.eql([])
           argv.name.should.equal('bcoe')
           argv.foo.should.equal('bar')
@@ -1251,9 +1220,9 @@ describe('Command', function () {
         .argv
     })
 
-    it('allows command to be run when alias is default command', function (done) {
+    it('allows command to be run when alias is default command', (done) => {
       yargs('start bcoe --foo bar')
-        .command(['start <name>', '*'], 'start command', function () {}, function (argv) {
+        .command(['start <name>', '*'], 'start command', noop, (argv) => {
           argv._.should.eql(['start'])
           argv.name.should.equal('bcoe')
           argv.foo.should.equal('bar')
@@ -1262,10 +1231,10 @@ describe('Command', function () {
         .argv
     })
 
-    it('the last default command set should take precedence', function (done) {
+    it('the last default command set should take precedence', (done) => {
       yargs('bcoe --foo bar')
-        .command(['first', '*'], 'override me', function () {}, function () {})
-        .command(['second <name>', '*'], 'start command', function () {}, function (argv) {
+        .command(['first', '*'], 'override me', noop, noop)
+        .command(['second <name>', '*'], 'start command', noop, (argv) => {
           argv._.should.eql([])
           argv.name.should.equal('bcoe')
           argv.foo.should.equal('bar')
@@ -1274,10 +1243,10 @@ describe('Command', function () {
         .argv
     })
 
-    describe('strict', function () {
-      it('executes default command when strict mode is enabled', function (done) {
+    describe('strict', () => {
+      it('executes default command when strict mode is enabled', (done) => {
         yargs('--foo bar')
-          .command('*', 'default command', function () {}, function (argv) {
+          .command('*', 'default command', noop, (argv) => {
             argv.foo.should.equal('bar')
             return done()
           })
@@ -1288,9 +1257,9 @@ describe('Command', function () {
           .argv
       })
 
-      it('allows default command aliases, when strict mode is enabled', function (done) {
+      it('allows default command aliases, when strict mode is enabled', (done) => {
         yargs('bcoe --foo bar')
-          .command(['start <name>', '*'], 'start command', function () {}, function (argv) {
+          .command(['start <name>', '*'], 'start command', noop, (argv) => {
             argv._.should.eql([])
             argv.name.should.equal('bcoe')
             argv.foo.should.equal('bar')
@@ -1306,11 +1275,11 @@ describe('Command', function () {
   })
 
   // addresses: https://github.com/yargs/yargs/issues/819
-  it('should kick along [demand] configuration to commands', function () {
-    var called = false
-    var r = checkOutput(function () {
+  it('should kick along [demand] configuration to commands', () => {
+    let called = false
+    const r = checkOutput(() => {
       yargs('foo')
-        .command('foo', 'foo command', function () {}, function (argv) {
+        .command('foo', 'foo command', noop, (argv) => {
           called = true
         })
         .option('bar', {
@@ -1323,10 +1292,10 @@ describe('Command', function () {
     r.errors.should.match(/Missing required argument/)
   })
 
-  it('should support numeric commands', function () {
-    var output = []
+  it('should support numeric commands', () => {
+    const output = []
     yargs('1')
-      .command('1', 'numeric command', function (yargs) {
+      .command('1', 'numeric command', (yargs) => {
         output.push('1')
       })
       .argv
@@ -1334,11 +1303,11 @@ describe('Command', function () {
   })
 
   // see: https://github.com/yargs/yargs/issues/853
-  it('should not execute command if it is proceeded by another positional argument', function () {
-    var commandCalled = false
+  it('should not execute command if it is proceeded by another positional argument', () => {
+    let commandCalled = false
     yargs()
-      .command('foo', 'foo command', function () {}, function () { commandCalled = true })
-      .parse('bar foo', function (err, argv) {
+      .command('foo', 'foo command', noop, () => { commandCalled = true })
+      .parse('bar foo', (err, argv) => {
         expect(err).to.equal(null)
         commandCalled.should.equal(false)
         argv._.should.eql(['bar', 'foo'])
@@ -1352,7 +1321,7 @@ describe('Command', function () {
         yargs.command('bar [optional]', 'inner command')
       })
       .strict()
-      .parse('foo bar 33', function (err, argv) {
+      .parse('foo bar 33', (err, argv) => {
         expect(err).to.equal(null)
         argv.optional.should.equal(33)
         argv._.should.eql(['foo', 'bar'])

--- a/test/completion.js
+++ b/test/completion.js
@@ -1,107 +1,100 @@
+'use strict'
 /* global describe, it, beforeEach */
-var checkUsage = require('./helpers/utils').checkOutput
-var yargs = require('../')
+const checkUsage = require('./helpers/utils').checkOutput
+const yargs = require('../')
 
 /* polyfill Promise for older Node.js */
 require('es6-promise').polyfill()
 
 require('chai').should()
 
-describe('Completion', function () {
-  beforeEach(function () {
+describe('Completion', () => {
+  beforeEach(() => {
     yargs.reset()
   })
 
-  describe('default completion behavior', function () {
-    it('it returns a list of commands as completion suggestions', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', ''])
+  describe('default completion behavior', () => {
+    it('it returns a list of commands as completion suggestions', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', ''])
           .command('foo', 'bar')
           .command('apple', 'banana')
           .completion()
           .argv
-      })
+        )
 
       r.logs.should.include('apple')
       r.logs.should.include('foo')
     })
 
-    it('avoids repeating already included commands', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', 'apple'])
+    it('avoids repeating already included commands', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', 'apple'])
           .command('foo', 'bar')
           .command('apple', 'banana')
           .argv
-      })
+        )
 
       // should not suggest foo for completion unless foo is subcommand of apple
       r.logs.should.not.include('apple')
     })
 
-    it('avoids repeating already included options', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', './completion', '--foo', '--'])
+    it('avoids repeating already included options', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', './completion', '--foo', '--'])
           .options({
             foo: {describe: 'foo option'},
             bar: {describe: 'bar option'}
           })
           .completion()
           .argv
-      })
+        )
 
       r.logs.should.include('--bar')
       r.logs.should.not.include('--foo')
     })
 
-    it('avoids repeating options whose aliases are already included', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', './completion', '--f', '--'])
+    it('avoids repeating options whose aliases are already included', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', './completion', '--f', '--'])
             .options({
               foo: {describe: 'foo option', alias: 'f'},
               bar: {describe: 'bar option'}
             })
             .completion()
             .argv
-      })
+          )
 
       r.logs.should.include('--bar')
       r.logs.should.not.include('--foo')
     })
 
-    it('completes options for a command', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
-          .command('foo', 'foo command', function (subYargs) {
-            return subYargs.options({
-              bar: {
-                describe: 'bar option'
-              }
-            })
-            .help(true)
-            .version(false)
+    it('completes options for a command', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
+          .command('foo', 'foo command', subYargs => subYargs.options({
+            bar: {
+              describe: 'bar option'
+            }
           })
+            .help(true)
+            .version(false))
           .completion()
           .argv
-      })
+        )
 
       r.logs.should.have.length(2)
       r.logs.should.include('--bar')
       r.logs.should.include('--help')
     })
 
-    it('completes options for the correct command', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', 'cmd2', '--o'])
+    it('completes options for the correct command', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', 'cmd2', '--o'])
           .help(false)
           .version(false)
-          .command('cmd1', 'first command', function (subYargs) {
+          .command('cmd1', 'first command', (subYargs) => {
             subYargs.options({
               opt1: {
                 describe: 'first option'
               }
             })
           })
-          .command('cmd2', 'second command', function (subYargs) {
+          .command('cmd2', 'second command', (subYargs) => {
             subYargs.options({
               opt2: {
                 describe: 'second option'
@@ -110,125 +103,110 @@ describe('Completion', function () {
           })
           .completion()
           .argv
-      })
+        )
 
       r.logs.should.have.length(1)
       r.logs.should.include('--opt2')
     })
 
-    it('does not complete hidden commands', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', 'cmd'])
+    it('does not complete hidden commands', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', 'cmd'])
           .command('cmd1', 'first command')
           .command('cmd2', false)
           .completion('completion', false)
           .argv
-      })
+        )
 
       r.logs.should.have.length(1)
       r.logs.should.include('cmd1')
     })
 
-    it('works if command has no options', function () {
-      var r = checkUsage(function () {
-        return yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
+    it('works if command has no options', () => {
+      const r = checkUsage(() => yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
           .help(false)
           .version(false)
-          .command('foo', 'foo command', function (subYargs) {
+          .command('foo', 'foo command', (subYargs) => {
             subYargs.completion().argv
           })
           .completion()
           .argv
-      })
+        )
 
       r.logs.should.have.length(0)
     })
 
-    it("returns arguments as completion suggestion, if next contains '-'", function () {
-      var r = checkUsage(function () {
-        return yargs(['./usage', '--get-yargs-completions', '-f'])
+    it("returns arguments as completion suggestion, if next contains '-'", () => {
+      const r = checkUsage(() => yargs(['./usage', '--get-yargs-completions', '-f'])
         .option('foo', {
           describe: 'foo option'
         })
         .command('bar', 'bar command')
         .completion()
         .argv
-      })
+      )
 
       r.logs.should.include('--foo')
       r.logs.should.not.include('bar')
     })
   })
 
-  describe('generateCompletionScript()', function () {
-    it('replaces application variable with $0 in script', function () {
-      var r = checkUsage(function () {
-        return yargs([])
-          .showCompletionScript()
-      }, ['ndm'])
+  describe('generateCompletionScript()', () => {
+    it('replaces application variable with $0 in script', () => {
+      const r = checkUsage(() => yargs([])
+          .showCompletionScript(), ['ndm'])
 
       r.logs[0].should.match(/ndm --get-yargs-completions/)
     })
 
-    it('if $0 has a .js extension, a ./ prefix is added', function () {
-      var r = checkUsage(function () {
-        return yargs([])
-          .showCompletionScript()
-      }, ['test.js'])
+    it('if $0 has a .js extension, a ./ prefix is added', () => {
+      const r = checkUsage(() => yargs([])
+          .showCompletionScript(), ['test.js'])
 
       r.logs[0].should.match(/\.\/test.js --get-yargs-completions/)
     })
   })
 
-  describe('completion()', function () {
-    it('shows completion script if command registered with completion(cmd) is called', function () {
-      var r = checkUsage(function () {
-        return yargs(['completion'])
+  describe('completion()', () => {
+    it('shows completion script if command registered with completion(cmd) is called', () => {
+      const r = checkUsage(() => yargs(['completion'])
           .completion('completion')
-          .argv
-      }, ['ndm'])
+          .argv, ['ndm'])
 
       r.logs[0].should.match(/ndm --get-yargs-completions/)
     })
 
-    it('allows a custom function to be registered for completion', function () {
-      var r = checkUsage(function () {
-        return yargs(['--get-yargs-completions'])
+    it('allows a custom function to be registered for completion', () => {
+      const r = checkUsage(() => yargs(['--get-yargs-completions'])
         .help('h')
-        .completion('completion', function (current, argv) {
-          return ['cat', 'bat']
-        })
+        .completion('completion', (current, argv) => ['cat', 'bat'])
         .argv
-      })
+      )
 
       r.logs.should.include('cat')
       r.logs.should.include('bat')
     })
 
-    it('passes current arg for completion and the parsed arguments thus far to custom function', function () {
-      var r = checkUsage(function () {
-        return yargs(['ndm', '--get-yargs-completions', '--cool', 'ma'])
-        .completion('completion', function (current, argv) {
+    it('passes current arg for completion and the parsed arguments thus far to custom function', () => {
+      const r = checkUsage(() => yargs(['ndm', '--get-yargs-completions', '--cool', 'ma'])
+        .completion('completion', (current, argv) => {
           if (current === 'ma' && argv.cool) return ['success!']
         })
         .argv
-      })
+      )
 
       r.logs.should.include('success!')
     })
 
-    it('if a promise is returned, completions can be asynchronous', function (done) {
-      checkUsage(function (cb) {
+    it('if a promise is returned, completions can be asynchronous', (done) => {
+      checkUsage((cb) => {
         yargs(['--get-yargs-completions'])
-        .completion('completion', function (current, argv) {
-          return new Promise(function (resolve, reject) {
-            setTimeout(function () {
-              resolve(['apple', 'banana'])
-            }, 10)
-          })
-        })
+        .completion('completion', (current, argv) => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            resolve(['apple', 'banana'])
+          }, 10)
+        }))
         .argv
-      }, null, function (err, r) {
+      }, null, (err, r) => {
         if (err) throw err
         r.logs.should.include('apple')
         r.logs.should.include('banana')
@@ -236,33 +214,31 @@ describe('Completion', function () {
       })
     })
 
-    it('if a promise is returned, errors are handled', function (done) {
-      checkUsage(function () {
+    it('if a promise is returned, errors are handled', (done) => {
+      checkUsage(() => {
         yargs(['--get-yargs-completions'])
-        .completion('completion', function (current, argv) {
-          return new Promise(function (resolve, reject) {
-            setTimeout(function () {
-              reject(new Error('Test'))
-            }, 10)
-          })
-        })
+        .completion('completion', (current, argv) => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            reject(new Error('Test'))
+          }, 10)
+        }))
         .argv
-      }, null, function (err) {
+      }, null, (err) => {
         err.message.should.equal('Test')
         return done()
       })
     })
 
-    it('if a callback parameter is provided, completions can be asynchronous', function (done) {
-      checkUsage(function () {
+    it('if a callback parameter is provided, completions can be asynchronous', (done) => {
+      checkUsage(() => {
         yargs(['--get-yargs-completions'])
-        .completion('completion', function (current, argv, cb) {
-          setTimeout(function () {
+        .completion('completion', (current, argv, cb) => {
+          setTimeout(() => {
             cb(['apple', 'banana'])
           }, 10)
         })
         .argv
-      }, null, function (err, r) {
+      }, null, (err, r) => {
         if (err) throw err
         r.logs.should.include('apple')
         r.logs.should.include('banana')
@@ -271,15 +247,15 @@ describe('Completion', function () {
     })
   })
 
-  describe('getCompletion()', function () {
-    it('returns default completion to callback', function () {
-      var r = checkUsage(function () {
+  describe('getCompletion()', () => {
+    it('returns default completion to callback', () => {
+      const r = checkUsage(() => {
         yargs()
           .command('foo', 'bar')
           .command('apple', 'banana')
           .completion()
-          .getCompletion([''], function (completions) {
-            ;(completions || []).forEach(function (completion) {
+          .getCompletion([''], (completions) => {
+            ;(completions || []).forEach((completion) => {
               console.log(completion)
             })
           })
@@ -291,8 +267,8 @@ describe('Completion', function () {
   })
 
   // fixes for #177.
-  it('does not apply validation when --get-yargs-completions is passed in', function () {
-    var r = checkUsage(function () {
+  it('does not apply validation when --get-yargs-completions is passed in', () => {
+    const r = checkUsage(() => {
       try {
         return yargs(['./completion', '--get-yargs-completions', '--'])
           .option('foo', {})

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,37 +1,38 @@
-var Hash = require('hashish')
+'use strict'
+const Hash = require('hashish')
 
 // capture terminal output, so that we might
 // assert against it.
-exports.checkOutput = function (f, argv, cb) {
-  var exit = false
-  var _exit = process.exit
-  var _emit = process.emit
-  var _env = process.env
-  var _argv = process.argv
-  var _error = console.error
-  var _log = console.log
-  var _warn = console.warn
+exports.checkOutput = function checkOutput (f, argv, cb) {
+  let exit = false
+  const _exit = process.exit
+  const _emit = process.emit
+  const _env = process.env
+  const _argv = process.argv
+  const _error = console.error
+  const _log = console.log
+  const _warn = console.warn
 
-  process.exit = function () { exit = true }
+  process.exit = () => { exit = true }
   process.env = Hash.merge(process.env, { _: 'node' })
   process.argv = argv || [ './usage' ]
 
-  var errors = []
-  var logs = []
-  var warnings = []
+  const errors = []
+  const logs = []
+  const warnings = []
 
-  console.error = function (msg) { errors.push(msg) }
-  console.log = function (msg) { logs.push(msg) }
-  console.warn = function (msg) { warnings.push(msg) }
+  console.error = (msg) => { errors.push(msg) }
+  console.log = (msg) => { logs.push(msg) }
+  console.warn = (msg) => { warnings.push(msg) }
 
-  var result
+  let result
 
   if (typeof cb === 'function') {
-    process.exit = function () {
+    process.exit = () => {
       exit = true
       cb(null, done())
     }
-    process.emit = function (ev, value) {
+    process.emit = function emit (ev, value) {
       if (ev === 'uncaughtException') {
         done()
         cb(value)
@@ -67,11 +68,11 @@ exports.checkOutput = function (f, argv, cb) {
     reset()
 
     return {
-      errors: errors,
-      logs: logs,
-      warnings: warnings,
-      exit: exit,
-      result: result
+      errors,
+      logs,
+      warnings,
+      exit,
+      result
     }
   }
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,54 +1,55 @@
+'use strict'
 /* global describe, it, before, after */
 
-var spawn = require('cross-spawn')
-var path = require('path')
-var which = require('which')
-var rimraf = require('rimraf')
-var cpr = require('cpr')
-var fs = require('fs')
+const spawn = require('cross-spawn')
+const path = require('path')
+const which = require('which')
+const rimraf = require('rimraf')
+const cpr = require('cpr')
+const fs = require('fs')
 
 require('chai').should()
 
-describe('integration tests', function () {
-  it('should run as a shell script with no arguments', function (done) {
+describe('integration tests', () => {
+  it('should run as a shell script with no arguments', (done) => {
     testArgs('./bin.js', [], done)
   })
 
-  it('should run as a shell script with arguments', function (done) {
+  it('should run as a shell script with arguments', (done) => {
     testArgs('./bin.js', [ 'a', 'b', 'c' ], done)
   })
 
-  it('should run as a node script with no arguments', function (done) {
+  it('should run as a node script with no arguments', (done) => {
     testArgs('node bin.js', [], done)
   })
 
-  it('should run as a node script with arguments', function (done) {
+  it('should run as a node script with arguments', (done) => {
     testArgs('node bin.js', [ 'x', 'y', 'z' ], done)
   })
 
-  describe('path returned by "which"', function () {
-    it('should match the actual path to the script file', function (done) {
-      which('node', function (err, path) {
+  describe('path returned by "which"', () => {
+    it('should match the actual path to the script file', (done) => {
+      which('node', (err, path) => {
         if (err) return done(err)
-        testArgs(path.replace('Program Files (x86)', 'Progra~2')
-                     .replace('Program Files', 'Progra~1') + ' bin.js', [], done)
+        testArgs(`${path.replace('Program Files (x86)', 'Progra~2')
+                     .replace('Program Files', 'Progra~1')} bin.js`, [], done)
       })
     })
 
-    it('should match the actual path to the script file, with arguments', function (done) {
-      which('node', function (err, path) {
+    it('should match the actual path to the script file, with arguments', (done) => {
+      which('node', (err, path) => {
         if (err) return done(err)
-        testArgs(path.replace('Program Files (x86)', 'Progra~2')
-                     .replace('Program Files', 'Progra~1') + ' bin.js', [ 'q', 'r' ], done)
+        testArgs(`${path.replace('Program Files (x86)', 'Progra~2')
+                     .replace('Program Files', 'Progra~1')} bin.js`, [ 'q', 'r' ], done)
       })
     })
   })
 
   // see #177
-  it('allows --help to be completed without returning help message', function (done) {
-    testCmd('./bin.js', [ '--get-yargs-completions', '--h' ], function (code, stdout) {
+  it('allows --help to be completed without returning help message', (done) => {
+    testCmd('./bin.js', [ '--get-yargs-completions', '--h' ], (code, stdout) => {
       if (code) {
-        done(new Error('cmd exited with code ' + code))
+        done(new Error(`cmd exited with code ${code}`))
         return
       }
 
@@ -65,9 +66,9 @@ describe('integration tests', function () {
       return this.skip()
     }
 
-    testCmd('./issue-497.js', [ '--help' ], function (code, stdout) {
+    testCmd('./issue-497.js', [ '--help' ], (code, stdout) => {
       if (code) {
-        done(new Error('cmd exited with code ' + code))
+        done(new Error(`cmd exited with code ${code}`))
         return
       }
 
@@ -77,14 +78,14 @@ describe('integration tests', function () {
     })
   })
 
-  it('correctly fills positional command args with preceding option', function (done) {
-    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo', 'fOo', 'bar', 'bAz'], function (code, stdout) {
+  it('correctly fills positional command args with preceding option', (done) => {
+    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo', 'fOo', 'bar', 'bAz'], (code, stdout) => {
       if (code) {
-        done(new Error('cmd exited with code ' + code))
+        done(new Error(`cmd exited with code ${code}`))
         return
       }
 
-      var argv = JSON.parse(stdout)
+      const argv = JSON.parse(stdout)
       argv._.should.deep.equal(['bar'])
       argv.foo.should.equal('fOo')
       argv.baz.should.equal('bAz')
@@ -92,14 +93,14 @@ describe('integration tests', function () {
     })
   })
 
-  it('correctly fills positional command args with = assignment in preceding option', function (done) {
-    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo=fOo', 'bar', 'bAz'], function (code, stdout) {
+  it('correctly fills positional command args with = assignment in preceding option', (done) => {
+    testCmd('./opt-assignment-and-positional-command-arg.js', ['--foo=fOo', 'bar', 'bAz'], (code, stdout) => {
       if (code) {
-        done(new Error('cmd exited with code ' + code))
+        done(new Error(`cmd exited with code ${code}`))
         return
       }
 
-      var argv = JSON.parse(stdout)
+      const argv = JSON.parse(stdout)
       argv._.should.deep.equal(['bar'])
       argv.foo.should.equal('fOo')
       argv.baz.should.equal('bAz')
@@ -108,7 +109,7 @@ describe('integration tests', function () {
   })
 
   if (process.platform !== 'win32') {
-    describe('load root package.json', function () {
+    describe('load root package.json', () => {
       before(function (done) {
         this.timeout(10000)
         // create a symlinked, and a physical copy of yargs in
@@ -116,17 +117,17 @@ describe('integration tests', function () {
         // nearest package.json is appropriately loaded.
         cpr('./', './test/fixtures/yargs', {
           filter: /node_modules|example|test|package\.json/
-        }, function () {
+        }, () => {
           fs.symlinkSync(process.cwd(), './test/fixtures/yargs-symlink')
           return done()
         })
       })
 
-      describe('version #', function () {
-        it('defaults to appropriate version # when yargs is installed normally', function (done) {
-          testCmd('./normal-bin.js', [ '--version' ], function (code, stdout) {
+      describe('version #', () => {
+        it('defaults to appropriate version # when yargs is installed normally', (done) => {
+          testCmd('./normal-bin.js', [ '--version' ], (code, stdout) => {
             if (code) {
-              return done(new Error('cmd exited with code ' + code))
+              return done(new Error(`cmd exited with code ${code}`))
             }
 
             stdout.should.match(/9\.9\.9/)
@@ -134,10 +135,10 @@ describe('integration tests', function () {
           })
         })
 
-        it('defaults to appropriate version # when yargs is symlinked', function (done) {
-          testCmd('./symlink-bin.js', [ '--version' ], function (code, stdout) {
+        it('defaults to appropriate version # when yargs is symlinked', (done) => {
+          testCmd('./symlink-bin.js', [ '--version' ], (code, stdout) => {
             if (code) {
-              return done(new Error('cmd exited with code ' + code))
+              return done(new Error(`cmd exited with code ${code}`))
             }
 
             stdout.should.match(/9\.9\.9/)
@@ -146,11 +147,11 @@ describe('integration tests', function () {
         })
       })
 
-      describe('parser settings', function (done) {
-        it('reads parser config settings when yargs is installed normally', function (done) {
-          testCmd('./normal-bin.js', [ '--foo.bar' ], function (code, stdout) {
+      describe('parser settings', () => {
+        it('reads parser config settings when yargs is installed normally', (done) => {
+          testCmd('./normal-bin.js', [ '--foo.bar' ], (code, stdout) => {
             if (code) {
-              return done(new Error('cmd exited with code ' + code))
+              return done(new Error(`cmd exited with code ${code}`))
             }
 
             stdout.should.match(/foo\.bar/)
@@ -158,10 +159,10 @@ describe('integration tests', function () {
           })
         })
 
-        it('reads parser config settings when yargs is installed as a symlink', function (done) {
-          testCmd('./symlink-bin.js', [ '--foo.bar' ], function (code, stdout) {
+        it('reads parser config settings when yargs is installed as a symlink', (done) => {
+          testCmd('./symlink-bin.js', [ '--foo.bar' ], (code, stdout) => {
             if (code) {
-              return done(new Error('cmd exited with code ' + code))
+              return done(new Error(`cmd exited with code ${code}`))
             }
 
             stdout.should.match(/foo\.bar/)
@@ -170,7 +171,7 @@ describe('integration tests', function () {
         })
       })
 
-      after(function () {
+      after(() => {
         rimraf.sync('./test/fixtures/yargs')
         fs.unlinkSync('./test/fixtures/yargs-symlink')
       })
@@ -179,36 +180,35 @@ describe('integration tests', function () {
 })
 
 function testCmd (cmd, args, cb) {
-  var oldDir = process.cwd()
+  const oldDir = process.cwd()
   process.chdir(path.join(__dirname, '/fixtures'))
 
-  var cmds = cmd.split(' ')
+  const cmds = cmd.split(' ')
 
-  var bin = spawn(cmds[0], cmds.slice(1).concat(args.map(String)))
+  const bin = spawn(cmds[0], cmds.slice(1).concat(args.map(String)))
   process.chdir(oldDir)
 
-  var stdout = ''
+  let stdout = ''
   bin.stdout.setEncoding('utf8')
-  bin.stdout.on('data', function (str) { stdout += str })
+  bin.stdout.on('data', (str) => { stdout += str })
 
-  var stderr = ''
+  let stderr = ''
   bin.stderr.setEncoding('utf8')
-  bin.stderr.on('data', function (str) { stderr += str })
+  bin.stderr.on('data', (str) => { stderr += str })
 
-  bin.on('close', function (code) {
+  bin.on('close', (code) => {
     cb(code, stdout, stderr)
   })
 }
 
 function testArgs (cmd, args, done) {
-  testCmd(cmd, args, function (code, stdout, stderr) {
+  testCmd(cmd, args, (code, stdout, stderr) => {
     if (code) {
-      done(new Error('cmd ' + cmd + ' ' + args + ' exited with code ' + code +
-          '\n' + stdout + '\n' + stderr))
+      done(new Error(`cmd ${cmd} ${args} exited with code ${code}\n${stdout}\n${stderr}`))
       return
     }
 
-    var _ = JSON.parse(stdout)
+    const _ = JSON.parse(stdout)
     _.map(String).should.deep.equal(args.map(String))
     done()
   })

--- a/test/usage.js
+++ b/test/usage.js
@@ -1,3 +1,4 @@
+'use strict'
 /* global describe, it, beforeEach */
 
 const checkUsage = require('./helpers/utils').checkOutput
@@ -9,21 +10,22 @@ const YError = require('../lib/yerror')
 
 require('chai').should()
 
-describe('usage tests', function () {
-  beforeEach(function () {
+const noop = () => {}
+
+describe('usage tests', () => {
+  beforeEach(() => {
     yargs.reset()
   })
 
-  describe('demand options', function () {
-    describe('using .demand()', function () {
-      it('should show an error along with the missing arguments on demand fail', function () {
-        var r = checkUsage(function () {
-          return yargs('-x 10 -z 20')
+  describe('demand options', () => {
+    describe('using .demand()', () => {
+      it('should show an error along with the missing arguments on demand fail', () => {
+        const r = checkUsage(() => yargs('-x 10 -z 20')
             .usage('Usage: $0 -x NUM -y NUM')
             .demand(['x', 'y'])
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('x', 10)
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
@@ -40,15 +42,14 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
-      it('missing argument message given if one command, but an argument not on the list is provided', function () {
-        var r = checkUsage(function () {
-          return yargs('wombat -w 10 -y 10')
+      it('missing argument message given if one command, but an argument not on the list is provided', () => {
+        const r = checkUsage(() => yargs('wombat -w 10 -y 10')
             .usage('Usage: $0 -w NUM -m NUM')
             .demand(1, ['w', 'm'])
             .strict()
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('w', 10)
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(1)
@@ -65,15 +66,14 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
-      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
-        var r = checkUsage(function () {
-          return yargs('-w 10 -y 10')
+      it('missing command message if all the required arguments exist, but not enough commands are provided', () => {
+        const r = checkUsage(() => yargs('-w 10 -y 10')
             .usage('Usage: $0 -w NUM -m NUM')
             .demand(1, ['w', 'm'])
             .strict()
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('w', 10)
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(0)
@@ -90,15 +90,14 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
-      it('no failure occurs if the required arguments and the required number of commands are provided', function () {
-        var r = checkUsage(function () {
-          return yargs('wombat -w 10 -m 10')
+      it('no failure occurs if the required arguments and the required number of commands are provided', () => {
+        const r = checkUsage(() => yargs('wombat -w 10 -m 10')
             .usage('Usage: $0 -w NUM -m NUM')
             .command('wombat', 'wombat handlers')
             .demand(1, ['w', 'm'])
             .wrap(null)
             .argv
-        })
+          )
 
         r.result.should.have.property('w', 10)
         r.result.should.have.property('m', 10)
@@ -108,15 +107,14 @@ describe('usage tests', function () {
         r.should.have.property('exit', false)
       })
 
-      describe('using .require()', function () {
-        it('should show an error along with the missing arguments on demand fail', function () {
-          var r = checkUsage(function () {
-            return yargs('-x 10 -z 20')
+      describe('using .require()', () => {
+        it('should show an error along with the missing arguments on demand fail', () => {
+          const r = checkUsage(() => yargs('-x 10 -z 20')
               .usage('Usage: $0 -x NUM -y NUM')
               .require(['x', 'y'])
               .wrap(null)
               .argv
-          })
+            )
           r.result.should.have.property('x', 10)
           r.result.should.have.property('z', 20)
           r.result.should.have.property('_').with.length(0)
@@ -132,15 +130,14 @@ describe('usage tests', function () {
           r.logs.should.have.length(0)
           r.exit.should.be.ok
         })
-        it('missing argument message given if one command and an argument not on the list are provided', function () {
-          var r = checkUsage(function () {
-            return yargs('wombat -w 10 -y 10')
+        it('missing argument message given if one command and an argument not on the list are provided', () => {
+          const r = checkUsage(() => yargs('wombat -w 10 -y 10')
               .usage('Usage: $0 -w NUM -m NUM')
               .required(1, ['w', 'm'])
               .strict()
               .wrap(null)
               .argv
-          })
+            )
           r.result.should.have.property('w', 10)
           r.result.should.have.property('y', 10)
           r.result.should.have.property('_').with.length(1)
@@ -158,15 +155,14 @@ describe('usage tests', function () {
         })
       })
 
-      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
-        var r = checkUsage(function () {
-          return yargs('-w 10 -y 10')
+      it('missing command message if all the required arguments exist, but not enough commands are provided', () => {
+        const r = checkUsage(() => yargs('-w 10 -y 10')
             .usage('Usage: $0 -w NUM -m NUM')
             .require(1, ['w', 'm'])
             .strict()
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('w', 10)
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(0)
@@ -184,14 +180,13 @@ describe('usage tests', function () {
       })
     })
 
-    it('should show an error along with a custom message on demand fail', function () {
-      var r = checkUsage(function () {
-        return yargs('-z 20')
+    it('should show an error along with a custom message on demand fail', () => {
+      const r = checkUsage(() => yargs('-z 20')
         .usage('Usage: $0 -x NUM -y NUM')
         .demand(['x', 'y'], 'x and y are both required to multiply all the things')
         .wrap(null)
         .argv
-      })
+      )
       r.result.should.have.property('z', 20)
       r.result.should.have.property('_').with.length(0)
       r.errors.join('\n').split(/\n+/).should.deep.equal([
@@ -208,14 +203,13 @@ describe('usage tests', function () {
       r.exit.should.be.ok
     })
 
-    it('should return valid values when demand passes', function () {
-      var r = checkUsage(function () {
-        return yargs('-x 10 -y 20')
+    it('should return valid values when demand passes', () => {
+      const r = checkUsage(() => yargs('-x 10 -y 20')
         .usage('Usage: $0 -x NUM -y NUM')
         .demand(['x', 'y'])
         .wrap(null)
         .argv
-      })
+      )
       r.should.have.property('result')
       r.result.should.have.property('x', 10)
       r.result.should.have.property('y', 20)
@@ -225,14 +219,13 @@ describe('usage tests', function () {
       r.should.have.property('exit', false)
     })
 
-    it('should not show a custom message if msg is null', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+    it('should not show a custom message if msg is null', () => {
+      const r = checkUsage(() => yargs('')
           .usage('Usage: foo')
           .demand(1, null)
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: foo',
@@ -244,27 +237,25 @@ describe('usage tests', function () {
     })
 
     // see #169.
-    describe('min/max demanded count', function () {
-      it("does not output an error if '_' count is within the min/max range", function () {
-        var r = checkUsage(function () {
-          return yargs(['foo', 'bar', 'apple'])
+    describe('min/max demanded count', () => {
+      it("does not output an error if '_' count is within the min/max range", () => {
+        const r = checkUsage(() => yargs(['foo', 'bar', 'apple'])
             .usage('Usage: foo')
             .demand(2, 3)
             .wrap(null)
             .argv
-        })
+          )
 
         r.errors.length.should.equal(0)
       })
 
-      it("outputs an error if '_' count is above max", function () {
-        var r = checkUsage(function () {
-          return yargs(['foo', 'bar', 'apple', 'banana'])
+      it("outputs an error if '_' count is above max", () => {
+        const r = checkUsage(() => yargs(['foo', 'bar', 'apple', 'banana'])
             .usage('Usage: foo')
             .demand(2, 3)
             .wrap(null)
             .argv
-        })
+          )
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
@@ -275,14 +266,13 @@ describe('usage tests', function () {
         ])
       })
 
-      it("outputs an error if '_' count is below min", function () {
-        var r = checkUsage(function () {
-          return yargs(['foo'])
+      it("outputs an error if '_' count is below min", () => {
+        const r = checkUsage(() => yargs(['foo'])
             .usage('Usage: foo')
             .demand(2, 3)
             .wrap(null)
             .argv
-        })
+          )
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
@@ -293,14 +283,13 @@ describe('usage tests', function () {
         ])
       })
 
-      it('allows a customer error message to be provided', function () {
-        var r = checkUsage(function () {
-          return yargs(['foo'])
+      it('allows a customer error message to be provided', () => {
+        const r = checkUsage(() => yargs(['foo'])
             .usage('Usage: foo')
             .demand(2, 3, 'pork chop sandwiches')
             .wrap(null)
             .argv
-        })
+          )
 
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: foo',
@@ -311,31 +300,29 @@ describe('usage tests', function () {
         ])
       })
 
-      it("shouldn't interpret the second argument as a max when it is an array", function () {
-        var r = checkUsage(function () {
-          return yargs(['koala', 'wombat', '--1'])
+      it("shouldn't interpret the second argument as a max when it is an array", () => {
+        const r = checkUsage(() => yargs(['koala', 'wombat', '--1'])
               .usage('Usage: foo')
               .demand(1, ['1'])
               .wrap(null)
               .argv
-        })
+            )
 
         r.errors.length.should.equal(0)
       })
     })
   })
 
-  it('should return valid values when check passes', function () {
-    var r = checkUsage(function () {
-      return yargs('-x 10 -y 20')
+  it('should return valid values when check passes', () => {
+    const r = checkUsage(() => yargs('-x 10 -y 20')
       .usage('Usage: $0 -x NUM -y NUM')
-      .check(function (argv) {
+      .check((argv) => {
         if (!('x' in argv)) throw Error('You forgot about -x')
         if (!('y' in argv)) throw Error('You forgot about -y')
         else return true
       })
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('x', 10)
     r.result.should.have.property('y', 20)
@@ -345,17 +332,16 @@ describe('usage tests', function () {
     r.should.have.property('exit', false)
   })
 
-  it('should display missing arguments when check fails with a thrown exception', function () {
-    var r = checkUsage(function () {
-      return yargs('-x 10 -z 20')
+  it('should display missing arguments when check fails with a thrown exception', () => {
+    const r = checkUsage(() => yargs('-x 10 -z 20')
         .usage('Usage: $0 -x NUM -y NUM')
         .wrap(null)
-        .check(function (argv) {
+        .check((argv) => {
           if (!('x' in argv)) throw Error('You forgot about -x')
           if (!('y' in argv)) throw Error('You forgot about -y')
         })
         .argv
-    })
+      )
     r.should.have.property('result')
     r.result.should.have.property('x', 10)
     r.result.should.have.property('z', 20)
@@ -371,17 +357,16 @@ describe('usage tests', function () {
     r.should.have.property('exit').and.be.ok
   })
 
-  it('should display missing arguments when check fails with a return value', function () {
-    var r = checkUsage(function () {
-      return yargs('-x 10 -z 20')
+  it('should display missing arguments when check fails with a return value', () => {
+    const r = checkUsage(() => yargs('-x 10 -z 20')
       .usage('Usage: $0 -x NUM -y NUM')
       .wrap(null)
-      .check(function (argv) {
+      .check((argv) => {
         if (!('x' in argv)) return 'You forgot about -x'
         if (!('y' in argv)) return 'You forgot about -y'
       })
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('x', 10)
     r.result.should.have.property('z', 20)
@@ -398,16 +383,15 @@ describe('usage tests', function () {
     ])
   })
 
-  it('should return a valid result when check condition passes', function () {
+  it('should return a valid result when check condition passes', () => {
     function checker (argv) {
       return 'x' in argv && 'y' in argv
     }
-    var r = checkUsage(function () {
-      return yargs('-x 10 -y 20')
+    const r = checkUsage(() => yargs('-x 10 -y 20')
       .usage('Usage: $0 -x NUM -y NUM')
       .check(checker)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('x', 10)
     r.result.should.have.property('y', 20)
@@ -417,17 +401,16 @@ describe('usage tests', function () {
     r.should.have.property('exit', false)
   })
 
-  it('should display a failed message when check condition fails', function () {
+  it('should display a failed message when check condition fails', () => {
     function checker (argv) {
       return 'x' in argv && 'y' in argv
     }
-    var r = checkUsage(function () {
-      return yargs('-x 10 -z 20')
+    const r = checkUsage(() => yargs('-x 10 -z 20')
       .usage('Usage: $0 -x NUM -y NUM')
       .check(checker)
       .wrap(null)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('x', 10)
     r.result.should.have.property('z', 20)
@@ -440,20 +423,20 @@ describe('usage tests', function () {
       'Options:\n' +
       '  --help     Show help  [boolean]\n' +
       '  --version  Show version number  [boolean]\n' +
-      'Argument check failed: ' + checker.toString()
+      `Argument check failed: ${checker.toString()}`
     )
   })
 
-  describe('when exitProcess is false', function () {
-    describe('when check fails with a thrown exception', function () {
-      it('should display missing arguments once', function () {
-        var r = checkUsage(function () {
+  describe('when exitProcess is false', () => {
+    describe('when check fails with a thrown exception', () => {
+      it('should display missing arguments once', () => {
+        const r = checkUsage(() => {
           try {
             return yargs('-x 10 -z 20')
               .usage('Usage: $0 -x NUM -y NUM')
               .exitProcess(false)
               .wrap(null)
-              .check(function (argv) {
+              .check((argv) => {
                 if (!('x' in argv)) throw Error('You forgot about -x')
                 if (!('y' in argv)) throw Error('You forgot about -y')
               })
@@ -473,17 +456,17 @@ describe('usage tests', function () {
         r.should.have.property('exit').and.be.false
       })
     })
-    describe('fail()', function () {
-      it('is called with the original error message as the first parameter', function () {
-        var r = checkUsage(function () {
+    describe('fail()', () => {
+      it('is called with the original error message as the first parameter', () => {
+        const r = checkUsage(() => {
           try {
             return yargs()
-              .fail(function (message) {
+              .fail((message) => {
                 console.log(message)
               })
               .exitProcess(false)
               .wrap(null)
-              .check(function (argv) {
+              .check((argv) => {
                 throw new Error('foo')
               })
               .argv
@@ -495,38 +478,37 @@ describe('usage tests', function () {
         r.should.have.property('exit').and.be.false
       })
 
-      it('is invoked with yargs instance as third argument', function () {
-        var r = checkUsage(function () {
-          return yargs('foo')
+      it('is invoked with yargs instance as third argument', () => {
+        const r = checkUsage(() => yargs('foo')
             .command('foo', 'desc', {
               bar: {
                 describe: 'bar command'
               }
-            }, function (argv) {
+            }, (argv) => {
               throw new YError('blah')
             })
-            .fail(function (message, error, yargs) {
+            .fail((message, error, yargs) => {
               yargs.showHelp()
             })
             .exitProcess(false)
             .wrap(null)
             .argv
-        })
+          )
 
         r.errors[0].should.contain('bar command')
       })
 
-      describe('when check() throws error', function () {
-        it('fail() is called with the original error object as the second parameter', function () {
-          var r = checkUsage(function () {
+      describe('when check() throws error', () => {
+        it('fail() is called with the original error object as the second parameter', () => {
+          const r = checkUsage(() => {
             try {
               return yargs()
-                .fail(function (message, error) {
+                .fail((message, error) => {
                   console.log(error.message)
                 })
                 .exitProcess(false)
                 .wrap(null)
-                .check(function () {
+                .check(() => {
                   throw new Error('foo')
                 })
                 .argv
@@ -538,23 +520,23 @@ describe('usage tests', function () {
           r.should.have.property('exit').and.be.false
         })
       })
-      describe('when command() throws error', function () {
-        it('fail() is called with the original error object as the second parameter', function () {
-          var r = checkUsage(function () {
+      describe('when command() throws error', () => {
+        it('fail() is called with the original error object as the second parameter', () => {
+          const r = checkUsage(() => {
             try {
               return yargs('test')
-                .fail(function () {
+                .fail(() => {
                   console.log('is triggered last')
                 })
                 .exitProcess(false)
                 .wrap(null)
-                .command('test', 'test', function (subYargs) {
+                .command('test', 'test', (subYargs) => {
                   subYargs
-                    .fail(function (message, error) {
+                    .fail((message, error) => {
                       console.log([error.name, error.message])
                     })
                     .exitProcess(false)
-                }, function (argv) {
+                }, (argv) => {
                   throw new YError('foo')
                 })
                 .argv
@@ -569,13 +551,12 @@ describe('usage tests', function () {
     })
   })
 
-  it('should return a valid result when demanding a count of non-hyphenated values', function () {
-    var r = checkUsage(function () {
-      return yargs('1 2 3 --moo')
+  it('should return a valid result when demanding a count of non-hyphenated values', () => {
+    const r = checkUsage(() => yargs('1 2 3 --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS}')
       .demand(3)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.should.have.property('errors').with.length(0)
     r.should.have.property('logs').with.length(0)
@@ -584,14 +565,13 @@ describe('usage tests', function () {
     r.result.should.have.property('moo', true)
   })
 
-  it('should return a failure message when not enough non-hyphenated arguments are found after a demand count', function () {
-    var r = checkUsage(function () {
-      return yargs('1 2 --moo')
+  it('should return a failure message when not enough non-hyphenated arguments are found after a demand count', () => {
+    const r = checkUsage(() => yargs('1 2 --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS}')
       .demand(3)
       .wrap(null)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.should.have.property('logs').with.length(0)
     r.should.have.property('exit').and.be.ok
@@ -607,14 +587,13 @@ describe('usage tests', function () {
     ])
   })
 
-  it('should return a custom failure message when not enough non-hyphenated arguments are found after a demand count', function () {
-    var r = checkUsage(function () {
-      return yargs('src --moo')
+  it('should return a custom failure message when not enough non-hyphenated arguments are found after a demand count', () => {
+    const r = checkUsage(() => yargs('src --moo')
       .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
       .demand(2, 'src and dest files are both required')
       .wrap(null)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.should.have.property('logs').with.length(0)
     r.should.have.property('exit').and.be.ok
@@ -630,14 +609,13 @@ describe('usage tests', function () {
     ])
   })
 
-  it('should return a valid result when setting defaults for singles', function () {
-    var r = checkUsage(function () {
-      return yargs('--foo 50 --baz 70 --powsy')
+  it('should return a valid result when setting defaults for singles', () => {
+    const r = checkUsage(() => yargs('--foo 50 --baz 70 --powsy')
       .default('foo', 5)
       .default('bar', 6)
       .default('baz', 7)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('foo', 50)
     r.result.should.have.property('bar', 6)
@@ -646,28 +624,26 @@ describe('usage tests', function () {
     r.result.should.have.property('_').with.length(0)
   })
 
-  it('should return a valid result when default is set for an alias', function () {
-    var r = checkUsage(function () {
-      return yargs('')
+  it('should return a valid result when default is set for an alias', () => {
+    const r = checkUsage(() => yargs('')
       .alias('f', 'foo')
       .default('f', 5)
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('f', 5)
     r.result.should.have.property('foo', 5)
     r.result.should.have.property('_').with.length(0)
   })
 
-  it('should print a single line when failing and default is set for an alias', function () {
-    var r = checkUsage(function () {
-      return yargs('')
+  it('should print a single line when failing and default is set for an alias', () => {
+    const r = checkUsage(() => yargs('')
         .alias('f', 'foo')
         .default('f', 5)
         .demand(1)
         .wrap(null)
         .argv
-    })
+      )
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
       '  --help     Show help  [boolean]',
@@ -677,12 +653,11 @@ describe('usage tests', function () {
     ])
   })
 
-  it('should allow you to set default values for a hash of options', function () {
-    var r = checkUsage(function () {
-      return yargs('--foo 50 --baz 70')
+  it('should allow you to set default values for a hash of options', () => {
+    const r = checkUsage(() => yargs('--foo 50 --baz 70')
       .default({ foo: 10, bar: 20, quux: 30 })
       .argv
-    })
+    )
     r.should.have.property('result')
     r.result.should.have.property('_').with.length(0)
     r.result.should.have.property('foo', 50)
@@ -691,11 +666,11 @@ describe('usage tests', function () {
     r.result.should.have.property('quux', 30)
   })
 
-  describe('required arguments', function () {
-    describe('with options object', function () {
-      it('should show a failure message if a required option is missing', function () {
-        var r = checkUsage(function () {
-          var opts = {
+  describe('required arguments', () => {
+    describe('with options object', () => {
+      it('should show a failure message if a required option is missing', () => {
+        const r = checkUsage(() => {
+          const opts = {
             foo: { description: 'foo option', alias: 'f', requiresArg: true },
             bar: { description: 'bar option', alias: 'b', requiresArg: true }
           }
@@ -721,9 +696,9 @@ describe('usage tests', function () {
         ])
       })
 
-      it('should show a failure message if more than one required option is missing', function () {
-        var r = checkUsage(function () {
-          var opts = {
+      it('should show a failure message if more than one required option is missing', () => {
+        const r = checkUsage(() => {
+          const opts = {
             foo: { description: 'foo option', alias: 'f', requiresArg: true },
             bar: { description: 'bar option', alias: 'b', requiresArg: true }
           }
@@ -750,10 +725,10 @@ describe('usage tests', function () {
       })
     })
 
-    describe('with requiresArg method', function () {
-      it('should show a failure message if a required option is missing', function () {
-        var r = checkUsage(function () {
-          var opts = {
+    describe('with requiresArg method', () => {
+      it('should show a failure message if a required option is missing', () => {
+        const r = checkUsage(() => {
+          const opts = {
             foo: { description: 'foo option', alias: 'f' },
             bar: { description: 'bar option', alias: 'b' }
           }
@@ -781,25 +756,24 @@ describe('usage tests', function () {
       })
     })
 
-    it("still requires argument if 'type' hints are given", function () {
-      var r = checkUsage(function () {
-        return yargs('--foo --bar')
+    it("still requires argument if 'type' hints are given", () => {
+      const r = checkUsage(() => yargs('--foo --bar')
           .requiresArg('foo')
           .string('foo')
           .requiresArg('bar')
           .array('bar')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors[1].should.equal('Missing argument values: foo, bar')
     })
   })
 
-  describe('with strict() option set', function () {
-    it('should fail given an option argument that is not demanded', function () {
-      var r = checkUsage(function () {
-        var opts = {
+  describe('with strict() option set', () => {
+    it('should fail given an option argument that is not demanded', () => {
+      const r = checkUsage(() => {
+        const opts = {
           foo: { demand: 'foo option', alias: 'f' },
           bar: { demand: 'bar option', alias: 'b' }
         }
@@ -832,9 +806,9 @@ describe('usage tests', function () {
       r.should.have.property('exit').and.be.ok
     })
 
-    it('should fail given an option argument without a corresponding description', function () {
-      var r = checkUsage(function () {
-        var opts = {
+    it('should fail given an option argument without a corresponding description', () => {
+      const r = checkUsage(() => {
+        const opts = {
           foo: { description: 'foo option', alias: 'f' },
           bar: { description: 'bar option', alias: 'b' }
         }
@@ -867,9 +841,9 @@ describe('usage tests', function () {
       r.should.have.property('exit').and.be.ok
     })
 
-    it('should fail given multiple option arguments without corresponding descriptions', function () {
-      var r = checkUsage(function () {
-        var opts = {
+    it('should fail given multiple option arguments without corresponding descriptions', () => {
+      const r = checkUsage(() => {
+        const opts = {
           foo: { description: 'foo option', alias: 'f' },
           bar: { description: 'bar option', alias: 'b' }
         }
@@ -903,9 +877,9 @@ describe('usage tests', function () {
       r.should.have.property('exit').and.be.ok
     })
 
-    it('should pass given option arguments with corresponding descriptions', function () {
-      var r = checkUsage(function () {
-        var opts = {
+    it('should pass given option arguments with corresponding descriptions', () => {
+      const r = checkUsage(() => {
+        const opts = {
           foo: { description: 'foo option' },
           bar: { description: 'bar option' }
         }
@@ -926,15 +900,14 @@ describe('usage tests', function () {
     })
   })
 
-  it('should display example on fail', function () {
-    var r = checkUsage(function () {
-      return yargs('')
+  it('should display example on fail', () => {
+    const r = checkUsage(() => yargs('')
         .example('$0 something', 'description')
         .example('$0 something else', 'other description')
         .demand(['y'])
         .wrap(null)
         .argv
-    })
+      )
     r.should.have.property('result')
     r.result.should.have.property('_').with.length(0)
     r.should.have.property('errors')
@@ -952,11 +925,10 @@ describe('usage tests', function () {
     ])
   })
 
-  describe('demand option with boolean flag', function () {
-    describe('with demand option', function () {
-      it('should report missing required arguments', function () {
-        var r = checkUsage(function () {
-          return yargs('-y 10 -z 20')
+  describe('demand option with boolean flag', () => {
+    describe('with demand option', () => {
+      it('should report missing required arguments', () => {
+        const r = checkUsage(() => yargs('-y 10 -z 20')
             .usage('Usage: $0 -x NUM [-y NUM]')
             .options({
               'x': { description: 'an option', demand: true },
@@ -964,7 +936,7 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('y', 10)
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
@@ -984,10 +956,9 @@ describe('usage tests', function () {
       })
     })
 
-    describe('with required option', function () {
-      it('should report missing required arguments', function () {
-        var r = checkUsage(function () {
-          return yargs('-y 10 -z 20')
+    describe('with required option', () => {
+      it('should report missing required arguments', () => {
+        const r = checkUsage(() => yargs('-y 10 -z 20')
             .usage('Usage: $0 -x NUM [-y NUM]')
             .options({
               'x': { description: 'an option', required: true },
@@ -995,7 +966,7 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
         r.result.should.have.property('y', 10)
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
@@ -1015,9 +986,8 @@ describe('usage tests', function () {
       })
     })
 
-    it('should not report missing required arguments when given an alias', function () {
-      var r = checkUsage(function () {
-        return yargs('-w 10')
+    it('should not report missing required arguments when given an alias', () => {
+      const r = checkUsage(() => yargs('-w 10')
         .usage('Usage: $0 --width NUM [--height NUM]')
         .options({
           'width': { description: 'Width', alias: 'w', demand: true },
@@ -1025,7 +995,7 @@ describe('usage tests', function () {
         })
         .wrap(null)
         .argv
-      })
+      )
       r.result.should.have.property('w', 10)
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('errors').with.length(0)
@@ -1033,14 +1003,13 @@ describe('usage tests', function () {
     })
   })
 
-  describe('help option', function () {
-    it('should display usage', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+  describe('help option', () => {
+    it('should display usage', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .demand(['y'])
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('errors')
@@ -1055,15 +1024,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should not show both dashed and camelCase aliases', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('should not show both dashed and camelCase aliases', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .usage('Usage: $0 options')
           .describe('some-opt', 'Some option')
           .default('some-opt', 2)
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('exit').and.be.ok
@@ -1079,10 +1047,9 @@ describe('usage tests', function () {
       ])
     })
 
-    describe('when exitProcess is false', function () {
-      it('should not validate arguments (required argument)', function () {
-        var r = checkUsage(function () {
-          return yargs(['--help'])
+    describe('when exitProcess is false', () => {
+      it('should not validate arguments (required argument)', () => {
+        const r = checkUsage(() => yargs(['--help'])
             .usage('Usage: $0 options')
             .alias('help', 'h')
             .describe('some-opt', 'Some option')
@@ -1090,7 +1057,7 @@ describe('usage tests', function () {
             .wrap(null)
             .exitProcess(false)
             .argv
-        })
+          )
         r.should.have.property('result')
         r.result.should.have.property('_').with.length(0)
         r.result.should.have.property('help').and.be.true
@@ -1110,9 +1077,8 @@ describe('usage tests', function () {
 
       // We need both this and the previous spec because a required argument
       // is a validation error and nargs is a parse error
-      it('should not validate arguments (nargs)', function () {
-        var r = checkUsage(function () {
-          return yargs(['--help', '--some-opt'])
+      it('should not validate arguments (nargs)', () => {
+        const r = checkUsage(() => yargs(['--help', '--some-opt'])
             .usage('Usage: $0 options')
             .alias('help', 'h')
             .describe('some-opt', 'Some option')
@@ -1121,7 +1087,7 @@ describe('usage tests', function () {
             .wrap(null)
             .exitProcess(false)
             .argv
-        })
+          )
         r.should.have.property('result')
         r.result.should.have.property('_').with.length(0)
         r.result.should.have.property('help').and.be.true
@@ -1141,14 +1107,13 @@ describe('usage tests', function () {
     })
   })
 
-  describe('version option', function () {
-    it('should display version', function () {
-      var r = checkUsage(function () {
-        return yargs(['--version'])
+  describe('version option', () => {
+    it('should display version', () => {
+      const r = checkUsage(() => yargs(['--version'])
         .version('version', 'Show version number', '1.0.1')
         .wrap(null)
         .argv
-      })
+      )
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('errors')
@@ -1157,36 +1122,33 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.1')
     })
 
-    it('accepts version option as first argument, and version number as second argument', function () {
-      var r = checkUsage(function () {
-        return yargs(['--version'])
+    it('accepts version option as first argument, and version number as second argument', () => {
+      const r = checkUsage(() => yargs(['--version'])
         .version('version', '1.0.0')
         .wrap(null)
         .argv
-      })
+      )
       r.logs[0].should.eql('1.0.0')
     })
 
-    it("should default to 'version' as version option", function () {
-      var r = checkUsage(function () {
-        return yargs(['--version'])
+    it("should default to 'version' as version option", () => {
+      const r = checkUsage(() => yargs(['--version'])
         .version('1.0.2')
         .wrap(null)
         .argv
-      })
+      )
       r.logs[0].should.eql('1.0.2')
     })
 
-    describe('when exitProcess is false', function () {
-      it('should not validate arguments (required argument)', function () {
-        var r = checkUsage(function () {
-          return yargs(['--version'])
+    describe('when exitProcess is false', () => {
+      it('should not validate arguments (required argument)', () => {
+        const r = checkUsage(() => yargs(['--version'])
             .version('version', 'Show version number', '1.0.1')
             .demand('some-opt')
             .wrap(null)
             .exitProcess(false)
             .argv
-        })
+          )
         r.should.have.property('result')
         r.result.should.have.property('_').with.length(0)
         r.result.should.have.property('version').and.be.true
@@ -1198,15 +1160,14 @@ describe('usage tests', function () {
 
       // We need both this and the previous spec because a required argument
       // is a validation error and nargs is a parse error
-      it('should not validate arguments (nargs)', function () {
-        var r = checkUsage(function () {
-          return yargs(['--version', '--some-opt'])
+      it('should not validate arguments (nargs)', () => {
+        const r = checkUsage(() => yargs(['--version', '--some-opt'])
             .nargs('some-opt', 3)
             .version('version', 'Show version number', '1.0.1')
             .wrap(null)
             .exitProcess(false)
             .argv
-        })
+          )
         r.should.have.property('result')
         r.result.should.have.property('_').with.length(0)
         r.result.should.have.property('version').and.be.true
@@ -1218,22 +1179,21 @@ describe('usage tests', function () {
     })
   })
 
-  describe('showHelpOnFail', function () {
-    it('should display user supplied message', function () {
-      var opts = {
+  describe('showHelpOnFail', () => {
+    it('should display user supplied message', () => {
+      const opts = {
         foo: { desc: 'foo option', alias: 'f' },
         bar: { desc: 'bar option', alias: 'b' }
       }
 
-      var r = checkUsage(function () {
-        return yargs(['--foo'])
+      const r = checkUsage(() => yargs(['--foo'])
           .usage('Usage: $0 [options]')
           .options(opts)
           .demand(['foo', 'bar'])
           .showHelpOnFail(false, 'Specify --help for available options')
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('errors')
@@ -1247,21 +1207,20 @@ describe('usage tests', function () {
     })
   })
 
-  describe('exitProcess', function () {
-    it('should not call process.exit on error if disabled', function () {
-      var opts = {
+  describe('exitProcess', () => {
+    it('should not call process.exit on error if disabled', () => {
+      const opts = {
         foo: { desc: 'foo option', alias: 'f' }
       }
 
-      var r = checkUsage(function () {
-        return yargs(['--foo'])
+      const r = checkUsage(() => yargs(['--foo'])
           .exitProcess(false)
           .usage('Usage: $0 [options]')
           .options(opts)
           .demand(['foo'])
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
       r.should.have.property('errors')
@@ -1270,32 +1229,29 @@ describe('usage tests', function () {
     })
   })
 
-  it('should succeed when rebase', function () {
+  it('should succeed when rebase', () => {
     rebase(['home', 'chevex'].join(path.sep), ['home', 'chevex', 'foo', 'bar', 'baz'].join(path.sep)).should.equal(['foo', 'bar', 'baz'].join(path.sep))
     rebase(['home', 'chevex', 'foo', 'bar', 'baz'].join(path.sep), ['home', 'chevex'].join(path.sep)).should.equal(['..', '..', '..'].join(path.sep))
     rebase(['home', 'chevex', 'foo'].join(path.sep), ['home', 'chevex', 'pow', 'zoom.txt'].join(path.sep)).should.equal(['..', 'pow', 'zoom.txt'].join(path.sep))
   })
 
-  it('should not print usage string if help() is called without arguments', function () {
-    var r = checkUsage(function () {
-      return yargs([]).usage('foo').help().argv
-    })
+  it('should not print usage string if help() is called without arguments', () => {
+    const r = checkUsage(() => yargs([]).usage('foo').help().argv
+  )
 
     r.logs.length.should.equal(0)
   })
 
-  it('should add --help as an option for printing usage text if help() is called without arguments', function () {
-    var r = checkUsage(function () {
-      return yargs(['--help']).usage('foo').help().argv
-    })
+  it('should add --help as an option for printing usage text if help() is called without arguments', () => {
+    const r = checkUsage(() => yargs(['--help']).usage('foo').help().argv
+  )
 
     r.logs.length.should.not.equal(0)
   })
 
-  describe('wrap', function () {
-    it('should wrap argument descriptions onto multiple lines', function () {
-      var r = checkUsage(function () {
-        return yargs([])
+  describe('wrap', () => {
+    it('should wrap argument descriptions onto multiple lines', () => {
+      const r = checkUsage(() => yargs([])
         .option('fairly-long-option', {
           alias: 'f',
           default: 'fairly-long-default',
@@ -1304,9 +1260,9 @@ describe('usage tests', function () {
         .demand('foo')
         .wrap(50)
         .argv
-      })
+      )
 
-      r.errors[0].split('\n').forEach(function (line, i) {
+      r.errors[0].split('\n').forEach((line, i) => {
         if (!i || !line) return // ignore first and last line.
         line.length.should.lte(50)
       })
@@ -1317,10 +1273,9 @@ describe('usage tests', function () {
         return this.skip()
       }
 
-      var width = process.stdout.columns
+      const width = process.stdout.columns
 
-      var r = checkUsage(function () {
-        return yargs([])
+      const r = checkUsage(() => yargs([])
           .option('fairly-long-option', {
             alias: 'f',
             // create a giant string that should wrap.
@@ -1328,27 +1283,24 @@ describe('usage tests', function () {
           })
           .demand('foo')
           .argv
-      })
+        )
 
       // the long description should cause several line
       // breaks when wrapped.
       r.errors[0].split('\n').length.should.gte(4)
     })
 
-    it('should not raise an exception when long default and description are provided', function () {
-      return yargs([])
+    it('should not raise an exception when long default and description are provided', () => yargs([])
       .option('fairly-long-option', {
         alias: 'f',
         default: 'npm prefix used to locate globally installed npm packages',
         description: 'npm prefix used to locate globally installed npm packages'
       })
       .wrap(40)
-      .help()
-    })
+      .help())
 
-    it('should wrap the left-hand-column if it takes up more than 50% of the screen', function () {
-      var r = checkUsage(function () {
-        return yargs([])
+    it('should wrap the left-hand-column if it takes up more than 50% of the screen', () => {
+      const r = checkUsage(() => yargs([])
           .example(
             'i am a fairly long example',
             'description that is also fairly long'
@@ -1356,13 +1308,13 @@ describe('usage tests', function () {
           .demand('foo')
           .wrap(40)
           .argv
-      })
+        )
 
       // should split example usage onto multiple lines.
       r.errors[0].split('\n').length.should.equal(11)
 
       // should wrap within appropriate boundaries.
-      r.errors[0].split('\n').forEach(function (line, i) {
+      r.errors[0].split('\n').forEach((line, i) => {
         // ignore headings and blank lines.
         if (!line || line.match('Examples:') || line.match('Options:')) return
 
@@ -1370,16 +1322,15 @@ describe('usage tests', function () {
       })
     })
 
-    it('should not wrap left-hand-column if no description is provided', function () {
-      var r = checkUsage(function () {
-        return yargs([])
+    it('should not wrap left-hand-column if no description is provided', () => {
+      const r = checkUsage(() => yargs([])
           .example('i am a fairly long example that is like really long woooo')
           .demand('foo')
           .wrap(50)
           .argv
-      })
+        )
 
-      r.errors[0].split('\n').forEach(function (line, i) {
+      r.errors[0].split('\n').forEach((line, i) => {
         // ignore headings and blank lines.
         if (!line.match('i am a fairly long example')) return
 
@@ -1389,24 +1340,22 @@ describe('usage tests', function () {
       })
     })
 
-    it('should wrap the usage string', function () {
-      var r = checkUsage(function () {
-        return yargs([])
+    it('should wrap the usage string', () => {
+      const r = checkUsage(() => yargs([])
         .usage('i am a fairly long usage string look at me go.')
         .demand('foo')
         .wrap(20)
         .argv
-      })
+      )
 
       // the long usage string should cause line-breaks.
       r.errors[0].split('\n').length.should.gt(6)
     })
 
-    it('should align span columns when ansi colors are not used in a description', function () {
-      var noColorAddedDescr = 'The file to add or remove'
+    it('should align span columns when ansi colors are not used in a description', () => {
+      const noColorAddedDescr = 'The file to add or remove'
 
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+      const r = checkUsage(() => yargs(['-h'])
           .option('f', {
             alias: 'file',
             describe: noColorAddedDescr,
@@ -1416,22 +1365,21 @@ describe('usage tests', function () {
           .help('h').alias('h', 'help')
           .wrap(80)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --version   Show version number                                      [boolean]',
-        '  -f, --file  ' + noColorAddedDescr + '                      [string] [required]',
+        `  -f, --file  ${noColorAddedDescr}                      [string] [required]`,
         '  -h, --help  Show help                                                [boolean]',
         ''
       ])
     })
 
-    it('should align span columns when ansi colors are used in a description', function () {
-      var yellowDescription = chalk.yellow('The file to add or remove')
+    it('should align span columns when ansi colors are used in a description', () => {
+      const yellowDescription = chalk.yellow('The file to add or remove')
 
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+      const r = checkUsage(() => yargs(['-h'])
           .option('f', {
             alias: 'file',
             describe: yellowDescription,
@@ -1441,28 +1389,27 @@ describe('usage tests', function () {
           .help('h').alias('h', 'help')
           .wrap(80)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --version   Show version number                                      [boolean]',
-        '  -f, --file  ' + yellowDescription + '                      [string] [required]',
+        `  -f, --file  ${yellowDescription}                      [string] [required]`,
         '  -h, --help  Show help                                                [boolean]',
         ''
       ])
     })
   })
 
-  describe('commands', function () {
-    it('should output a list of available commands', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+  describe('commands', () => {
+    it('should output a list of available commands', () => {
+      const r = checkUsage(() => yargs('')
           .command('upload', 'upload something')
           .command('download', 'download something from somewhere')
           .demand('y')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Commands:',
@@ -1476,15 +1423,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should not show hidden commands', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+    it('should not show hidden commands', () => {
+      const r = checkUsage(() => yargs('')
           .command('upload', 'upload something')
           .command('secret', false)
           .demand('y')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\s+/).should.deep.equal([
         'Commands:',
@@ -1497,15 +1443,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows completion command to be hidden', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+    it('allows completion command to be hidden', () => {
+      const r = checkUsage(() => yargs('')
           .command('upload', 'upload something')
           .completion('completion', false)
           .demand('y')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\s+/).should.deep.equal([
         'Commands:',
@@ -1518,29 +1463,27 @@ describe('usage tests', function () {
       ])
     })
 
-    it('preserves global wrap() for commands that do not override it', function () {
-      var uploadCommand = 'upload <dest>'
-      var uploadDesc = 'Upload cwd to remote destination'
-      var uploadOpts = {
+    it('preserves global wrap() for commands that do not override it', () => {
+      const uploadCommand = 'upload <dest>'
+      const uploadDesc = 'Upload cwd to remote destination'
+      const uploadOpts = {
         force: {
           describe: 'Force overwrite of remote directory contents',
           type: 'boolean'
         }
       }
-      var uploadHandler = function (argv) {}
+      const uploadHandler = (argv) => {}
 
-      var generalHelp = checkUsage(function () {
-        return yargs('--help')
+      const generalHelp = checkUsage(() => yargs('--help')
           .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
           .wrap(null)
           .argv
-      })
-      var commandHelp = checkUsage(function () {
-        return yargs('upload --help')
+        )
+      const commandHelp = checkUsage(() => yargs('upload --help')
           .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
           .wrap(null)
           .argv
-      })
+        )
 
       generalHelp.logs[0].split('\n').should.deep.equal([
         'Commands:',
@@ -1562,31 +1505,27 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows a command to override global wrap()', function () {
-      var uploadCommand = 'upload <dest>'
-      var uploadDesc = 'Upload cwd to remote destination'
-      var uploadBuilder = function (yargs) {
-        return yargs
+    it('allows a command to override global wrap()', () => {
+      const uploadCommand = 'upload <dest>'
+      const uploadDesc = 'Upload cwd to remote destination'
+      const uploadBuilder = yargs => yargs
           .option('force', {
             describe: 'Force overwrite of remote directory contents',
             type: 'boolean'
           })
           .wrap(46)
-      }
-      var uploadHandler = function (argv) {}
+      const uploadHandler = argv => {}
 
-      var generalHelp = checkUsage(function () {
-        return yargs('--help')
+      const generalHelp = checkUsage(() => yargs('--help')
           .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
           .wrap(null)
           .argv
-      })
-      var commandHelp = checkUsage(function () {
-        return yargs('upload --help')
+        )
+      const commandHelp = checkUsage(() => yargs('upload --help')
           .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
           .wrap(null)
           .argv
-      })
+        )
 
       generalHelp.logs[0].split('\n').should.deep.equal([
         'Commands:',
@@ -1609,22 +1548,19 @@ describe('usage tests', function () {
       ])
     })
 
-    it('resets groups for a command handler, respecting order', function () {
-      var r = checkUsage(function () {
-        return yargs(['upload', '-h'])
-          .command('upload', 'upload something', function (yargs) {
-            return yargs
+    it('resets groups for a command handler, respecting order', () => {
+      const r = checkUsage(() => yargs(['upload', '-h'])
+          .command('upload', 'upload something', yargs => yargs
               .option('q', {
                 type: 'boolean',
                 group: 'Flags:'
               })
               .help('h').group('h', 'Global Flags:')
-              .wrap(null)
-          })
+              .wrap(null))
           .help('h').group('h', 'Global Flags:')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage upload',
@@ -1641,17 +1577,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows global option to be disabled', function () {
-      var r = checkUsage(function () {
-        return yargs(['upload', '-h'])
-          .command('upload', 'upload something', function (yargs) {
-            return yargs
+    it('allows global option to be disabled', () => {
+      const r = checkUsage(() => yargs(['upload', '-h'])
+          .command('upload', 'upload something', yargs => yargs
               .option('q', {
                 type: 'boolean',
                 group: 'Flags:'
               })
-              .wrap(null)
-          })
+              .wrap(null))
           .option('i', {
             type: 'boolean',
             global: true,
@@ -1665,7 +1598,7 @@ describe('usage tests', function () {
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage upload',
@@ -1683,17 +1616,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('can add to preserved groups', function () {
-      var r = checkUsage(function () {
-        return yargs(['upload', '-h'])
-          .command('upload', 'upload something', function (yargs) {
-            return yargs
+    it('can add to preserved groups', () => {
+      const r = checkUsage(() => yargs(['upload', '-h'])
+          .command('upload', 'upload something', yargs => yargs
               .option('q', {
                 type: 'boolean',
                 group: 'Awesome Flags:'
               })
-              .wrap(null)
-          })
+              .wrap(null))
           .option('i', {
             type: 'boolean',
             global: true,
@@ -1702,7 +1632,7 @@ describe('usage tests', function () {
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage upload',
@@ -1718,18 +1648,15 @@ describe('usage tests', function () {
       ])
     })
 
-    it('can bump up preserved groups', function () {
-      var r = checkUsage(function () {
-        return yargs(['upload', '-h'])
-          .command('upload', 'upload something', function (yargs) {
-            return yargs
+    it('can bump up preserved groups', () => {
+      const r = checkUsage(() => yargs(['upload', '-h'])
+          .command('upload', 'upload something', yargs => yargs
               .group([], 'Awesome Flags:')
               .option('q', {
                 type: 'boolean',
                 group: 'Flags:'
               })
-              .wrap(null)
-          })
+              .wrap(null))
           .option('i', {
             type: 'boolean',
             global: true,
@@ -1743,7 +1670,7 @@ describe('usage tests', function () {
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage upload',
@@ -1761,18 +1688,17 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should list a module command only once', function () {
-      var r = checkUsage(function () {
-        return yargs('--help')
+    it('should list a module command only once', () => {
+      const r = checkUsage(() => yargs('--help')
           .command('upload', 'upload something', {
-            builder: function (yargs) {
+            builder (yargs) {
               return yargs
             },
-            handler: function (argv) {}
+            handler (argv) {}
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Commands:',
@@ -1785,18 +1711,17 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows a builder function to override default usage() string', function () {
-      var r = checkUsage(function () {
-        return yargs('upload --help')
+    it('allows a builder function to override default usage() string', () => {
+      const r = checkUsage(() => yargs('upload --help')
           .command('upload', 'upload something', {
-            builder: function (yargs) {
+            builder (yargs) {
               return yargs.usage('Usage: program upload <something> [opts]').demand(1)
             },
-            handler: function (argv) {}
+            handler (argv) {}
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Usage: program upload <something> [opts]',
@@ -1808,15 +1733,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows a builder function to disable default usage() with null', function () {
-      var r = checkUsage(function () {
-        return yargs('upload --help')
-          .command('upload', 'upload something', function (yargs) {
-            return yargs.usage(null)
-          }, function (argv) {})
+    it('allows a builder function to disable default usage() with null', () => {
+      const r = checkUsage(() => yargs('upload --help')
+          .command('upload', 'upload something', yargs => yargs.usage(null), (argv) => {})
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
@@ -1826,15 +1748,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays given command chain with positional args in default usage for subcommand with builder object', function () {
-      var r = checkUsage(function () {
-        return yargs('one two --help')
-          .command('one <sub>', 'level one, requires subcommand', function (yargs) {
-            return yargs.command('two [next]', 'level two', {}, function (argv) {})
-          }, function (argv) {})
+    it('displays given command chain with positional args in default usage for subcommand with builder object', () => {
+      const r = checkUsage(() => yargs('one two --help')
+          .command('one <sub>', 'level one, requires subcommand', yargs => yargs.command('two [next]', 'level two', {}, (argv) => {}), (argv) => {})
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage one two [next]',
@@ -1846,15 +1765,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays given command chain with positional args in default usage for subcommand with builder function', function () {
-      var r = checkUsage(function () {
-        return yargs('one two --help')
-          .command('one <sub>', 'level one, requires subcommand', function (yargs) {
-            return yargs.command('two [next]', 'level two', function (yargs) { return yargs }, function (argv) {})
-          }, function (argv) {})
+    it('displays given command chain with positional args in default usage for subcommand with builder function', () => {
+      const r = checkUsage(() => yargs('one two --help')
+          .command('one <sub>', 'level one, requires subcommand', yargs => yargs.command('two [next]', 'level two', yargs => yargs, (argv) => {}), (argv) => {})
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         './usage one two [next]',
@@ -1866,13 +1782,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays aliases for commands that have them (no wrap)', function () {
-      var r = checkUsage(function () {
-        return yargs('help')
+    it('displays aliases for commands that have them (no wrap)', () => {
+      const r = checkUsage(() => yargs('help')
           .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Commands:',
@@ -1885,13 +1800,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays aliases for commands that have them (with wrap)', function () {
-      var r = checkUsage(function () {
-        return yargs('help')
+    it('displays aliases for commands that have them (with wrap)', () => {
+      const r = checkUsage(() => yargs('help')
           .command(['copy <src> [dest]', 'cp', 'dupe'], 'Copy something')
           .wrap(80)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Commands:',
@@ -1905,15 +1819,14 @@ describe('usage tests', function () {
     })
   })
 
-  describe('epilogue', function () {
-    it('should display an epilog message at the end of the usage instructions', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+  describe('epilogue', () => {
+    it('should display an epilog message at the end of the usage instructions', () => {
+      const r = checkUsage(() => yargs('')
           .epilog('for more info view the manual at http://example.com')
           .demand('y')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -1925,14 +1838,13 @@ describe('usage tests', function () {
       ])
     })
 
-    it('replaces $0 in epilog string', function () {
-      var r = checkUsage(function () {
-        return yargs('')
+    it('replaces $0 in epilog string', () => {
+      const r = checkUsage(() => yargs('')
           .epilog("Try '$0 --long-help' for more information")
           .demand('y')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -1945,59 +1857,53 @@ describe('usage tests', function () {
     })
   })
 
-  describe('default', function () {
-    it('should indicate that the default is a generated-value, if function is provided', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+  describe('default', () => {
+    it('should indicate that the default is a generated-value, if function is provided', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .help('h')
-          .default('f', function () {
-            return 99
-          })
+          .default('f', () => 99)
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].should.include('default: (generated-value)')
     })
 
-    it('if a named function is provided, should use name rather than (generated-value)', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('if a named function is provided, should use name rather than (generated-value)', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .help('h')
           .default('f', function randomNumber () {
             return Math.random() * 256
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].should.include('default: (random-number)')
     })
 
-    it('default-description take precedence if one is provided', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('default-description take precedence if one is provided', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .help('h')
           .default('f', function randomNumber () {
             return Math.random() * 256
           }, 'foo-description')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].should.include('default: foo-description')
     })
 
-    it('serializes object and array defaults', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('serializes object and array defaults', () => {
+      const r = checkUsage(() => yargs(['-h'])
         .help('h')
         .default('a', [])
         .default('a2', [3])
         .default('o', {a: '33'})
         .wrap(null)
         .argv
-      })
+      )
 
       r.logs[0].should.include('default: []')
       r.logs[0].should.include('default: {"a":"33"}')
@@ -2005,11 +1911,10 @@ describe('usage tests', function () {
     })
   })
 
-  describe('defaultDescription', function () {
-    describe('using option() without default()', function () {
-      it('should output given desc with default value', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+  describe('defaultDescription', () => {
+    describe('using option() without default()', () => {
+      it('should output given desc with default value', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .option('port', {
               describe: 'The port value for URL',
@@ -2018,14 +1923,13 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
       })
 
-      it('should output given desc without default value', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+      it('should output given desc without default value', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .option('port', {
               describe: 'The port value for URL',
@@ -2033,14 +1937,13 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
       })
 
-      it('should prefer given desc over function desc', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+      it('should prefer given desc over function desc', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .option('port', {
               describe: 'The port value for URL',
@@ -2051,16 +1954,15 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
       })
     })
 
-    describe('using option() with default()', function () {
-      it('should prefer default() desc when given last', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+    describe('using option() with default()', () => {
+      it('should prefer default() desc when given last', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .option('port', {
               describe: 'The port value for URL',
@@ -2069,14 +1971,13 @@ describe('usage tests', function () {
             .default('port', null, '80 for HTTP and 443 for HTTPS')
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
       })
 
-      it('should prefer option() desc when given last', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+      it('should prefer option() desc when given last', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .default('port', null, '80 for HTTP and 443 for HTTPS')
             .option('port', {
@@ -2085,14 +1986,13 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: depends on protocol')
       })
 
-      it('should prefer option() desc over default() function', function () {
-        var r = checkUsage(function () {
-          return yargs(['-h'])
+      it('should prefer option() desc over default() function', () => {
+        const r = checkUsage(() => yargs(['-h'])
             .help('h')
             .option('port', {
               describe: 'The port value for URL',
@@ -2103,24 +2003,23 @@ describe('usage tests', function () {
             })
             .wrap(null)
             .argv
-        })
+          )
 
         r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
       })
     })
   })
 
-  describe('normalizeAliases', function () {
+  describe('normalizeAliases', () => {
     // see #128
-    it("should display 'description' string in help message if set for alias", function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it("should display 'description' string in help message if set for alias", () => {
+      const r = checkUsage(() => yargs(['-h'])
           .describe('foo', 'foo option')
           .alias('f', 'foo')
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -2131,15 +2030,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it("should display 'required' string in help message if set for alias", function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it("should display 'required' string in help message if set for alias", () => {
+      const r = checkUsage(() => yargs(['-h'])
           .demand('foo')
           .alias('f', 'foo')
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -2150,16 +2048,15 @@ describe('usage tests', function () {
       ])
     })
 
-    it("should display 'type' string in help message if set for alias", function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it("should display 'type' string in help message if set for alias", () => {
+      const r = checkUsage(() => yargs(['-h'])
           .string('foo')
           .describe('foo', 'bar')
           .alias('f', 'foo')
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -2170,9 +2067,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it("should display 'type' number in help message if set for alias", function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it("should display 'type' number in help message if set for alias", () => {
+      const r = checkUsage(() => yargs(['-h'])
           .string('foo')
           .describe('foo', 'bar')
           .alias('f', 'foo')
@@ -2180,7 +2076,7 @@ describe('usage tests', function () {
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -2192,11 +2088,11 @@ describe('usage tests', function () {
     })
   })
 
-  describe('showHelp', function (done) {
+  describe('showHelp', () => {
     // see #143.
-    it('should show help regardless of whether argv has been called', function () {
-      var r = checkUsage(function () {
-        var y = yargs(['--foo'])
+    it('should show help regardless of whether argv has been called', () => {
+      const r = checkUsage(() => {
+        const y = yargs(['--foo'])
           .options('foo', {
             alias: 'f',
             describe: 'foo option'
@@ -2215,9 +2111,9 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should call the correct console.log method', function () {
-      var r = checkUsage(function () {
-        var y = yargs(['--foo'])
+    it('should call the correct console.log method', () => {
+      const r = checkUsage(() => {
+        const y = yargs(['--foo'])
           .options('foo', {
             alias: 'f',
             describe: 'foo option'
@@ -2237,8 +2133,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should provide a help string to handler when provided', function (done) {
-      var y = yargs(['--foo'])
+    it('should provide a help string to handler when provided', (done) => {
+      const y = yargs(['--foo'])
         .options('foo', {
           alias: 'f',
           describe: 'foo option'
@@ -2259,9 +2155,9 @@ describe('usage tests', function () {
     })
   })
 
-  describe('$0', function () {
+  describe('$0', () => {
     function mockProcessArgv (argv, cb) {
-      var argvOld = process.argv
+      const argvOld = process.argv
       process.argv = argv
       // cb must be sync for now
       try {
@@ -2273,93 +2169,92 @@ describe('usage tests', function () {
       }
     }
 
-    it('is detected correctly for a basic script', function () {
-      mockProcessArgv(['script.js'], function () {
+    it('is detected correctly for a basic script', () => {
+      mockProcessArgv(['script.js'], () => {
         yargs([]).$0.should.equal('script.js')
       })
     })
 
-    it('is detected correctly when argv contains "node"', function () {
-      mockProcessArgv(['node', 'script.js'], function () {
+    it('is detected correctly when argv contains "node"', () => {
+      mockProcessArgv(['node', 'script.js'], () => {
         yargs([]).$0.should.equal('script.js')
       })
     })
 
-    it('is detected correctly when dirname contains "node"', function () {
-      mockProcessArgv(['/code/node/script.js'], function () {
+    it('is detected correctly when dirname contains "node"', () => {
+      mockProcessArgv(['/code/node/script.js'], () => {
         yargs([]).$0.should.equal('/code/node/script.js')
       })
     })
 
-    it('is detected correctly when dirname and argv contain "node"', function () {
-      mockProcessArgv(['node', '/code/node/script.js'], function () {
+    it('is detected correctly when dirname and argv contain "node"', () => {
+      mockProcessArgv(['node', '/code/node/script.js'], () => {
         yargs([]).$0.should.equal('/code/node/script.js')
       })
     })
 
-    it('is detected correctly when argv contains "iojs"', function () {
-      mockProcessArgv(['iojs', 'script.js'], function () {
+    it('is detected correctly when argv contains "iojs"', () => {
+      mockProcessArgv(['iojs', 'script.js'], () => {
         yargs([]).$0.should.equal('script.js')
       })
     })
 
-    it('is detected correctly when dirname contains "iojs"', function () {
-      mockProcessArgv(['/code/iojs/script.js'], function () {
+    it('is detected correctly when dirname contains "iojs"', () => {
+      mockProcessArgv(['/code/iojs/script.js'], () => {
         yargs([]).$0.should.equal('/code/iojs/script.js')
       })
     })
 
-    it('is detected correctly when dirname and argv contain "iojs"', function () {
-      mockProcessArgv(['iojs', '/code/iojs/script.js'], function () {
+    it('is detected correctly when dirname and argv contain "iojs"', () => {
+      mockProcessArgv(['iojs', '/code/iojs/script.js'], () => {
         yargs([]).$0.should.equal('/code/iojs/script.js')
       })
     })
 
-    it('is detected correctly when argv contains "node.exe"', function () {
-      mockProcessArgv(['node.exe', 'script.js'], function () {
+    it('is detected correctly when argv contains "node.exe"', () => {
+      mockProcessArgv(['node.exe', 'script.js'], () => {
         yargs([]).$0.should.equal('script.js')
       })
     })
 
-    it('is detected correctly when argv contains "iojs.exe"', function () {
-      mockProcessArgv(['iojs.exe', 'script.js'], function () {
+    it('is detected correctly when argv contains "iojs.exe"', () => {
+      mockProcessArgv(['iojs.exe', 'script.js'], () => {
         yargs([]).$0.should.equal('script.js')
       })
     })
 
     if (process.platform !== 'win32') {
-      it('is resolved to the relative path if it is shorter', function () {
-        mockProcessArgv(['node', '/code/node/script.js'], function () {
+      it('is resolved to the relative path if it is shorter', () => {
+        mockProcessArgv(['node', '/code/node/script.js'], () => {
           yargs([], '/code/python/').$0.should.equal('../node/script.js')
         })
       })
 
-      it('is not resolved to the relative path if it is larger', function () {
-        mockProcessArgv(['node', '/script.js'], function () {
+      it('is not resolved to the relative path if it is larger', () => {
+        mockProcessArgv(['node', '/script.js'], () => {
           yargs([], '/very/long/current/directory/').$0.should.equal('/script.js')
         })
       })
     }
 
     if (process.platform === 'win32') {
-      it('is resolved to the relative path if it is shorter, using Windows paths', function () {
-        mockProcessArgv(['node.exe', 'C:\\code\\node\\script.js'], function () {
+      it('is resolved to the relative path if it is shorter, using Windows paths', () => {
+        mockProcessArgv(['node.exe', 'C:\\code\\node\\script.js'], () => {
           yargs([], 'C:\\code\\python\\').$0.should.equal('..\\node\\script.js')
         })
       })
 
-      it('is not resolved to the relative path if it is larger, using Windows paths', function () {
-        mockProcessArgv(['node', 'C:\\script.js'], function () {
+      it('is not resolved to the relative path if it is larger, using Windows paths', () => {
+        mockProcessArgv(['node', 'C:\\script.js'], () => {
           yargs([], 'C:\\very\\long\\current\\directory\\').$0.should.equal('C:\\script.js')
         })
       })
     }
   })
 
-  describe('choices', function () {
-    it('should output choices when defined for non-hidden options', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+  describe('choices', () => {
+    it('should output choices when defined for non-hidden options', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .option('answer', {
             describe: 'does this look good?',
             choices: ['yes', 'no', 'maybe']
@@ -2370,7 +2265,7 @@ describe('usage tests', function () {
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
@@ -2382,9 +2277,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it('should not output choices when defined for hidden options', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('should not output choices when defined for hidden options', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .option('answer', {
             type: 'string',
             choices: ['yes', 'no', 'maybe']
@@ -2394,7 +2288,7 @@ describe('usage tests', function () {
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
@@ -2405,10 +2299,9 @@ describe('usage tests', function () {
     })
   })
 
-  describe('count', function () {
-    it('should indicate when an option is a count', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+  describe('count', () => {
+    it('should indicate when an option is a count', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .option('verbose', {
             describe: 'verbose level',
             count: true
@@ -2416,16 +2309,15 @@ describe('usage tests', function () {
           .help('help')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join(' ').should.match(/\[count]/)
     })
   })
 
-  describe('array', function () {
-    it('should indicate when an option is an array', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+  describe('array', () => {
+    it('should indicate when an option is an array', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .option('arr', {
             describe: 'array option',
             array: true
@@ -2433,16 +2325,15 @@ describe('usage tests', function () {
           .help('help')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs.join(' ').should.match(/\[array]/)
     })
   })
 
-  describe('group', function () {
-    it('allows an an option to be placed in an alternative group', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+  describe('group', () => {
+    it('allows an an option to be placed in an alternative group', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .option('batman', {
             type: 'string',
             describe: "not the world's happiest guy",
@@ -2451,7 +2342,7 @@ describe('usage tests', function () {
           .group('batman', 'Heroes:')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
@@ -2464,9 +2355,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it("does not print the 'Options:' group if no keys are in it", function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it("does not print the 'Options:' group if no keys are in it", () => {
+      const r = checkUsage(() => yargs(['-h'])
           .string('batman')
           .describe('batman', "not the world's happiest guy")
           .default('batman', 'Bruce Wayne')
@@ -2475,7 +2365,7 @@ describe('usage tests', function () {
           .help('h')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
@@ -2488,15 +2378,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('displays alias keys appropriately within a grouping', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('displays alias keys appropriately within a grouping', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .alias('h', 'help')
           .group('help', 'Magic Variable:')
           .group('version', 'Magic Variable:')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Magic Variable:',
@@ -2506,13 +2395,12 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows a group to be provided as the only information about an option', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('allows a group to be provided as the only information about an option', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .group('batman', 'Heroes:')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
@@ -2525,15 +2413,14 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows multiple options to be grouped at the same time', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('allows multiple options to be grouped at the same time', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .help('h')
           .group('h', 'Options:')
           .group(['batman', 'robin'], 'Heroes:')
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
@@ -2547,9 +2434,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it('allows group to be provided in the options object', function () {
-      var r = checkUsage(function () {
-        return yargs(['-h'])
+    it('allows group to be provided in the options object', () => {
+      const r = checkUsage(() => yargs(['-h'])
           .help('h')
           .option('batman', {
             group: 'Heroes:',
@@ -2557,7 +2443,7 @@ describe('usage tests', function () {
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
@@ -2570,9 +2456,8 @@ describe('usage tests', function () {
       ])
     })
 
-    it('only displays a duplicated option once per group', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('only displays a duplicated option once per group', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .group(['batman', 'batman'], 'Heroes:')
           .group('robin', 'Heroes:')
           .option('robin', {
@@ -2580,7 +2465,7 @@ describe('usage tests', function () {
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
@@ -2595,10 +2480,10 @@ describe('usage tests', function () {
     })
   })
 
-  describe('cjk', function () {
-    it('should calculate width of cjk text correctly', function () {
-      var r = checkUsage(function () {
-        var y = yargs()
+  describe('cjk', () => {
+    it('should calculate width of cjk text correctly', () => {
+      const r = checkUsage(() => {
+        const y = yargs()
           .example('안녕하세요 선생님 안녕 친구야', '인사하는 어린이 착한 어린이')
           .wrap(80)
 
@@ -2616,15 +2501,14 @@ describe('usage tests', function () {
     })
   })
 
-  describe('default command', function () {
-    it('--help should display top-level help with no command given', function () {
-      var r = checkUsage(function () {
-        return yargs('--help')
-          .command(['list [pattern]', 'ls', '*'], 'List key-value pairs for pattern', {}, function () {})
-          .command('get <key>', 'Get value for key', {}, function () {})
-          .command('set <key> [value]', 'Set value for key', {}, function () {})
+  describe('default command', () => {
+    it('--help should display top-level help with no command given', () => {
+      const r = checkUsage(() => yargs('--help')
+          .command(['list [pattern]', 'ls', '*'], 'List key-value pairs for pattern', {}, noop)
+          .command('get <key>', 'Get value for key', {}, noop)
+          .command('set <key> [value]', 'Set value for key', {}, noop)
           .argv
-      })
+        )
 
       r.logs[0].split('\n').should.deep.equal([
         'Commands:',

--- a/test/validation.js
+++ b/test/validation.js
@@ -1,74 +1,75 @@
+'use strict'
 /* global describe, it, beforeEach */
 
-var checkUsage = require('./helpers/utils').checkOutput
-var expect = require('chai').expect
-var yargs = require('../')
+const checkUsage = require('./helpers/utils').checkOutput
+const expect = require('chai').expect
+const yargs = require('../')
 
 require('chai').should()
 
-describe('validation tests', function () {
-  beforeEach(function () {
+describe('validation tests', () => {
+  beforeEach(() => {
     yargs.reset()
   })
 
-  describe('implies', function () {
-    it("fails if '_' populated, and implied argument not set", function (done) {
+  describe('implies', () => {
+    it("fails if '_' populated, and implied argument not set", (done) => {
       yargs(['cat'])
         .implies({
           1: 'foo' // 1 arg in _ means --foo is required
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.match(/Implications failed/)
           return done()
         })
         .argv
     })
 
-    it("fails if key implies values in '_', but '_' is not populated", function (done) {
+    it("fails if key implies values in '_', but '_' is not populated", (done) => {
       yargs(['--foo'])
         .boolean('foo')
         .implies({
           'foo': 1 // --foo means 1 arg in _ is required
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.match(/Implications failed/)
           return done()
         })
         .argv
     })
 
-    it("fails if --no-foo's implied argument is not set", function (done) {
+    it("fails if --no-foo's implied argument is not set", (done) => {
       yargs([])
         .implies({
           '--no-bar': 'foo' // when --bar is not given, --foo is required
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.match(/Implications failed/)
           return done()
         })
         .argv
     })
 
-    it('fails if a key is set, along with a key that it implies should not be set', function (done) {
+    it('fails if a key is set, along with a key that it implies should not be set', (done) => {
       yargs(['--bar', '--foo'])
         .implies({
           'bar': '--no-foo' // --bar means --foo cannot be given
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.match(/Implications failed/)
           return done()
         })
         .argv
     })
 
-    it('fails if implied key (with "no" in the name) is not set', function () {
-      var failCalled = false
+    it('fails if implied key (with "no" in the name) is not set', () => {
+      let failCalled = false
       yargs('--bar')
         .implies({
           'bar': 'noFoo' // --bar means --noFoo (or --no-foo with boolean-negation disabled) is required
                          // note that this has nothing to do with --foo
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           failCalled = true
           msg.should.match(/Implications failed/)
         })
@@ -76,14 +77,14 @@ describe('validation tests', function () {
       failCalled.should.be.true
     })
 
-    it('doesn\'t fail if implied key (with "no" in the name) is set', function () {
-      var failCalled = false
+    it('doesn\'t fail if implied key (with "no" in the name) is set', () => {
+      let failCalled = false
       const argv = yargs('--bar --noFoo')
         .implies({
           'bar': 'noFoo' // --bar means --noFoo (or --no-foo with boolean-negation disabled) is required
                          // note that this has nothing to do with --foo
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           failCalled = true
         })
         .argv
@@ -93,14 +94,14 @@ describe('validation tests', function () {
       expect(argv.foo).to.not.exist
     })
 
-    it('fails if implied key (with "no" in the name) is given when it should not', function () {
-      var failCalled = false
+    it('fails if implied key (with "no" in the name) is given when it should not', () => {
+      let failCalled = false
       yargs('--bar --noFoo')
         .implies({
           'bar': '--no-noFoo' // --bar means --noFoo (or --no-foo with boolean-negation disabled) cannot be given
                               // note that this has nothing to do with --foo
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           failCalled = true
           msg.should.match(/Implications failed/)
         })
@@ -108,14 +109,14 @@ describe('validation tests', function () {
       failCalled.should.be.true
     })
 
-    it('doesn\'t fail if implied key (with "no" in the name) that should not be given is not set', function () {
-      var failCalled = false
+    it('doesn\'t fail if implied key (with "no" in the name) that should not be given is not set', () => {
+      let failCalled = false
       const argv = yargs('--bar')
         .implies({
           'bar': '--no-noFoo' // --bar means --noFoo (or --no-foo with boolean-negation disabled) cannot be given
                               // note that this has nothing to do with --foo
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           failCalled = true
         })
         .argv
@@ -125,12 +126,12 @@ describe('validation tests', function () {
       expect(argv.foo).to.not.exist
     })
 
-    it('allows key to be specified with option shorthand', function (done) {
+    it('allows key to be specified with option shorthand', (done) => {
       yargs('--bar')
         .option('bar', {
           implies: 'foo'
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.match(/Implications failed/)
           return done()
         })
@@ -138,27 +139,27 @@ describe('validation tests', function () {
     })
   })
 
-  describe('conflicts', function () {
-    it('fails if both arguments are supplied', function (done) {
+  describe('conflicts', () => {
+    it('fails if both arguments are supplied', (done) => {
       yargs(['-f', '-b'])
           .conflicts('f', 'b')
-          .fail(function (msg) {
+          .fail((msg) => {
             msg.should.equal('Arguments f and b are mutually exclusive')
             return done()
           })
           .argv
     })
 
-    it('should not fail if no conflicting arguments are provided', function () {
+    it('should not fail if no conflicting arguments are provided', () => {
       yargs(['-b', '-c'])
         .conflicts('f', 'b')
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
     })
 
-    it('should not fail if argument with conflict is provided, but not the argument it conflicts with', function () {
+    it('should not fail if argument with conflict is provided, but not the argument it conflicts with', () => {
       yargs(['command', '-f', '-c'])
         .command('command')
         .option('f', {
@@ -168,13 +169,13 @@ describe('validation tests', function () {
           describe: 'a bar'
         })
         .conflicts('f', 'b')
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
     })
 
-    it('should not fail if conflicting argument is provided, without argument with conflict', function () {
+    it('should not fail if conflicting argument is provided, without argument with conflict', () => {
       yargs(['command', '-b', '-c'])
           .command('command')
           .option('f', {
@@ -184,67 +185,67 @@ describe('validation tests', function () {
             describe: 'a bar'
           })
           .conflicts('f', 'b')
-          .fail(function (msg) {
+          .fail((msg) => {
             expect.fail()
           })
           .argv
     })
 
-    it('allows an object to be provided defining conflicting option pairs', function (done) {
+    it('allows an object to be provided defining conflicting option pairs', (done) => {
       yargs(['-t', '-s'])
         .conflicts({
           'c': 'a',
           's': 't'
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Arguments s and t are mutually exclusive')
           return done()
         })
         .argv
     })
 
-    it('takes into account aliases when applying conflicts logic', function (done) {
+    it('takes into account aliases when applying conflicts logic', (done) => {
       yargs(['-t', '-c'])
         .conflicts({
           'c': 'a',
           's': 't'
         })
         .alias('c', 's')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Arguments s and t are mutually exclusive')
           return done()
         })
         .argv
     })
 
-    it('allows key to be specified with option shorthand', function (done) {
+    it('allows key to be specified with option shorthand', (done) => {
       yargs(['-f', '-b'])
           .option('f', {
             conflicts: 'b'
           })
-          .fail(function (msg) {
+          .fail((msg) => {
             msg.should.equal('Arguments f and b are mutually exclusive')
             return done()
           })
           .argv
     })
 
-    it('should fail if alias of conflicting argument is provided', function (done) {
+    it('should fail if alias of conflicting argument is provided', (done) => {
       yargs(['-f', '--batman=99'])
         .conflicts('f', 'b')
         .alias('b', 'batman')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Arguments f and b are mutually exclusive')
           return done()
         })
         .argv
     })
 
-    it('should fail if alias of argument with conflict is provided', function (done) {
+    it('should fail if alias of argument with conflict is provided', (done) => {
       yargs(['--foo', '-b'])
         .conflicts('f', 'b')
         .alias('foo', 'f')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Arguments f and b are mutually exclusive')
           return done()
         })
@@ -252,35 +253,35 @@ describe('validation tests', function () {
     })
   })
 
-  describe('demand', function () {
-    it('fails with standard error message if msg is not defined', function (done) {
+  describe('demand', () => {
+    it('fails with standard error message if msg is not defined', (done) => {
       yargs([])
         .demand(1)
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
           return done()
         })
         .argv
     })
 
-    it('fails in strict mode with invalid command', function (done) {
+    it('fails in strict mode with invalid command', (done) => {
       yargs(['koala'])
         .command('wombat', 'wombat burrows')
         .command('kangaroo', 'kangaroo handlers')
         .demand(1)
         .strict()
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Unknown argument: koala')
           return done()
         })
         .argv
     })
 
-    it('does not fail in strict mode when no commands configured', function () {
-      var argv = yargs('koala')
+    it('does not fail in strict mode when no commands configured', () => {
+      const argv = yargs('koala')
         .demand(1)
         .strict()
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
@@ -288,11 +289,11 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/791
-    it('should recognize context variables in strict mode', function (done) {
+    it('should recognize context variables in strict mode', (done) => {
       yargs()
         .command('foo <y>')
         .strict()
-        .parse('foo 99', {x: 33}, function (err, argv, output) {
+        .parse('foo 99', {x: 33}, (err, argv, output) => {
           expect(err).to.equal(null)
           expect(output).to.equal('')
           argv.y.should.equal(99)
@@ -303,9 +304,9 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/791
-    it('should recognize context variables in strict mode, when running sub-commands', function (done) {
+    it('should recognize context variables in strict mode, when running sub-commands', (done) => {
       yargs()
-        .command('request', 'request command', function (yargs) {
+        .command('request', 'request command', (yargs) => {
           yargs
             .command('get', 'sub-command')
             .option('y', {
@@ -313,7 +314,7 @@ describe('validation tests', function () {
             })
         })
         .strict()
-        .parse('request get --y=22', {x: 33}, function (err, argv, output) {
+        .parse('request get --y=22', {x: 33}, (err, argv, output) => {
           expect(err).to.equal(null)
           expect(output).to.equal('')
           argv.y.should.equal(22)
@@ -324,30 +325,30 @@ describe('validation tests', function () {
         })
     })
 
-    it('fails when a required argument is missing', function (done) {
+    it('fails when a required argument is missing', (done) => {
       yargs('-w 10 marsupial')
         .demand(1, ['w', 'b'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Missing required argument: b')
           return done()
         })
         .argv
     })
 
-    it('fails when required arguments are present, but a command is missing', function (done) {
+    it('fails when required arguments are present, but a command is missing', (done) => {
       yargs('-w 10 -m wombat')
         .demand(1, ['w', 'm'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
           return done()
         })
         .argv
     })
 
-    it('fails without a message if msg is null', function (done) {
+    it('fails without a message if msg is null', (done) => {
       yargs([])
         .demand(1, null)
-        .fail(function (msg) {
+        .fail((msg) => {
           expect(msg).to.equal(null)
           return done()
         })
@@ -355,21 +356,21 @@ describe('validation tests', function () {
     })
 
     // address regression in: https://github.com/yargs/yargs/pull/740
-    it('custom failure message should be printed for both min and max constraints', function (done) {
+    it('custom failure message should be printed for both min and max constraints', (done) => {
       yargs(['foo'])
         .demand(0, 0, 'hey! give me a custom exit message')
-        .fail(function (msg) {
+        .fail((msg) => {
           expect(msg).to.equal('hey! give me a custom exit message')
           return done()
         })
         .argv
     })
 
-    it('interprets min relative to command', function () {
-      var failureMsg
+    it('interprets min relative to command', () => {
+      let failureMsg
       yargs('lint')
-        .command('lint', 'Lint a file', function (yargs) {
-          yargs.demand(1).fail(function (msg) {
+        .command('lint', 'Lint a file', (yargs) => {
+          yargs.demand(1).fail((msg) => {
             failureMsg = msg
           })
         })
@@ -377,11 +378,11 @@ describe('validation tests', function () {
       expect(failureMsg).to.equal('Not enough non-option arguments: got 0, need at least 1')
     })
 
-    it('interprets max relative to command', function () {
-      var failureMsg
+    it('interprets max relative to command', () => {
+      let failureMsg
       yargs('lint one.js two.js')
-        .command('lint', 'Lint a file', function (yargs) {
-          yargs.demand(0, 1).fail(function (msg) {
+        .command('lint', 'Lint a file', (yargs) => {
+          yargs.demand(0, 1).fail((msg) => {
             failureMsg = msg
           })
         })
@@ -390,11 +391,11 @@ describe('validation tests', function () {
     })
   })
 
-  describe('choices', function () {
-    it('fails with one invalid value', function (done) {
+  describe('choices', () => {
+    it('fails with one invalid value', (done) => {
       yargs(['--state', 'denial'])
         .choices('state', ['happy', 'sad', 'hungry'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.split('\n').should.deep.equal([
             'Invalid values:',
             '  Argument: state, Given: "denial", Choices: "happy", "sad", "hungry"'
@@ -404,10 +405,10 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with one valid and one invalid value', function (done) {
+    it('fails with one valid and one invalid value', (done) => {
       yargs(['--characters', 'susie', '--characters', 'linus'])
         .choices('characters', ['calvin', 'hobbes', 'susie', 'moe'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.split('\n').should.deep.equal([
             'Invalid values:',
             '  Argument: characters, Given: "linus", Choices: "calvin", "hobbes", "susie", "moe"'
@@ -417,10 +418,10 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with multiple invalid values for same argument', function (done) {
+    it('fails with multiple invalid values for same argument', (done) => {
       yargs(['--category', 'comedy', '--category', 'drama'])
         .choices('category', ['animal', 'vegetable', 'mineral'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.split('\n').should.deep.equal([
             'Invalid values:',
             '  Argument: category, Given: "comedy", "drama", Choices: "animal", "vegetable", "mineral"'
@@ -430,10 +431,10 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with case-insensitive value', function (done) {
+    it('fails with case-insensitive value', (done) => {
       yargs(['--env', 'DEV'])
         .choices('env', ['dev', 'prd'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.split('\n').should.deep.equal([
             'Invalid values:',
             '  Argument: env, Given: "DEV", Choices: "dev", "prd"'
@@ -443,11 +444,11 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with multiple invalid arguments', function (done) {
+    it('fails with multiple invalid arguments', (done) => {
       yargs(['--system', 'osx', '--arch', '64'])
         .choices('system', ['linux', 'mac', 'windows'])
         .choices('arch', ['x86', 'x64', 'arm'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.split('\n').should.deep.equal([
             'Invalid values:',
             '  Argument: system, Given: "osx", Choices: "linux", "mac", "windows"',
@@ -459,9 +460,9 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('succeeds when demandOption is true and valid choice is provided', function (done) {
+    it('succeeds when demandOption is true and valid choice is provided', (done) => {
       yargs('one -a 10 marsupial')
-        .command('one', 'level one', function (yargs) {
+        .command('one', 'level one', (yargs) => {
           yargs
             .options({
               'a': {
@@ -469,21 +470,21 @@ describe('validation tests', function () {
                 choices: [10, 20]
               }
             })
-        }, function (argv) {
+        }, (argv) => {
           argv._[0].should.equal('one')
           argv.a.should.equal(10)
           return done()
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('fails when demandOption is true and choice is not provided', function (done) {
+    it('fails when demandOption is true and choice is not provided', (done) => {
       yargs('one -a 10 marsupial')
-        .command('one', 'level one', function (yargs) {
+        .command('one', 'level one', (yargs) => {
           yargs
             .options({
               'c': {
@@ -491,10 +492,10 @@ describe('validation tests', function () {
               }
             })
             .demandOption('c')
-        }, function (argv) {
+        }, (argv) => {
           expect.fail()
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Missing required argument: c')
           return done()
         })
@@ -502,9 +503,9 @@ describe('validation tests', function () {
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('succeeds when demandOption is false and no choice is provided', function () {
+    it('succeeds when demandOption is false and no choice is provided', () => {
       yargs('one')
-        .command('one', 'level one', function (yargs) {
+        .command('one', 'level one', (yargs) => {
           yargs
             .options({
               'a': {
@@ -512,41 +513,41 @@ describe('validation tests', function () {
                 choices: [10, 20]
               }
             })
-        }, function (argv) {
+        }, (argv) => {
           argv._[0].should.equal('one')
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
     })
 
     // addresses: https://github.com/yargs/yargs/issues/849
-    it('succeeds when demandOption is not provided and no choice is provided', function () {
+    it('succeeds when demandOption is not provided and no choice is provided', () => {
       yargs('one')
-        .command('one', 'level one', function (yargs) {
+        .command('one', 'level one', (yargs) => {
           yargs
             .options({
               'a': {
                 choices: [10, 20]
               }
             })
-        }, function (argv) {
+        }, (argv) => {
           argv._[0].should.equal('one')
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           expect.fail()
         })
         .argv
     })
   })
 
-  describe('config', function () {
-    it('should raise an appropriate error if JSON file is not found', function (done) {
+  describe('config', () => {
+    it('should raise an appropriate error if JSON file is not found', (done) => {
       yargs(['--settings', 'fake.json', '--foo', 'bar'])
         .alias('z', 'zoom')
         .config('settings')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.eql('Invalid JSON config file: fake.json')
           return done()
         })
@@ -554,14 +555,14 @@ describe('validation tests', function () {
     })
 
     // see: https://github.com/yargs/yargs/issues/172
-    it('should not raise an exception if config file is set as default argument value', function () {
-      var fail = false
+    it('should not raise an exception if config file is set as default argument value', () => {
+      let fail = false
       yargs([])
         .option('config', {
           default: 'foo.json'
         })
         .config('config')
-        .fail(function () {
+        .fail(() => {
           fail = true
         })
         .argv
@@ -569,15 +570,14 @@ describe('validation tests', function () {
       fail.should.equal(false)
     })
 
-    it('should be displayed in the help message', function () {
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('should be displayed in the help message', () => {
+      const r = checkUsage(() => yargs(['--help'])
           .config('settings')
           .help('help')
           .version(false)
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('logs').with.length(1)
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -587,16 +587,15 @@ describe('validation tests', function () {
       ])
     })
 
-    it('should be displayed in the help message with its default name', function () {
-      var checkUsage = require('./helpers/utils').checkOutput
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('should be displayed in the help message with its default name', () => {
+      const checkUsage = require('./helpers/utils').checkOutput
+      const r = checkUsage(() => yargs(['--help'])
             .config()
             .help('help')
             .version(false)
             .wrap(null)
             .argv
-      })
+          )
       r.should.have.property('logs').with.length(1)
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -606,16 +605,15 @@ describe('validation tests', function () {
       ])
     })
 
-    it('should allow help message to be overridden', function () {
-      var checkUsage = require('./helpers/utils').checkOutput
-      var r = checkUsage(function () {
-        return yargs(['--help'])
+    it('should allow help message to be overridden', () => {
+      const checkUsage = require('./helpers/utils').checkOutput
+      const r = checkUsage(() => yargs(['--help'])
           .config('settings', 'pork chop sandwiches')
           .help('help')
           .version(false)
           .wrap(null)
           .argv
-      })
+        )
       r.should.have.property('logs').with.length(1)
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -625,17 +623,14 @@ describe('validation tests', function () {
       ])
     })
 
-    it('outputs an error returned by the parsing function', function () {
-      var checkUsage = require('./helpers/utils').checkOutput
-      var r = checkUsage(function () {
-        return yargs(['--settings=./package.json'])
-          .config('settings', 'path to config file', function (configPath) {
-            return Error('someone set us up the bomb')
-          })
+    it('outputs an error returned by the parsing function', () => {
+      const checkUsage = require('./helpers/utils').checkOutput
+      const r = checkUsage(() => yargs(['--settings=./package.json'])
+          .config('settings', 'path to config file', configPath => Error('someone set us up the bomb'))
           .help('help')
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -646,16 +641,15 @@ describe('validation tests', function () {
       ])
     })
 
-    it('outputs an error if thrown by the parsing function', function () {
-      var checkUsage = require('./helpers/utils').checkOutput
-      var r = checkUsage(function () {
-        return yargs(['--settings=./package.json'])
-          .config('settings', 'path to config file', function (configPath) {
+    it('outputs an error if thrown by the parsing function', () => {
+      const checkUsage = require('./helpers/utils').checkOutput
+      const r = checkUsage(() => yargs(['--settings=./package.json'])
+          .config('settings', 'path to config file', (configPath) => {
             throw Error('someone set us up the bomb')
           })
           .wrap(null)
           .argv
-      })
+        )
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
@@ -667,11 +661,11 @@ describe('validation tests', function () {
     })
   })
 
-  describe('defaults', function () {
+  describe('defaults', () => {
     // See https://github.com/chevex/yargs/issues/31
-    it('should not fail when demanded options with defaults are missing', function () {
+    it('should not fail when demanded options with defaults are missing', () => {
       yargs()
-        .fail(function (msg) {
+        .fail((msg) => {
           throw new Error(msg)
         })
         .option('some-option', {
@@ -684,41 +678,39 @@ describe('validation tests', function () {
     })
   })
 
-  describe('strict mode', function () {
-    it('does not fail when command with subcommands called', function () {
+  describe('strict mode', () => {
+    it('does not fail when command with subcommands called', () => {
       yargs('one')
-        .command('one', 'level one', function (yargs) {
-          return yargs
+        .command('one', 'level one', yargs => yargs
             .command('twoA', 'level two A')
             .command('twoB', 'level two B')
             .strict()
-            .fail(function (msg) {
+            .fail((msg) => {
               expect.fail()
+            }), (argv) => {
+              argv._[0].should.equal('one')
             })
-        }, function (argv) {
-          argv._[0].should.equal('one')
-        })
         .argv
     })
   })
 
-  describe('demandOption', function () {
-    it('allows an array of options to be demanded', function (done) {
+  describe('demandOption', () => {
+    it('allows an array of options to be demanded', (done) => {
       yargs('-a 10 marsupial')
         .demandOption(['a', 'b'])
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Missing required argument: b')
           return done()
         })
         .argv
     })
 
-    it('allows demandOption in option shorthand', function (done) {
+    it('allows demandOption in option shorthand', (done) => {
       yargs('-a 10 marsupial')
         .option('c', {
           demandOption: true
         })
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Missing required argument: c')
           return done()
         })
@@ -726,17 +718,16 @@ describe('validation tests', function () {
     })
   })
 
-  describe('demandCommand', function () {
-    it('should return a custom failure message when too many non-hyphenated arguments are found after a demand count', function () {
-      var r = checkUsage(function () {
-        return yargs(['src', 'dest'])
+  describe('demandCommand', () => {
+    it('should return a custom failure message when too many non-hyphenated arguments are found after a demand count', () => {
+      const r = checkUsage(() => yargs(['src', 'dest'])
           .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
           .demandCommand(0, 1, 'src and dest files are both required', 'too many arguments are provided')
           .wrap(null)
           .help(false)
           .version(false)
           .argv
-      })
+        )
       r.should.have.property('result')
       r.should.have.property('logs').with.length(0)
       r.should.have.property('exit').and.be.ok
@@ -748,10 +739,10 @@ describe('validation tests', function () {
     })
 
     // see: https://github.com/yargs/yargs/pull/438
-    it('allows a custom min message to be provided', function (done) {
+    it('allows a custom min message to be provided', (done) => {
       yargs('-a 10 marsupial')
         .demandCommand(2, 'totes got $0 totes expected $1')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('totes got 1 totes expected 2')
           return done()
         })
@@ -759,20 +750,20 @@ describe('validation tests', function () {
     })
 
     // see: https://github.com/yargs/yargs/pull/438
-    it('allows a custom min and max message to be provided', function (done) {
+    it('allows a custom min and max message to be provided', (done) => {
       yargs('-a 10 marsupial mammal bro')
         .demandCommand(1, 2, 'totes too few, got $0 totes expected $1', 'totes too many, got $0 totes expected $1')
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('totes too many, got 3 totes expected 2')
           return done()
         })
         .argv
     })
 
-    it('defaults to demanding 1 command', function (done) {
+    it('defaults to demanding 1 command', (done) => {
       yargs('-a 10')
         .demandCommand()
-        .fail(function (msg) {
+        .fail((msg) => {
           msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
           return done()
         })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1,33 +1,36 @@
+'use strict'
 /* global context, describe, it, beforeEach, afterEach */
 
-var expect = require('chai').expect
-var fs = require('fs')
-var path = require('path')
-var checkOutput = require('./helpers/utils').checkOutput
-var yargs
-var YError = require('../lib/yerror')
+const expect = require('chai').expect
+const fs = require('fs')
+const path = require('path')
+const checkOutput = require('./helpers/utils').checkOutput
+let yargs
+const YError = require('../lib/yerror')
 
 require('chai').should()
 
-describe('yargs dsl tests', function () {
-  beforeEach(function () {
+const noop = () => {}
+
+describe('yargs dsl tests', () => {
+  beforeEach(() => {
     yargs = require('../')
   })
 
-  afterEach(function () {
+  afterEach(() => {
     delete require.cache[require.resolve('../')]
   })
 
-  it('should use bin name for $0, eliminating path', function () {
+  it('should use bin name for $0, eliminating path', () => {
     process.argv[1] = '/usr/local/bin/ndm'
     process.env._ = '/usr/local/bin/ndm'
     process.execPath = '/usr/local/bin/ndm'
-    var argv = yargs([]).argv
+    const argv = yargs([]).argv
     argv['$0'].should.eql('ndm')
   })
 
-  it('accepts an object for aliases', function () {
-    var argv = yargs([])
+  it('accepts an object for aliases', () => {
+    const argv = yargs([])
     .alias({
       cool: 'cat'
     })
@@ -37,44 +40,42 @@ describe('yargs dsl tests', function () {
     argv.cat.should.eql(33)
   })
 
-  it('populates argv with placeholder keys for all options', function () {
-    var argv = yargs([])
+  it('populates argv with placeholder keys for all options', () => {
+    const argv = yargs([])
       .option('cool', {})
       .argv
 
     Object.keys(argv).should.include('cool')
   })
 
-  it('accepts an object for implies', function () {
-    var r = checkOutput(function () {
-      return yargs(['--x=33'])
+  it('accepts an object for implies', () => {
+    const r = checkOutput(() => yargs(['--x=33'])
         .implies({
           x: 'y'
         })
         .argv
-    })
+      )
 
     r.errors[1].should.match(/Implications failed/)
   })
 
-  it('accepts an object for describes', function () {
-    var r = checkOutput(function () {
-      return yargs([])
+  it('accepts an object for describes', () => {
+    const r = checkOutput(() => yargs([])
         .describe({
           x: 'really cool key'
         })
         .demand('x')
         .wrap(null)
         .argv
-    })
+      )
 
     r.errors[0].should.match(/really cool key/)
     r.result.should.have.property('x')
     r.result.should.not.have.property('[object Object]')
   })
 
-  it('treats usage as alias for options, if object provided as first argument', function () {
-    var argv = yargs([])
+  it('treats usage as alias for options, if object provided as first argument', () => {
+    const argv = yargs([])
       .usage({
         a: {
           default: 99
@@ -85,20 +86,20 @@ describe('yargs dsl tests', function () {
     argv.a.should.eql(99)
   })
 
-  it('a function can be provided, to execute when a parsing failure occurs', function (done) {
+  it('a function can be provided, to execute when a parsing failure occurs', (done) => {
     yargs(['--x=33'])
       .implies({
         x: 'y'
       })
-      .fail(function (msg) {
+      .fail((msg) => {
         msg.should.match(/Implications failed/)
         return done()
       })
       .argv
   })
 
-  it('should set alias to string if option is string', function () {
-    var argv = yargs(['--cat=99'])
+  it('should set alias to string if option is string', () => {
+    const argv = yargs(['--cat=99'])
       .options('c', {
         alias: 'cat',
         string: true
@@ -109,8 +110,8 @@ describe('yargs dsl tests', function () {
     argv.c.should.eql('99')
   })
 
-  it('should allow a valid choice', function () {
-    var argv = yargs(['--looks=good'])
+  it('should allow a valid choice', () => {
+    const argv = yargs(['--looks=good'])
       .option('looks', {
         choices: ['good', 'bad']
       })
@@ -119,8 +120,8 @@ describe('yargs dsl tests', function () {
     argv.looks.should.eql('good')
   })
 
-  it('should allow defaultDescription to be set with .option()', function () {
-    var optDefaultDescriptions = yargs([])
+  it('should allow defaultDescription to be set with .option()', () => {
+    const optDefaultDescriptions = yargs([])
       .option('port', {
         defaultDescription: '80 for HTTP and 443 for HTTPS'
       })
@@ -131,45 +132,42 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  it('should not require config object for an option', function () {
-    var r = checkOutput(function () {
-      return yargs([])
+  it('should not require config object for an option', () => {
+    const r = checkOutput(() => yargs([])
         .option('x')
         .argv
-    })
+      )
 
     expect(r.errors).to.deep.equal([])
   })
 
-  describe('showHelpOnFail', function () {
-    it('should display custom failure message, if string is provided as first argument', function () {
-      var r = checkOutput(function () {
-        return yargs([])
+  describe('showHelpOnFail', () => {
+    it('should display custom failure message, if string is provided as first argument', () => {
+      const r = checkOutput(() => yargs([])
           .showHelpOnFail('pork chop sandwiches')
           .demand('cat')
           .argv
-      })
+        )
 
       r.errors[3].should.match(/pork chop sandwiches/)
     })
 
-    it('calling with no arguments should default to displaying help', function () {
-      var r = checkOutput(function () {
-        return yargs([])
+    it('calling with no arguments should default to displaying help', () => {
+      const r = checkOutput(() => yargs([])
           .showHelpOnFail()
           .demand('cat')
           .argv
-      })
+        )
 
       r.errors[1].should.match(/required argument/)
     })
   })
 
-  describe('exitProcess', function () {
-    describe('when exitProcess is set to false and a failure occurs', function () {
-      it('should throw an exception', function () {
-        checkOutput(function () {
-          expect(function () {
+  describe('exitProcess', () => {
+    describe('when exitProcess is set to false and a failure occurs', () => {
+      it('should throw an exception', () => {
+        checkOutput(() => {
+          expect(() => {
             yargs([])
               .demand('cat')
               .showHelpOnFail(false)
@@ -178,8 +176,8 @@ describe('yargs dsl tests', function () {
           }).to.throw(/Missing required argument/)
         })
       })
-      it('should output the errors to stderr once', function () {
-        var r = checkOutput(function () {
+      it('should output the errors to stderr once', () => {
+        const r = checkOutput(() => {
           try {
             yargs([])
               .demand('cat')
@@ -194,24 +192,23 @@ describe('yargs dsl tests', function () {
         expect(r.errors).to.deep.equal(['Missing required argument: cat'])
       })
     })
-    it('should set exit process to true, if no argument provided', function () {
-      var r = checkOutput(function () {
-        return yargs([])
+    it('should set exit process to true, if no argument provided', () => {
+      const r = checkOutput(() => yargs([])
           .demand('cat')
           .exitProcess()
           .argv
-      })
+        )
 
       r.exit.should.eql(true)
     })
   })
 
-  describe('reset', function () {
-    it('should put yargs back into its initial state', function () {
+  describe('reset', () => {
+    it('should put yargs back into its initial state', () => {
       // create a command line with all the things.
       // so that we can confirm they're reset.
-      var y = yargs(['--help'])
-        .command('foo', 'bar', function () {})
+      const y = yargs(['--help'])
+        .command('foo', 'bar', noop)
         .default('foo', 'bar')
         .describe('foo', 'foo variable')
         .demandCommand(1)
@@ -220,7 +217,7 @@ describe('yargs dsl tests', function () {
         .alias('foo', 'bar')
         .string('foo')
         .choices('foo', ['bar', 'baz'])
-        .coerce('foo', function (foo) { return foo + 'bar' })
+        .coerce('foo', foo => `${foo}bar`)
         .implies('foo', 'snuh')
         .conflicts('qux', 'xyzzy')
         .group('foo', 'Group:')
@@ -230,7 +227,7 @@ describe('yargs dsl tests', function () {
         .env('YARGS')
         .reset()
 
-      var emptyOptions = {
+      const emptyOptions = {
         array: [],
         boolean: ['help', 'version'],
         string: [],
@@ -272,30 +269,30 @@ describe('yargs dsl tests', function () {
       expect(y.getGroups()).to.deep.equal({})
     })
 
-    it('does not invoke parse with an error if reset has been called and option is not global', function (done) {
-      var y = yargs()
+    it('does not invoke parse with an error if reset has been called and option is not global', (done) => {
+      const y = yargs()
         .demand('cake')
         .global('cake', false)
 
-      y.parse('hello', function (err) {
+      y.parse('hello', (err) => {
         err.message.should.match(/Missing required argument/)
       })
       y.reset()
-      y.parse('cake', function (err) {
+      y.parse('cake', (err) => {
         expect(err).to.equal(null)
         return done()
       })
     })
   })
 
-  describe('command', function () {
-    it('executes command handler with parsed argv', function (done) {
+  describe('command', () => {
+    it('executes command handler with parsed argv', (done) => {
       yargs(['blerg'])
         .command(
           'blerg',
           'handle blerg things',
-          function () {},
-          function (argv) {
+          noop,
+          (argv) => {
             // we should get the argv from the prior yargs.
             argv._[0].should.equal('blerg')
             return done()
@@ -305,8 +302,8 @@ describe('yargs dsl tests', function () {
         .argv
     })
 
-    it('recommends a similar command if no command handler is found', function () {
-      var r = checkOutput(function () {
+    it('recommends a similar command if no command handler is found', () => {
+      const r = checkOutput(() => {
         yargs(['boat'])
           .command('goat')
           .recommendCommands()
@@ -316,8 +313,8 @@ describe('yargs dsl tests', function () {
       r.errors[1].should.match(/Did you mean goat/)
     })
 
-    it('does not recommend a similiar command if no similar command exists', function () {
-      var r = checkOutput(function () {
+    it('does not recommend a similiar command if no similar command exists', () => {
+      const r = checkOutput(() => {
         yargs(['foo'])
           .command('nothingSimilar')
           .recommendCommands()
@@ -327,8 +324,8 @@ describe('yargs dsl tests', function () {
       r.logs.should.be.empty
     })
 
-    it('recommends the longest match first', function () {
-      var r = checkOutput(function () {
+    it('recommends the longest match first', () => {
+      const r = checkOutput(() => {
         yargs(['boat'])
           .command('bot')
           .command('goat')
@@ -340,32 +337,30 @@ describe('yargs dsl tests', function () {
     })
 
     // see: https://github.com/yargs/yargs/issues/822
-    it('does not print command recommendation if help message will be shown', function (done) {
+    it('does not print command recommendation if help message will be shown', (done) => {
       const parser = yargs()
         .command('goat')
         .help()
         .recommendCommands()
 
-      parser.parse('boat help', {}, function (err, _argv, output) {
+      parser.parse('boat help', {}, (err, _argv, output) => {
         if (err) return done(err)
         output.split('Commands:').length.should.equal(2)
         return done()
       })
     })
 
-    it("skips executing top-level command if builder's help is executed", function () {
-      var r = checkOutput(function () {
+    it("skips executing top-level command if builder's help is executed", () => {
+      const r = checkOutput(() => {
         yargs(['blerg', '-h'])
           .command(
             'blerg',
             'handle blerg things',
-            function (yargs) {
-              return yargs
+            yargs => yargs
                 .command('snuh', 'snuh command')
                 .help('h')
-                .wrap(null)
-            },
-            function () {
+                .wrap(null),
+            () => {
               throw Error('should not happen')
             }
           )
@@ -386,15 +381,14 @@ describe('yargs dsl tests', function () {
       ])
     })
 
-    it('executes top-level help if no handled command is provided', function () {
-      var r = checkOutput(function () {
+    it('executes top-level help if no handled command is provided', () => {
+      const r = checkOutput(() => {
         yargs(['snuh', '-h'])
-          .command('blerg', 'handle blerg things', function (yargs) {
-            return yargs
+          .command('blerg', 'handle blerg things', yargs => yargs
               .command('snuh', 'snuh command')
               .help('h')
               .argv
-          })
+            )
           .help('h')
           .wrap(null)
           .argv
@@ -411,8 +405,8 @@ describe('yargs dsl tests', function () {
       ])
     })
 
-    it("accepts an object for describing a command's options", function () {
-      var r = checkOutput(function () {
+    it("accepts an object for describing a command's options", () => {
+      const r = checkOutput(() => {
         yargs(['blerg', '-h'])
           .command('blerg <foo>', 'handle blerg things', {
             foo: {
@@ -427,14 +421,14 @@ describe('yargs dsl tests', function () {
           .argv
       })
 
-      var usageString = r.logs[0]
+      const usageString = r.logs[0]
       usageString.should.match(/usage blerg <foo>/)
       usageString.should.match(/--foo.*default: 99/)
       usageString.should.match(/--bar.*default: "hello world"/)
     })
 
-    it("accepts a module with a 'builder' and 'handler' key", function () {
-      var argv = yargs(['blerg', 'bar'])
+    it("accepts a module with a 'builder' and 'handler' key", () => {
+      const argv = yargs(['blerg', 'bar'])
         .command('blerg <foo>', 'handle blerg things', require('./fixtures/command'))
         .argv
 
@@ -448,8 +442,8 @@ describe('yargs dsl tests', function () {
       delete global.commandHandlerCalledWith
     })
 
-    it("accepts a module with a keys 'command', 'describe', 'builder', and 'handler'", function () {
-      var argv = yargs(['blerg', 'bar'])
+    it("accepts a module with a keys 'command', 'describe', 'builder', and 'handler'", () => {
+      const argv = yargs(['blerg', 'bar'])
         .command(require('./fixtures/command-module'))
         .argv
 
@@ -463,8 +457,8 @@ describe('yargs dsl tests', function () {
       delete global.commandHandlerCalledWith
     })
 
-    it('derives \'command\' string from filename when missing', function () {
-      var argv = yargs('nameless --foo bar')
+    it('derives \'command\' string from filename when missing', () => {
+      const argv = yargs('nameless --foo bar')
         .command(require('./fixtures/cmddir_noname/nameless'))
         .argv
 
@@ -478,18 +472,18 @@ describe('yargs dsl tests', function () {
       delete global.commandHandlerCalledWith
     })
 
-    it('throws error for non-module command object missing \'command\' string', function () {
-      expect(function () {
+    it('throws error for non-module command object missing \'command\' string', () => {
+      expect(() => {
         yargs.command({
           desc: 'A command with no name',
-          builder: function (yargs) { return yargs },
-          handler: function (argv) {}
+          builder (yargs) { return yargs },
+          handler (argv) {}
         })
       }).to.throw(/No command name given for module: { desc: 'A command with no name',\n {2}builder: \[Function(: builder)?],\n {2}handler: \[Function(: handler)?] }/)
     })
   })
 
-  describe('terminalWidth', function () {
+  describe('terminalWidth', () => {
     it('returns the maximum width of the terminal', function () {
       if (!process.stdout.isTTY) {
         return this.skip()
@@ -499,17 +493,17 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('number', function () {
-    it('accepts number arguments when a number type is specified', function () {
-      var argv = yargs('-w banana')
+  describe('number', () => {
+    it('accepts number arguments when a number type is specified', () => {
+      const argv = yargs('-w banana')
         .number('w')
         .argv
 
       expect(typeof argv.w).to.equal('number')
     })
 
-    it('should expose an options short-hand for numbers', function () {
-      var argv = yargs('-w banana')
+    it('should expose an options short-hand for numbers', () => {
+      const argv = yargs('-w banana')
         .option('w', {
           number: true
         })
@@ -521,9 +515,9 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('choices', function () {
-    it('accepts an object', function () {
-      var optChoices = yargs([])
+  describe('choices', () => {
+    it('accepts an object', () => {
+      const optChoices = yargs([])
         .choices({
           color: ['red', 'green', 'blue'],
           stars: [1, 2, 3, 4, 5]
@@ -540,8 +534,8 @@ describe('yargs dsl tests', function () {
       })
     })
 
-    it('accepts a string and array', function () {
-      var optChoices = yargs([])
+    it('accepts a string and array', () => {
+      const optChoices = yargs([])
         .choices('meat', ['beef', 'chicken', 'pork', 'bison'])
         .choices('temp', ['rare', 'med-rare', 'med', 'med-well', 'well'])
         .getOptions().choices
@@ -552,8 +546,8 @@ describe('yargs dsl tests', function () {
       })
     })
 
-    it('accepts a string and single value', function () {
-      var optChoices = yargs([])
+    it('accepts a string and single value', () => {
+      const optChoices = yargs([])
         .choices('gender', 'male')
         .choices('gender', 'female')
         .getOptions().choices
@@ -564,24 +558,24 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('locale', function () {
-    it('uses english as a default locale', function () {
-      ['LANGUAGE', 'LC_ALL', 'LANG', 'LC_MESSAGES'].forEach(function (e) {
+  describe('locale', () => {
+    it('uses english as a default locale', () => {
+      ['LANGUAGE', 'LC_ALL', 'LANG', 'LC_MESSAGES'].forEach((e) => {
         delete process.env[e]
       })
       yargs.locale().should.equal('en_US')
     })
 
-    it("detects the operating system's locale", function () {
+    it("detects the operating system's locale", () => {
       loadLocale('es_ES.UTF-8')
       yargs.locale().should.equal('es_ES')
       loadLocale('en_US.UTF-8')
     })
 
-    it("should not detect the OS locale if detectLocale is 'false'", function () {
+    it("should not detect the OS locale if detectLocale is 'false'", () => {
       loadLocale('es_ES.UTF-8')
 
-      var r = checkOutput(function () {
+      const r = checkOutput(() => {
         yargs(['snuh', '-h'])
           .command('blerg', 'blerg command')
           .help('h')
@@ -604,8 +598,8 @@ describe('yargs dsl tests', function () {
       process.env.LC_ALL = locale
     }
 
-    it("allows a locale other than the default 'en' to be specified", function () {
-      var r = checkOutput(function () {
+    it("allows a locale other than the default 'en' to be specified", () => {
+      const r = checkOutput(() => {
         yargs(['snuh', '-h'])
           .command('blerg', 'blerg command')
           .help('h')
@@ -617,10 +611,10 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Choose yer command:/)
     })
 
-    it('handles a missing locale', function () {
+    it('handles a missing locale', () => {
       loadLocale('zz_ZZ.UTF-8')
 
-      var r = checkOutput(function () {
+      const r = checkOutput(() => {
         yargs(['snuh', '-h'])
           .command('blerg', 'blerg command')
           .help('h')
@@ -633,10 +627,10 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Commands:/)
     })
 
-    it('properly translates a region-specific locale file', function () {
+    it('properly translates a region-specific locale file', () => {
       loadLocale('pt_BR.UTF-8')
 
-      var r = checkOutput(function () {
+      const r = checkOutput(() => {
         yargs(['-h'])
           .help('h')
           .wrap(null)
@@ -648,10 +642,10 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Exibe ajuda/)
     })
 
-    it('handles os-locale throwing an exception', function () {
+    it('handles os-locale throwing an exception', () => {
       // make os-locale throw.
       require('os-locale')
-      require.cache[require.resolve('os-locale')].exports.sync = function () { throw Error('an error!') }
+      require.cache[require.resolve('os-locale')].exports.sync = () => { throw Error('an error!') }
 
       delete require.cache[require.resolve('../')]
       yargs = require('../')
@@ -659,8 +653,8 @@ describe('yargs dsl tests', function () {
       yargs.locale().should.equal('en')
     })
 
-    it('uses locale string for help option default desc on .locale().help()', function () {
-      var r = checkOutput(function () {
+    it('uses locale string for help option default desc on .locale().help()', () => {
+      const r = checkOutput(() => {
         yargs(['-h'])
           .locale('pirate')
           .help('h')
@@ -671,8 +665,8 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Parlay this here code of conduct/)
     })
 
-    it('uses locale string for help option default desc on .help().locale()', function () {
-      var r = checkOutput(function () {
+    it('uses locale string for help option default desc on .help().locale()', () => {
+      const r = checkOutput(() => {
         yargs(['-h'])
           .help('h')
           .locale('pirate')
@@ -683,9 +677,9 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Parlay this here code of conduct/)
     })
 
-    describe('updateLocale', function () {
-      it('allows you to override the default locale strings', function () {
-        var r = checkOutput(function () {
+    describe('updateLocale', () => {
+      it('allows you to override the default locale strings', () => {
+        const r = checkOutput(() => {
           yargs(['snuh', '-h'])
             .command('blerg', 'blerg command')
             .help('h')
@@ -699,8 +693,8 @@ describe('yargs dsl tests', function () {
         r.logs.join(' ').should.match(/COMMANDS!/)
       })
 
-      it('allows you to use updateStrings() as an alias for updateLocale()', function () {
-        var r = checkOutput(function () {
+      it('allows you to use updateStrings() as an alias for updateLocale()', () => {
+        const r = checkOutput(() => {
           yargs(['snuh', '-h'])
             .command('blerg', 'blerg command')
             .help('h')
@@ -716,37 +710,37 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('env', function () {
-    it('translates no arg as empty prefix (parser applies all env vars)', function () {
-      var options = yargs.env().getOptions()
+  describe('env', () => {
+    it('translates no arg as empty prefix (parser applies all env vars)', () => {
+      const options = yargs.env().getOptions()
       options.envPrefix.should.equal('')
     })
 
-    it('accepts true as a valid prefix (parser applies all env vars)', function () {
-      var options = yargs.env(true).getOptions()
+    it('accepts true as a valid prefix (parser applies all env vars)', () => {
+      const options = yargs.env(true).getOptions()
       options.envPrefix.should.equal(true)
     })
 
-    it('accepts empty string as a valid prefix (parser applies all env vars)', function () {
-      var options = yargs.env('').getOptions()
+    it('accepts empty string as a valid prefix (parser applies all env vars)', () => {
+      const options = yargs.env('').getOptions()
       options.envPrefix.should.equal('')
     })
 
-    it('accepts a string prefix', function () {
-      var options = yargs.env('COOL').getOptions()
+    it('accepts a string prefix', () => {
+      const options = yargs.env('COOL').getOptions()
       options.envPrefix.should.equal('COOL')
     })
 
-    it('translates false as undefined prefix (disables parsing of env vars)', function () {
-      var options = yargs.env(false).getOptions()
+    it('translates false as undefined prefix (disables parsing of env vars)', () => {
+      const options = yargs.env(false).getOptions()
       expect(options.envPrefix).to.be.undefined
     })
   })
 
-  describe('parse', function () {
-    it('parses a simple string', function () {
-      var a1 = yargs.parse('-x=2 --foo=bar')
-      var a2 = yargs('-x=2 --foo=bar').argv
+  describe('parse', () => {
+    it('parses a simple string', () => {
+      const a1 = yargs.parse('-x=2 --foo=bar')
+      const a2 = yargs('-x=2 --foo=bar').argv
       a1.x.should.equal(2)
       a2.x.should.equal(2)
 
@@ -754,9 +748,9 @@ describe('yargs dsl tests', function () {
       a2.foo.should.equal('bar')
     })
 
-    it('parses a quoted string', function () {
-      var a1 = yargs.parse('-x=\'marks "the" spot\' --foo "break \'dance\'"')
-      var a2 = yargs('-x=\'marks "the" spot\' --foo "break \'dance\'"').argv
+    it('parses a quoted string', () => {
+      const a1 = yargs.parse('-x=\'marks "the" spot\' --foo "break \'dance\'"')
+      const a2 = yargs('-x=\'marks "the" spot\' --foo "break \'dance\'"').argv
 
       a1.x.should.equal('marks "the" spot')
       a2.x.should.equal('marks "the" spot')
@@ -765,9 +759,9 @@ describe('yargs dsl tests', function () {
       a2.foo.should.equal("break 'dance'")
     })
 
-    it('parses an array', function () {
-      var a1 = yargs.parse(['-x', '99', '--why=hello world'])
-      var a2 = yargs(['-x', '99', '--why=hello world']).argv
+    it('parses an array', () => {
+      const a1 = yargs.parse(['-x', '99', '--why=hello world'])
+      const a2 = yargs(['-x', '99', '--why=hello world']).argv
 
       a1.x.should.equal(99)
       a2.x.should.equal(99)
@@ -776,13 +770,13 @@ describe('yargs dsl tests', function () {
       a2.why.should.equal('hello world')
     })
 
-    it('ignores implicit help command (with short-circuit)', function () {
-      var parsed = yargs.help().parse('help', true)
+    it('ignores implicit help command (with short-circuit)', () => {
+      const parsed = yargs.help().parse('help', true)
       parsed._.should.deep.equal(['help'])
     })
 
-    it('allows an optional context object to be provided', function () {
-      var a1 = yargs.parse('-x=2 --foo=bar', {
+    it('allows an optional context object to be provided', () => {
+      const a1 = yargs.parse('-x=2 --foo=bar', {
         context: 'look at me go!'
       })
       a1.x.should.equal(2)
@@ -791,8 +785,8 @@ describe('yargs dsl tests', function () {
     })
 
     // see https://github.com/yargs/yargs/issues/724
-    it('overrides parsed value of argv with context object', function () {
-      var a1 = yargs.parse('-x=33', {
+    it('overrides parsed value of argv with context object', () => {
+      const a1 = yargs.parse('-x=33', {
         x: 42
       })
       a1.x.should.equal(42)
@@ -800,24 +794,24 @@ describe('yargs dsl tests', function () {
   })
 
   // yargs.parse(['foo', '--bar'], function (err, argv, output) {}
-  context('function passed as second argument to parse', function () {
-    it('does not print to stdout', function () {
-      var r = checkOutput(function () {
+  context('function passed as second argument to parse', () => {
+    it('does not print to stdout', () => {
+      const r = checkOutput(() => {
         yargs()
           .help('h')
-          .parse('-h', function (_err, argv, output) {})
+          .parse('-h', (_err, argv, output) => {})
       })
 
       r.logs.length.should.equal(0)
       r.errors.length.should.equal(0)
     })
 
-    it('gets passed error as first argument', function () {
-      var err = null
-      var r = checkOutput(function () {
+    it('gets passed error as first argument', () => {
+      let err = null
+      const r = checkOutput(() => {
         yargs()
           .demand('robin')
-          .parse('batman', function (_err, argv, output) {
+          .parse('batman', (_err, argv, output) => {
             err = _err
           })
       })
@@ -826,12 +820,12 @@ describe('yargs dsl tests', function () {
       err.should.match(/Missing required argument/)
     })
 
-    it('gets passed argv as second argument', function () {
-      var argv = null
-      var r = checkOutput(function () {
+    it('gets passed argv as second argument', () => {
+      let argv = null
+      const r = checkOutput(() => {
         yargs()
           .demand('robin')
-          .parse('batman --foo', function (_err, _argv, output) {
+          .parse('batman --foo', (_err, _argv, output) => {
             argv = _argv
           })
       })
@@ -840,13 +834,13 @@ describe('yargs dsl tests', function () {
       argv.foo.should.equal(true)
     })
 
-    it('gets passed output as third argument', function () {
-      var output = null
-      var r = checkOutput(function () {
+    it('gets passed output as third argument', () => {
+      let output = null
+      const r = checkOutput(() => {
         yargs()
           .demand('robin')
           .help()
-          .parse('--help', function (_err, argv, _output) {
+          .parse('--help', (_err, argv, _output) => {
             output = _output
           })
       })
@@ -855,13 +849,13 @@ describe('yargs dsl tests', function () {
       output.should.match(/--robin.*\[required]/)
     })
 
-    it('reinstates original exitProcess setting after invocation', function () {
-      var callbackCalled = false
-      var r = checkOutput(function () {
+    it('reinstates original exitProcess setting after invocation', () => {
+      let callbackCalled = false
+      const r = checkOutput(() => {
         yargs
           .exitProcess(true)
           .help()
-          .parse('--help', function () {
+          .parse('--help', () => {
             callbackCalled = true
             yargs.getExitProcess().should.be.false
           })
@@ -873,16 +867,16 @@ describe('yargs dsl tests', function () {
       yargs.getExitProcess().should.be.true
     })
 
-    it('does not call callback if subsequently called without callback', function () {
-      var callbackCalled = 0
-      var callback = function () {
+    it('does not call callback if subsequently called without callback', () => {
+      let callbackCalled = 0
+      const callback = () => {
         callbackCalled++
       }
       yargs.help()
-      var r1 = checkOutput(function () {
+      const r1 = checkOutput(() => {
         yargs.parse('--help', callback)
       })
-      var r2 = checkOutput(function () {
+      const r2 = checkOutput(() => {
         yargs.parse('--help')
       })
       callbackCalled.should.equal(1)
@@ -894,14 +888,14 @@ describe('yargs dsl tests', function () {
       r2.logs[0].should.match(/--help.*Show help.*\[boolean]/)
     })
 
-    it('resets error state between calls to parse', function () {
-      var y = yargs()
+    it('resets error state between calls to parse', () => {
+      const y = yargs()
         .demand(2)
 
-      var err1 = null
-      var out1 = null
-      var argv1 = null
-      y.parse('foo', function (err, argv, output) {
+      let err1 = null
+      let out1 = null
+      let argv1 = null
+      y.parse('foo', (err, argv, output) => {
         err1 = err
         argv1 = argv
         out1 = output
@@ -911,10 +905,10 @@ describe('yargs dsl tests', function () {
       argv1._.should.include('foo')
       out1.should.match(/Not enough non-option arguments/)
 
-      var err2 = null
-      var argv2 = null
-      var out2 = null
-      y.parse('foo bar', function (err, argv, output) {
+      let err2 = null
+      let argv2 = null
+      let out2 = null
+      y.parse('foo bar', (err, argv, output) => {
         err2 = err
         argv2 = argv
         out2 = output
@@ -928,16 +922,16 @@ describe('yargs dsl tests', function () {
       expect(out2).to.equal('')
     })
 
-    describe('commands', function () {
-      it('does not invoke command handler if output is populated', function () {
-        var err = null
-        var handlerCalled = false
-        var r = checkOutput(function () {
+    describe('commands', () => {
+      it('does not invoke command handler if output is populated', () => {
+        let err = null
+        let handlerCalled = false
+        const r = checkOutput(() => {
           yargs()
-            .command('batman <api-token>', 'batman command', function () {}, function () {
+            .command('batman <api-token>', 'batman command', noop, () => {
               handlerCalled = true
             })
-            .parse('batman --what', function (_err, argv, output) {
+            .parse('batman --what', (_err, argv, output) => {
               err = _err
             })
         })
@@ -947,15 +941,15 @@ describe('yargs dsl tests', function () {
         handlerCalled.should.equal(false)
       })
 
-      it('invokes command handler normally if no output is populated', function () {
-        var argv = null
-        var output = null
-        var r = checkOutput(function () {
+      it('invokes command handler normally if no output is populated', () => {
+        let argv = null
+        let output = null
+        const r = checkOutput(() => {
           yargs()
-            .command('batman <api-token>', 'batman command', function () {}, function (_argv) {
+            .command('batman <api-token>', 'batman command', noop, (_argv) => {
               argv = _argv
             })
-            .parse('batman robin --what', function (_err, argv, _output) {
+            .parse('batman robin --what', (_err, argv, _output) => {
               output = _output
             })
         })
@@ -966,15 +960,15 @@ describe('yargs dsl tests', function () {
         argv.what.should.equal(true)
       })
 
-      it('allows context object to be passed to parse', function () {
-        var argv = null
+      it('allows context object to be passed to parse', () => {
+        let argv = null
         yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {
             argv = _argv
           })
           .parse('batman robin --what', {
             state: 'grumpy but rich'
-          }, function (_err, argv, _output) {})
+          }, (_err, argv, _output) => {})
 
         argv.state.should.equal('grumpy but rich')
         argv['api-token'].should.equal('robin')
@@ -982,65 +976,65 @@ describe('yargs dsl tests', function () {
       })
 
       // see: https://github.com/yargs/yargs/issues/671
-      it('does not fail if context object has cyclical reference', function () {
-        var argv = null
-        var context = {state: 'grumpy but rich'}
+      it('does not fail if context object has cyclical reference', () => {
+        let argv = null
+        const context = {state: 'grumpy but rich'}
         context.res = context
         yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {
             argv = _argv
           })
-          .parse('batman robin --what', context, function (_err, argv, _output) {})
+          .parse('batman robin --what', context, (_err, argv, _output) => {})
 
         argv.state.should.equal('grumpy but rich')
         argv['api-token'].should.equal('robin')
         argv.what.should.equal(true)
       })
 
-      it('allows nested sub-commands to be invoked multiple times', function () {
-        var context = {counter: 0}
+      it('allows nested sub-commands to be invoked multiple times', () => {
+        const context = {counter: 0}
 
-        checkOutput(function () {
-          var parser = yargs()
+        checkOutput(() => {
+          const parser = yargs()
             .commandDir('fixtures/cmddir')
 
-          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
-          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
-          parser.parse('dream within-a-dream --what', {context: context}, function (_err, argv, _output) {})
+          parser.parse('dream within-a-dream --what', {context}, (_err, argv, _output) => {})
+          parser.parse('dream within-a-dream --what', {context}, (_err, argv, _output) => {})
+          parser.parse('dream within-a-dream --what', {context}, (_err, argv, _output) => {})
         })
 
         context.counter.should.equal(3)
       })
 
-      it('overwrites the prior context object, when parse is called multiple times', function () {
-        var argv = null
-        var parser = yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
+      it('overwrites the prior context object, when parse is called multiple times', () => {
+        let argv = null
+        const parser = yargs()
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {})
 
         parser.parse('batman robin --what', {
           state: 'grumpy but rich'
-        }, function (_err, _argv, _output) {})
+        }, (_err, _argv, _output) => {})
 
         parser.parse('batman robin --what', {
           state: 'the hero we need'
-        }, function (_err, _argv, _output) {
+        }, (_err, _argv, _output) => {
           argv = _argv
         })
 
         argv.state.should.equal('the hero we need')
       })
 
-      it('populates argv appropriately when parse is called multiple times', function () {
-        var parser = yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
-          .command('robin <egg>', 'robin command', function () {}, function (_argv) {})
+      it('populates argv appropriately when parse is called multiple times', () => {
+        const parser = yargs()
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {})
+          .command('robin <egg>', 'robin command', noop, (_argv) => {})
 
-        var argv1 = null
-        parser.parse('batman abc123', function (_err, argv, _output) {
+        let argv1 = null
+        parser.parse('batman abc123', (_err, argv, _output) => {
           argv1 = argv
         })
-        var argv2 = null
-        parser.parse('robin blue', function (_err, argv, _output) {
+        let argv2 = null
+        parser.parse('robin blue', (_err, argv, _output) => {
           argv2 = argv
         })
         expect(argv1.egg).to.equal(undefined)
@@ -1050,18 +1044,18 @@ describe('yargs dsl tests', function () {
         argv2.egg.should.equal('blue')
       })
 
-      it('populates output appropriately when parse is called multiple times', function () {
-        var parser = yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
-          .command('robin <egg>', 'robin command', function () {}, function (_argv) {})
+      it('populates output appropriately when parse is called multiple times', () => {
+        const parser = yargs()
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {})
+          .command('robin <egg>', 'robin command', noop, (_argv) => {})
           .wrap(null)
 
-        var output1 = null
-        parser.parse('batman help', function (_err, _argv, output) {
+        let output1 = null
+        parser.parse('batman help', (_err, _argv, output) => {
           output1 = output
         })
-        var output2 = null
-        parser.parse('robin help', function (_err, _argv, output) {
+        let output2 = null
+        parser.parse('robin help', (_err, _argv, output) => {
           output2 = output
         })
 
@@ -1084,21 +1078,21 @@ describe('yargs dsl tests', function () {
         ])
       })
 
-      it('resets errors when parse is called multiple times', function () {
-        var parser = yargs()
-          .command('batman <api-token>', 'batman command', function () {}, function (_argv) {})
-          .command('robin <egg>', 'robin command', function () {}, function (_argv) {})
+      it('resets errors when parse is called multiple times', () => {
+        const parser = yargs()
+          .command('batman <api-token>', 'batman command', noop, (_argv) => {})
+          .command('robin <egg>', 'robin command', noop, (_argv) => {})
           .wrap(null)
 
-        var error1 = null
-        var output1 = null
-        parser.parse('batman', function (err, _argv, output) {
+        let error1 = null
+        let output1 = null
+        parser.parse('batman', (err, _argv, output) => {
           error1 = err
           output1 = output
         })
-        var error2 = null
-        var output2 = null
-        parser.parse('robin help', function (err, _argv, output) {
+        let error2 = null
+        let output2 = null
+        parser.parse('robin help', (err, _argv, output) => {
           error2 = err
           output2 = output
         })
@@ -1125,22 +1119,22 @@ describe('yargs dsl tests', function () {
         ])
       })
 
-      it('preserves top-level config when parse is called multiple times', function () {
-        var x = 'wrong'
-        var err
-        var output
+      it('preserves top-level config when parse is called multiple times', () => {
+        let x = 'wrong'
+        let err
+        let output
         // set some top-level, reset-able config
-        var parser = yargs()
+        const parser = yargs()
           .demand(1, 'Must call a command')
           .strict()
           .wrap(null)
           .command('one <x>', 'The one and only command')
         // first call parse with command, which calls reset
-        parser.parse('one two', function (_, argv) {
+        parser.parse('one two', (_, argv) => {
           x = argv.x
         })
         // then call parse without command, which should enforce top-level config
-        parser.parse('', function (_err, argv, _output) {
+        parser.parse('', (_err, argv, _output) => {
           err = _err || {}
           output = _output || ''
         })
@@ -1160,20 +1154,18 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('config', function () {
-    it('allows a parsing function to be provided as a second argument', function () {
-      var argv = yargs('--config ./test/fixtures/config.json')
-        .config('config', function (path) {
-          return JSON.parse(fs.readFileSync(path))
-        })
+  describe('config', () => {
+    it('allows a parsing function to be provided as a second argument', () => {
+      const argv = yargs('--config ./test/fixtures/config.json')
+        .config('config', path => JSON.parse(fs.readFileSync(path)))
         .global('config', false)
         .argv
 
       argv.foo.should.equal('baz')
     })
 
-    it('allows key to be specified with option shorthand', function () {
-      var argv = yargs('--config ./test/fixtures/config.json')
+    it('allows key to be specified with option shorthand', () => {
+      const argv = yargs('--config ./test/fixtures/config.json')
         .option('config', {
           config: true,
           global: false
@@ -1183,8 +1175,8 @@ describe('yargs dsl tests', function () {
       argv.foo.should.equal('baz')
     })
 
-    it('allows to pass a configuration object', function () {
-      var argv = yargs
+    it('allows to pass a configuration object', () => {
+      const argv = yargs
           .config({foo: 1, bar: 2})
           .argv
 
@@ -1192,9 +1184,9 @@ describe('yargs dsl tests', function () {
       argv.bar.should.equal(2)
     })
 
-    describe('extends', function () {
-      it('applies default configurations when given config object', function () {
-        var argv = yargs
+    describe('extends', () => {
+      it('applies default configurations when given config object', () => {
+        const argv = yargs
           .config({
             extends: './test/fixtures/extends/config_1.json',
             a: 1
@@ -1206,16 +1198,16 @@ describe('yargs dsl tests', function () {
         argv.z.should.equal(15)
       })
 
-      it('protects against circular extended configurations', function () {
-        expect(function () {
+      it('protects against circular extended configurations', () => {
+        expect(() => {
           yargs.config({extends: './test/fixtures/extends/circular_1.json'})
         }).to.throw(YError)
       })
 
-      it('handles aboslute paths', function () {
-        var absolutePath = path.join(process.cwd(), 'test', 'fixtures', 'extends', 'config_1.json')
+      it('handles aboslute paths', () => {
+        const absolutePath = path.join(process.cwd(), 'test', 'fixtures', 'extends', 'config_1.json')
 
-        var argv = yargs
+        const argv = yargs
           .config({
             a: 2,
             extends: absolutePath
@@ -1229,7 +1221,7 @@ describe('yargs dsl tests', function () {
 
       // see: https://www.npmjs.com/package/yargs-test-extends
       it('allows a module to be extended, rather than a JSON file', () => {
-        var argv = yargs()
+        const argv = yargs()
           .config({
             a: 2,
             extends: 'yargs-test-extends'
@@ -1241,7 +1233,7 @@ describe('yargs dsl tests', function () {
       })
 
       it('ignores an extends key that does not look like a path or module', () => {
-        var argv = yargs()
+        const argv = yargs()
           .config({
             a: 2,
             extends: 'batman'
@@ -1254,17 +1246,17 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('normalize', function () {
-    it('normalizes paths passed as arguments', function () {
-      var argv = yargs('--path /foo/bar//baz/asdf/quux/..')
+  describe('normalize', () => {
+    it('normalizes paths passed as arguments', () => {
+      const argv = yargs('--path /foo/bar//baz/asdf/quux/..')
         .normalize(['path'])
         .argv
 
       argv.path.should.equal(['', 'foo', 'bar', 'baz', 'asdf'].join(path.sep))
     })
 
-    it('normalizes path when when it is updated', function () {
-      var argv = yargs('--path /batman')
+    it('normalizes path when when it is updated', () => {
+      const argv = yargs('--path /batman')
         .normalize(['path'])
         .argv
 
@@ -1272,8 +1264,8 @@ describe('yargs dsl tests', function () {
       argv.path.should.equal(['', 'foo', 'bar', 'baz', 'asdf'].join(path.sep))
     })
 
-    it('allows key to be specified with option shorthand', function () {
-      var argv = yargs('--path /batman')
+    it('allows key to be specified with option shorthand', () => {
+      const argv = yargs('--path /batman')
         .option('path', {
           normalize: true
         })
@@ -1284,9 +1276,9 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('narg', function () {
-    it('accepts a key as the first argument and a count as the second', function () {
-      var argv = yargs('--foo a b c')
+  describe('narg', () => {
+    it('accepts a key as the first argument and a count as the second', () => {
+      const argv = yargs('--foo a b c')
         .nargs('foo', 2)
         .argv
 
@@ -1294,8 +1286,8 @@ describe('yargs dsl tests', function () {
       argv._.should.deep.equal(['c'])
     })
 
-    it('accepts a hash of keys and counts', function () {
-      var argv = yargs('--foo a b c')
+    it('accepts a hash of keys and counts', () => {
+      const argv = yargs('--foo a b c')
         .nargs({
           foo: 2
         })
@@ -1305,8 +1297,8 @@ describe('yargs dsl tests', function () {
       argv._.should.deep.equal(['c'])
     })
 
-    it('allows key to be specified with option shorthand', function () {
-      var argv = yargs('--foo a b c')
+    it('allows key to be specified with option shorthand', () => {
+      const argv = yargs('--foo a b c')
         .option('foo', {
           nargs: 2
         })
@@ -1317,9 +1309,9 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('global', function () {
-    it('does not reset a global options when reset is called', function () {
-      var y = yargs('--foo a b c')
+  describe('global', () => {
+    it('does not reset a global options when reset is called', () => {
+      const y = yargs('--foo a b c')
         .option('foo', {
           nargs: 2
         })
@@ -1329,13 +1321,13 @@ describe('yargs dsl tests', function () {
         })
         .global('foo')
         .reset()
-      var options = y.getOptions()
+      const options = y.getOptions()
       options.key.foo.should.equal(true)
       expect(options.key.bar).to.equal(undefined)
     })
 
-    it('does not reset alias of global option', function () {
-      var y = yargs('--foo a b c')
+    it('does not reset alias of global option', () => {
+      const y = yargs('--foo a b c')
         .option('foo', {
           nargs: 2,
           alias: 'awesome-sauce'
@@ -1352,7 +1344,7 @@ describe('yargs dsl tests', function () {
         .reset({
           foo: ['awesome-sauce', 'awesomeSauce']
         })
-      var options = y.getOptions()
+      const options = y.getOptions()
 
       options.key.foo.should.equal(true)
       options.string.should.include('awesome-sauce')
@@ -1363,34 +1355,34 @@ describe('yargs dsl tests', function () {
       Object.keys(options.demandedOptions).should.not.include('bar')
     })
 
-    it('should set help to global option by default', function () {
-      var y = yargs('--foo')
+    it('should set help to global option by default', () => {
+      const y = yargs('--foo')
         .help('help')
-      var options = y.getOptions()
+      const options = y.getOptions()
       options.local.should.not.include('help')
     })
 
-    it('should set version to global option by default', function () {
-      var y = yargs('--foo')
+    it('should set version to global option by default', () => {
+      const y = yargs('--foo')
         .version()
-      var options = y.getOptions()
+      const options = y.getOptions()
       options.local.should.not.include('version')
     })
 
-    it('should not reset usage descriptions of global options', function () {
-      var y = yargs('--foo')
+    it('should not reset usage descriptions of global options', () => {
+      const y = yargs('--foo')
         .describe('bar', 'my awesome bar option')
         .describe('foo', 'my awesome foo option')
         .global('foo')
         .global('bar', false)
         .reset()
-      var descriptions = y.getUsageInstance().getDescriptions()
+      const descriptions = y.getUsageInstance().getDescriptions()
       Object.keys(descriptions).should.include('foo')
       Object.keys(descriptions).should.not.include('bar')
     })
 
-    it('should not reset implications of global options', function () {
-      var y = yargs(['--x=33'])
+    it('should not reset implications of global options', () => {
+      const y = yargs(['--x=33'])
         .implies({
           x: 'y'
         })
@@ -1399,13 +1391,13 @@ describe('yargs dsl tests', function () {
         })
         .global(['z'], false)
         .reset()
-      var implied = y.getValidationInstance().getImplied()
+      const implied = y.getValidationInstance().getImplied()
       Object.keys(implied).should.include('x')
       Object.keys(implied).should.not.include('z')
     })
 
-    it('should expose an options short-hand for declaring global options', function () {
-      var y = yargs('--foo a b c')
+    it('should expose an options short-hand for declaring global options', () => {
+      const y = yargs('--foo a b c')
         .option('foo', {
           nargs: 2
         })
@@ -1414,22 +1406,22 @@ describe('yargs dsl tests', function () {
           global: false
         })
         .reset()
-      var options = y.getOptions()
+      const options = y.getOptions()
       options.key.foo.should.equal(true)
       expect(options.key.bar).to.equal(undefined)
     })
   })
 
-  describe('pkgConf', function () {
-    it('uses values from package.json', function () {
-      var argv = yargs('--foo a').pkgConf('repository').argv
+  describe('pkgConf', () => {
+    it('uses values from package.json', () => {
+      const argv = yargs('--foo a').pkgConf('repository').argv
 
       argv.foo.should.equal('a')
       argv.type.should.equal('git')
     })
 
-    it('combines yargs defaults with package.json values', function () {
-      var argv = yargs('--foo a')
+    it('combines yargs defaults with package.json values', () => {
+      const argv = yargs('--foo a')
         .default('b', 99)
         .pkgConf('repository')
         .argv
@@ -1439,8 +1431,8 @@ describe('yargs dsl tests', function () {
       argv.type.should.equal('git')
     })
 
-    it('should use value from package.json, if argv value is using default value', function () {
-      var argv = yargs('--foo a')
+    it('should use value from package.json, if argv value is using default value', () => {
+      const argv = yargs('--foo a')
         .default('b', 99)
         .pkgConf('repository')
         .default('type', 'default')
@@ -1451,8 +1443,8 @@ describe('yargs dsl tests', function () {
       argv.type.should.equal('git')
     })
 
-    it('should apply value from config object to all aliases', function () {
-      var argv = yargs('--foo a')
+    it('should apply value from config object to all aliases', () => {
+      const argv = yargs('--foo a')
         .pkgConf('repository')
         .alias('type', 't')
         .alias('t', 'u')
@@ -1464,8 +1456,8 @@ describe('yargs dsl tests', function () {
       argv.u.should.equal('git')
     })
 
-    it('is cool with a key not existing', function () {
-      var argv = yargs('--foo a')
+    it('is cool with a key not existing', () => {
+      const argv = yargs('--foo a')
         .default('b', 99)
         .pkgConf('banana')
         .argv
@@ -1475,8 +1467,8 @@ describe('yargs dsl tests', function () {
       expect(argv.type).to.equal(undefined)
     })
 
-    it('allows an alternative cwd to be specified', function () {
-      var argv = yargs('--foo a')
+    it('allows an alternative cwd to be specified', () => {
+      const argv = yargs('--foo a')
         .pkgConf('yargs', './test/fixtures')
         .argv
 
@@ -1484,13 +1476,12 @@ describe('yargs dsl tests', function () {
       argv.dotNotation.should.equal(false)
     })
 
-    it('doesn\'t mess up other pkg lookups when cwd is specified', function () {
-      var r = checkOutput(function () {
-        return yargs('--version')
+    it('doesn\'t mess up other pkg lookups when cwd is specified', () => {
+      const r = checkOutput(() => yargs('--version')
           .pkgConf('repository', './test/fixtures')
           .version()
           .argv
-      })
+        )
       const options = yargs.getOptions()
 
       // assert pkgConf lookup (test/fixtures/package.json)
@@ -1501,34 +1492,34 @@ describe('yargs dsl tests', function () {
     })
 
     // see https://github.com/yargs/yargs/issues/485
-    it('handles an invalid package.json', function () {
-      var argv = yargs('--foo a')
+    it('handles an invalid package.json', () => {
+      const argv = yargs('--foo a')
         .pkgConf('yargs', './test/fixtures/broken-json')
         .argv
 
       argv.foo.should.equal('a')
     })
 
-    it('should apply default configurations from extended packages', function () {
-      var argv = yargs().pkgConf('foo', 'test/fixtures/extends/packageA').argv
+    it('should apply default configurations from extended packages', () => {
+      const argv = yargs().pkgConf('foo', 'test/fixtures/extends/packageA').argv
 
       argv.a.should.equal(80)
       argv.b.should.equals('riffiwobbles')
     })
 
-    it('should apply extended configurations from cwd when no path is given', function () {
-      var argv = yargs('', 'test/fixtures/extends/packageA').pkgConf('foo').argv
+    it('should apply extended configurations from cwd when no path is given', () => {
+      const argv = yargs('', 'test/fixtures/extends/packageA').pkgConf('foo').argv
 
       argv.a.should.equal(80)
       argv.b.should.equals('riffiwobbles')
     })
   })
 
-  describe('skipValidation', function () {
-    it('skips validation if an option with skipValidation is present', function () {
-      var argv = yargs(['--koala', '--skip'])
+  describe('skipValidation', () => {
+    it('skips validation if an option with skipValidation is present', () => {
+      const argv = yargs(['--koala', '--skip'])
           .demand(1)
-          .fail(function (msg) {
+          .fail((msg) => {
             expect.fail()
           })
           .skipValidation(['skip', 'reallySkip'])
@@ -1536,21 +1527,19 @@ describe('yargs dsl tests', function () {
       argv.koala.should.equal(true)
     })
 
-    it('does not skip validation if no option with skipValidation is present', function (done) {
-      var argv = yargs(['--koala'])
+    it('does not skip validation if no option with skipValidation is present', (done) => {
+      const argv = yargs(['--koala'])
           .demand(1)
-          .fail(function (msg) {
-            return done()
-          })
+          .fail(msg => done())
           .skipValidation(['skip', 'reallySkip'])
           .argv
       argv.koala.should.equal(true)
     })
 
-    it('allows key to be specified with option shorthand', function () {
-      var argv = yargs(['--koala', '--skip'])
+    it('allows key to be specified with option shorthand', () => {
+      const argv = yargs(['--koala', '--skip'])
           .demand(1)
-          .fail(function (msg) {
+          .fail((msg) => {
             expect.fail()
           })
           .option('skip', {
@@ -1560,14 +1549,14 @@ describe('yargs dsl tests', function () {
       argv.koala.should.equal(true)
     })
 
-    it('allows having an option that skips validation but not skipping validation if that option is not used', function () {
-      var skippedValidation = true
+    it('allows having an option that skips validation but not skipping validation if that option is not used', () => {
+      let skippedValidation = true
       yargs(['--no-skip'])
           .demand(5)
           .option('skip', {
             skipValidation: true
           })
-          .fail(function (msg) {
+          .fail((msg) => {
             skippedValidation = false
           })
           .argv
@@ -1575,19 +1564,17 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('.help()', function () {
-    it('enables `--help` option and `help` command without arguments', function () {
-      var option = checkOutput(function () {
-        return yargs('--help')
+  describe('.help()', () => {
+    it('enables `--help` option and `help` command without arguments', () => {
+      const option = checkOutput(() => yargs('--help')
           .wrap(null)
           .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('help')
+        )
+      const command = checkOutput(() => yargs('help')
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -1597,20 +1584,18 @@ describe('yargs dsl tests', function () {
       command.logs[0].split('\n').should.deep.equal(expected)
     })
 
-    it('enables `--help` option and `help` command with `true` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--help')
+    it('enables `--help` option and `help` command with `true` argument', () => {
+      const option = checkOutput(() => yargs('--help')
           .help(true)
           .wrap(null)
           .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('help')
+        )
+      const command = checkOutput(() => yargs('help')
           .help(true)
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
         '  --help     Show help  [boolean]',
@@ -1620,26 +1605,23 @@ describe('yargs dsl tests', function () {
       command.logs[0].split('\n').should.deep.equal(expected)
     })
 
-    it('enables given string as help option and command with string argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
+    it('enables given string as help option and command with string argument', () => {
+      const option = checkOutput(() => yargs('--info')
           .help('info')
           .wrap(null)
           .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
+        )
+      const command = checkOutput(() => yargs('info')
           .help('info')
           .wrap(null)
           .argv
-      })
-      var helpOption = checkOutput(function () {
-        return yargs('--help')
+        )
+      const helpOption = checkOutput(() => yargs('--help')
           .help('info')
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
         '  --info     Show help  [boolean]',
@@ -1650,20 +1632,18 @@ describe('yargs dsl tests', function () {
       helpOption.result.should.have.property('help').and.be.true
     })
 
-    it('enables given string as help option and command with custom description with two string arguments', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
+    it('enables given string as help option and command with custom description with two string arguments', () => {
+      const option = checkOutput(() => yargs('--info')
           .help('info', 'Display info')
           .wrap(null)
           .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
+        )
+      const command = checkOutput(() => yargs('info')
           .help('info', 'Display info')
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
         '  --info     Display info  [boolean]',
@@ -1673,20 +1653,18 @@ describe('yargs dsl tests', function () {
       command.logs[0].split('\n').should.deep.equal(expected)
     })
 
-    it('enables given string as help option and command with custom description with two string arguments and `true` argument', function () {
-      var option = checkOutput(function () {
-        return yargs('--info')
+    it('enables given string as help option and command with custom description with two string arguments and `true` argument', () => {
+      const option = checkOutput(() => yargs('--info')
           .help('info', 'Display info', true)
           .wrap(null)
           .argv
-      })
-      var command = checkOutput(function () {
-        return yargs('info')
+        )
+      const command = checkOutput(() => yargs('info')
           .help('info', 'Display info', true)
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
         '  --info     Display info  [boolean]',
@@ -1697,20 +1675,18 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('.help() with .alias()', function () {
-    it('uses multi-char (but not single-char) help alias as command', function () {
-      var info = checkOutput(function () {
-        return yargs('info')
+  describe('.help() with .alias()', () => {
+    it('uses multi-char (but not single-char) help alias as command', () => {
+      const info = checkOutput(() => yargs('info')
           .help().alias('h', 'help').alias('h', 'info')
           .wrap(null)
           .argv
-      })
-      var h = checkOutput(function () {
-        return yargs('h')
+        )
+      const h = checkOutput(() => yargs('h')
           .help().alias('h', 'help').alias('h', 'info')
           .wrap(null)
           .argv
-      })
+        )
       info.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --version           Show version number  [boolean]',
@@ -1720,20 +1696,18 @@ describe('yargs dsl tests', function () {
       h.result.should.have.property('_').and.deep.equal(['h'])
     })
 
-    it('uses single-char help alias as command if there are no multi-char aliases', function () {
-      var h = checkOutput(function () {
-        return yargs('h')
+    it('uses single-char help alias as command if there are no multi-char aliases', () => {
+      const h = checkOutput(() => yargs('h')
           .help('h').alias('h', '?')
           .wrap(null)
           .argv
-      })
-      var q = checkOutput(function () {
-        return yargs('?')
+        )
+      const q = checkOutput(() => yargs('?')
           .help('h').alias('h', '?')
           .wrap(null)
           .argv
-      })
-      var expected = [
+        )
+      const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
         '  -h, -?     Show help  [boolean]',
@@ -1744,24 +1718,22 @@ describe('yargs dsl tests', function () {
     })
   })
 
-  describe('.coerce()', function () {
-    it('supports string and function args (as option key and coerce function)', function () {
-      var argv = yargs(['--file', path.join(__dirname, 'fixtures', 'package.json')])
-        .coerce('file', function (arg) {
-          return JSON.parse(fs.readFileSync(arg, 'utf8'))
-        })
+  describe('.coerce()', () => {
+    it('supports string and function args (as option key and coerce function)', () => {
+      const argv = yargs(['--file', path.join(__dirname, 'fixtures', 'package.json')])
+        .coerce('file', arg => JSON.parse(fs.readFileSync(arg, 'utf8')))
         .argv
       expect(argv.file).to.have.property('version').and.equal('9.9.9')
     })
 
-    it('supports object arg (as map of multiple options)', function () {
-      var argv = yargs('--expand abc --range 1..3')
+    it('supports object arg (as map of multiple options)', () => {
+      const argv = yargs('--expand abc --range 1..3')
         .coerce({
-          expand: function (arg) {
+          expand (arg) {
             return arg.split('')
           },
-          range: function (arg) {
-            var arr = arg.split('..').map(Number)
+          range (arg) {
+            const arr = arg.split('..').map(Number)
             return { begin: arr[0], end: arr[1] }
           }
         })
@@ -1771,22 +1743,20 @@ describe('yargs dsl tests', function () {
       expect(argv.range).to.have.property('end').and.equal(3)
     })
 
-    it('supports array and function args (as option keys and coerce function)', function () {
-      var argv = yargs(['--src', 'in', '--dest', 'out'])
-        .coerce(['src', 'dest'], function (arg) {
-          return path.resolve(arg)
-        })
+    it('supports array and function args (as option keys and coerce function)', () => {
+      const argv = yargs(['--src', 'in', '--dest', 'out'])
+        .coerce(['src', 'dest'], arg => path.resolve(arg))
         .argv
       argv.src.should.match(/in/).and.have.length.above(2)
       argv.dest.should.match(/out/).and.have.length.above(3)
     })
 
-    it('allows an error to be handled by fail() handler', function () {
-      var msg
-      var err
-      var jsonErrMessage
+    it('allows an error to be handled by fail() handler', () => {
+      let msg
+      let err
+      let jsonErrMessage
       yargs('--json invalid')
-        .coerce('json', function (arg) {
+        .coerce('json', (arg) => {
           try {
             JSON.parse(arg)
           } catch (err) {
@@ -1794,7 +1764,7 @@ describe('yargs dsl tests', function () {
           }
           return JSON.parse(arg)
         })
-        .fail(function (m, e) {
+        .fail((m, e) => {
           msg = m
           err = e
         })
@@ -1803,20 +1773,20 @@ describe('yargs dsl tests', function () {
       expect(err).to.exist
     })
 
-    it('supports an option alias', function () {
-      var argv = yargs('-d 2016-08-12')
+    it('supports an option alias', () => {
+      const argv = yargs('-d 2016-08-12')
         .coerce('date', Date.parse)
         .alias('date', 'd')
         .argv
       argv.date.should.equal(1470960000000)
     })
 
-    it('supports a global option within command', function () {
-      var regex
+    it('supports a global option within command', () => {
+      let regex
       yargs('check --regex x')
         .global('regex')
         .coerce('regex', RegExp)
-        .command('check', 'Check something', {}, function (argv) {
+        .command('check', 'Check something', {}, (argv) => {
           regex = argv.regex
         })
         .argv
@@ -1824,11 +1794,11 @@ describe('yargs dsl tests', function () {
       regex.toString().should.equal('/x/')
     })
 
-    it('is supported by .option()', function () {
-      var argv = yargs('--env SHELL=/bin/bash')
+    it('is supported by .option()', () => {
+      const argv = yargs('--env SHELL=/bin/bash')
         .option('env', {
-          coerce: function (arg) {
-            var arr = arg.split('=')
+          coerce (arg) {
+            const arr = arg.split('=')
             return { name: arr[0], value: arr[1] || '' }
           }
         })
@@ -1837,24 +1807,16 @@ describe('yargs dsl tests', function () {
       expect(argv.env).to.have.property('value').and.equal('/bin/bash')
     })
 
-    it('supports positional and variadic args for a command', function () {
-      var age
-      var dates
+    it('supports positional and variadic args for a command', () => {
+      let age
+      let dates
       yargs('add 30days 2016-06-13 2016-07-18')
-        .command('add <age> [dates..]', 'Testing', function (yargs) {
-          return yargs
-            .coerce('age', function (arg) {
-              return parseInt(arg, 10) * 86400000
+        .command('add <age> [dates..]', 'Testing', yargs => yargs
+            .coerce('age', arg => parseInt(arg, 10) * 86400000)
+            .coerce('dates', arg => arg.map(str => new Date(str))), (argv) => {
+              age = argv.age
+              dates = argv.dates
             })
-            .coerce('dates', function (arg) {
-              return arg.map(function (str) {
-                return new Date(str)
-              })
-            })
-        }, function (argv) {
-          age = argv.age
-          dates = argv.dates
-        })
         .argv
       expect(age).to.equal(2592000000)
       expect(dates).to.have.lengthOf(2)
@@ -1862,26 +1824,18 @@ describe('yargs dsl tests', function () {
       dates[1].toString().should.equal(new Date('2016-07-18').toString())
     })
 
-    it('returns camelcase args for a command', function () {
-      var age1
-      var age2
-      var dates
+    it('returns camelcase args for a command', () => {
+      let age1
+      let age2
+      let dates
       yargs('add 30days 2016-06-13 2016-07-18')
-        .command('add <age-in-days> [dates..]', 'Testing', function (yargs) {
-          return yargs
-            .coerce('age-in-days', function (arg) {
-              return parseInt(arg, 10) * 86400000
+        .command('add <age-in-days> [dates..]', 'Testing', yargs => yargs
+            .coerce('age-in-days', arg => parseInt(arg, 10) * 86400000)
+            .coerce('dates', arg => arg.map(str => new Date(str))), (argv) => {
+              age1 = argv.ageInDays
+              age2 = argv['age-in-days']
+              dates = argv.dates
             })
-            .coerce('dates', function (arg) {
-              return arg.map(function (str) {
-                return new Date(str)
-              })
-            })
-        }, function (argv) {
-          age1 = argv.ageInDays
-          age2 = argv['age-in-days']
-          dates = argv.dates
-        })
         .argv
       expect(age1).to.equal(2592000000)
       expect(age2).to.equal(2592000000)
@@ -1890,20 +1844,18 @@ describe('yargs dsl tests', function () {
       dates[1].toString().should.equal(new Date('2016-07-18').toString())
     })
 
-    it('allows an error from positional arg to be handled by fail() handler', function () {
-      var msg
-      var err
+    it('allows an error from positional arg to be handled by fail() handler', () => {
+      let msg
+      let err
       yargs('throw ball')
-        .command('throw <msg>', false, function (yargs) {
-          return yargs
-            .coerce('msg', function (arg) {
+        .command('throw <msg>', false, yargs => yargs
+            .coerce('msg', (arg) => {
               throw new Error(arg)
             })
-            .fail(function (m, e) {
+            .fail((m, e) => {
               msg = m
               err = e
-            })
-        })
+            }))
         .argv
       expect(msg).to.equal('ball')
       expect(err).to.exist
@@ -1921,20 +1873,20 @@ describe('yargs dsl tests', function () {
   })
 })
 
-describe('yargs context', function () {
-  beforeEach(function () {
+describe('yargs context', () => {
+  beforeEach(() => {
     delete require.cache[require.resolve('../')]
     yargs = require('../')
   })
 
-  it('should begin with initial state', function () {
-    var context = yargs.getContext()
+  it('should begin with initial state', () => {
+    const context = yargs.getContext()
     context.resets.should.equal(0)
     context.commands.should.deep.equal([])
   })
 
-  it('should track number of resets', function () {
-    var context = yargs.getContext()
+  it('should track number of resets', () => {
+    const context = yargs.getContext()
     yargs.reset()
     context.resets.should.equal(1)
     yargs.reset()
@@ -1942,18 +1894,18 @@ describe('yargs context', function () {
     context.resets.should.equal(3)
   })
 
-  it('should track commands being executed', function () {
-    var context
+  it('should track commands being executed', () => {
+    let context
     yargs('one two')
-      .command('one', 'level one', function (yargs) {
+      .command('one', 'level one', (yargs) => {
         context = yargs.getContext()
         context.commands.should.deep.equal(['one'])
-        return yargs.command('two', 'level two', function (yargs) {
+        return yargs.command('two', 'level two', (yargs) => {
           context.commands.should.deep.equal(['one', 'two'])
-        }, function (argv) {
+        }, (argv) => {
           context.commands.should.deep.equal(['one', 'two'])
         })
-      }, function (argv) {
+      }, (argv) => {
         context.commands.should.deep.equal(['one'])
       })
       .argv


### PR DESCRIPTION
## Changelog
* Add `'use strict'` directive in source and test files. Here's why:
  ```
  λ node --version
  v4.0.0
  
  λ echo let a = 1 > test-node4.js

  λ node test-node4.js
  E:\Projects\experiments\test-node4.js:1
  (function (exports, require, module, __filename, __dirname) { let a = 1
                                                                ^^^
  SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
      at exports.runInThisContext (vm.js:53:16)
      at Module._compile (module.js:413:25)
      at Object.Module._extensions..js (module.js:452:10)
      at Module.load (module.js:355:32)
      at Function.Module._load (module.js:310:12)
      at Function.Module.runMain (module.js:475:10)
      at startup (node.js:117:18)
      at node.js:951:3
  ``` 
* Use arrow functions for callbacks and simple functions(`() => someval`). See below for caveats.
* Use `const`/`let` instead of `var`. See below for caveats.
* Use `${template} strings`
* Wherever possible, set appropriate name for anonymous function. This helps for stack traces.
* Object shorthands (`{ min: min, f: function () {} }` 🡺 `{ min, f() {} }`)
* Alias and reuse `noop`(`function () {}`) in tests

### Caveats
* File `lib/assign.js` was not modified as it is being removed in #936
* Some functions access `arguments`. This doesn't work well with arrow functions. So a few functions have been left alone and not converted to arrow functions.
* In the file `yargs.js`, some variables are accessed using scope hoisting. These have been left as `var`(ex: `exitProcess`).
* Some tests call `this.skip`, `this.timeout`. These haven't been changed to arrow functions.
