### PR TITLE
Run default cmd even if it is the only defined cmd

### DIFF
--- a/test/command.js
+++ b/test/command.js
@@ -1198,6 +1198,26 @@ describe('Command', () => {
         .argv
     })
 
+    it('executes default command if undefined positional arguments and only command', (done) => {
+      yargs('baz --foo bar')
+        .command('*', 'default command', noop, (argv) => {
+          argv.foo.should.equal('bar')
+          argv._.should.contain('baz')
+          return done()
+        })
+        .argv
+    })
+
+    it('executes default command if defined positional arguments and only command', (done) => {
+      yargs('baz --foo bar')
+        .command('* <target>', 'default command', noop, (argv) => {
+          argv.foo.should.equal('bar')
+          argv.target.should.equal('baz')
+          return done()
+        })
+        .argv
+    })
+
     it('does not execute default command if another command is provided', (done) => {
       yargs('run bcoe --foo bar')
         .command('*', 'default command', noop, (argv) => {})

--- a/yargs.js
+++ b/yargs.js
@@ -985,6 +985,9 @@ function Yargs (processArgs, cwd, parentRequire) {
           if (recommendCommands && firstUnknownCommand && !argv[helpOpt]) {
             validation.recommendCommands(firstUnknownCommand, handlerKeys)
           }
+        } else if (command.hasDefaultCommand() && !argv[helpOpt]) {
+          setPlaceholderKeys(argv)
+          return command.runCommand(null, self, parsed)
         }
 
         // generate a completion script for adding to ~/.bashrc.


### PR DESCRIPTION
This ensures that the default command is executed even if the default command
is the only command that is defined.