### PR TITLE
fix: strict mode should not fail for hidden options

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -120,26 +120,16 @@ module.exports = function validation (yargs, usage, y18n) {
 
   // check for unknown arguments (strict-mode).
   self.unknownArguments = function unknownArguments (argv, aliases, positionalMap) {
-    const aliasLookup = {}
-    const descriptions = usage.getDescriptions()
-    const demandedOptions = yargs.getDemandedOptions()
     const commandKeys = yargs.getCommandInstance().getCommands()
     const unknown = []
     const currentContext = yargs.getContext()
 
-    Object.keys(aliases).forEach((key) => {
-      aliases[key].forEach((alias) => {
-        aliasLookup[alias] = key
-      })
-    })
-
     Object.keys(argv).forEach((key) => {
       if (specialKeys.indexOf(key) === -1 &&
-        !descriptions.hasOwnProperty(key) &&
-        !demandedOptions.hasOwnProperty(key) &&
         !positionalMap.hasOwnProperty(key) &&
         !yargs._getParseContext().hasOwnProperty(key) &&
-        !aliasLookup.hasOwnProperty(key)) {
+        !aliases.hasOwnProperty(key)
+      ) {
         unknown.push(key)
       }
     })

--- a/test/validation.js
+++ b/test/validation.js
@@ -724,6 +724,32 @@ describe('validation tests', () => {
             })
         .argv
     })
+
+    it('does not fail for hidden options', () => {
+      const args = yargs('--foo hey')
+        .strict()
+        .option('foo', {boolean: true, describe: false})
+        .fail((msg) => {
+          expect.fail()
+        })
+        .argv
+      args.foo.should.equal(true)
+    })
+
+    it('does not fail if an alias is provided, rather than option itself', () => {
+      const args = yargs('--cat hey')
+        .strict()
+        .option('foo', {boolean: true, describe: false})
+        .alias('foo', 'bar')
+        .alias('bar', 'cat')
+        .fail((msg) => {
+          expect.fail()
+        })
+        .argv
+      args.cat.should.equal(true)
+      args.foo.should.equal(true)
+      args.bar.should.equal(true)
+    })
   })
 
   describe('demandOption', () => {


### PR DESCRIPTION
Address a bug @satazor found related to `strict()` mode firing for hidden options -- in the process I cleaned up strict mode logic for options a bit ... it seems like simply looking at the `aliases` map covers most of our bases.

fixes #948 