### PR TITLE
feat: allow parse with no arguments as alias for yargs.argv

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,12 @@ or use `.parse()` to do the same thing:
 require('yargs').parse([ '-x', '1', '-y', '2' ])
 ````
 
+Calling `.parse()` with no arguments is equivalent to calling `yargs.argv`:
+
+```javascript
+require('yargs').parse()
+```
+
 The rest of these methods below come in just before the terminating `.argv`.
 
 <a name="alias"></a>.alias(key, alias)
@@ -1007,7 +1013,7 @@ Valid `opt` keys include:
     - `'number'`: synonymous for `number: true`, see [`number()`](#number)
     - `'string'`: synonymous for `string: true`, see [`string()`](#string)
 
-.parse(args, [context], [parseCallback])
+.parse([args], [context], [parseCallback])
 ------------
 
 Parse `args` instead of `process.argv`. Returns the `argv` object.

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -791,6 +791,17 @@ describe('yargs dsl tests', () => {
       })
       a1.x.should.equal(42)
     })
+
+    it('parses process.argv if no arguments are provided', () => {
+      const r = checkOutput(() => {
+        yargs(['--help'])
+          .command('blerg', 'blerg command')
+          .wrap(null)
+          .parse()
+      })
+
+      r.logs[0].should.match(/Commands:[\s\S]*blerg command/)
+    })
   })
 
   // yargs.parse(['foo', '--bar'], function (err, argv, output) {}

--- a/yargs.js
+++ b/yargs.js
@@ -511,7 +511,8 @@ function Yargs (processArgs, cwd, parentRequire) {
   let parseFn = null
   let parseContext = null
   self.parse = function parse (args, shortCircuit, _parseFn) {
-    argsert('<string|array> [function|boolean|object] [function]', [args, shortCircuit, _parseFn], arguments.length)
+    argsert('[string|array] [function|boolean|object] [function]', [args, shortCircuit, _parseFn], arguments.length)
+    if (typeof args === 'undefined') args = processArgs
 
     // a context object can optionally be provided, this allows
     // additional information to be passed to a command handler.


### PR DESCRIPTION
I showed the the [proposed promise API](https://github.com/yargs/yargs/pull/940) for yargs to several coworkers today at npm, and they managed to talk me out of it. Their reasoning being:

1. yargs is for the most part a synchronous API, and they didn't see much value in introducing the deferred behavior.
2. my coworker @zkat felt that the method name `.then()` felt weird; _this method name should be used internally by the Promise api, not by APIs exposing a promise._

Rather than introducing a new method `run()` (or the method I recommended `then()` for exposing a Promise), I feel a good compromise is to instead extend the method `parse()` which already exists in the API. Calling:

```js
require('yargs')
  .option('x', {describe: 'x option'})
  .parse()
```

is now possible, and is equivalent to:

```js
require('yargs')
  .option('x', {describe: 'x option'})
  .argv
```

I like this approach: it gets around the linting warning now frequently triggered by `.argv`, and avoids adding a new method to yargs' already large API surface.

We definitely might revisit a Promise-based API in the future, one recommendation made by my coworker @chrisdickinson was to make yargs' command API promise based, e.g.,

* a command would return a promise to execute.
* yargs would return a promise that resolves once the command is completed.