### PR TITLE
[WIP] Implies support object with AND / OR / ONE directives (arg inter-dependencies)

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -344,7 +344,7 @@ module.exports = function validation (yargs, usage, y18n) {
       implyFail.forEach((key) => {
         if (implied[key]) {
           implied[key].forEach((value) => {
-            if (typeof implied[key] === 'object') {
+            if (typeof value === 'object') {
               msg += (` ${key} -> ${Object.keys(value).map(k => conditions[k].error(value[k])).join(', and ')}`)
             } else {
               msg += (` ${key} -> ${value}`)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -219,7 +219,7 @@ module.exports = function validation (yargs, usage, y18n) {
   // check implications, argument foo implies => argument bar.
   let implied = {}
   self.implies = function implies (key, value) {
-    argsert('<string|object> [array|number|string]', [key, value], arguments.length)
+    argsert('<string|object> [array|number|string|object]', [key, value], arguments.length)
 
     if (typeof key === 'object') {
       Object.keys(key).forEach((k) => {
@@ -233,7 +233,19 @@ module.exports = function validation (yargs, usage, y18n) {
       if (Array.isArray(value)) {
         value.forEach((i) => self.implies(key, i))
       } else {
-        implied[key].push(value)
+        if (typeof value === 'object') {
+          const valueCopy = Object.assign({}, value)
+
+          for (let k in valueCopy) {
+            if (typeof valueCopy[k] === 'string') {
+              valueCopy[k] = [valueCopy[k]]
+            }
+          }
+
+          implied[key].push(valueCopy)
+        } else {
+          implied[key].push(value)
+        }
       }
     }
   }
@@ -243,6 +255,35 @@ module.exports = function validation (yargs, usage, y18n) {
 
   self.implications = function implications (argv) {
     const implyFail = []
+    const conditions = {
+      and: {
+        error: (depKeys) => `need ${depKeys.join(' and ')} options`,
+        satisfy: (depKeys) => (
+          depKeys.reduce(
+            (res, key) => res && !!argv[key],
+            true
+          )
+        )
+      },
+      or: {
+        error: (depKeys) => `need ${depKeys.join(' or ')} options`,
+        satisfy: (depKeys) => (
+          depKeys.reduce(
+            (res, key) => res || !!argv[key],
+            depKeys.length === 0
+          )
+        )
+      },
+      one: {
+        error: (depKeys) => `need one ${depKeys.join(' or ')} option`,
+        satisfy: (depKeys) => (
+          depKeys
+            .map(key => !!argv[key])
+            .filter(v => v)
+            .length === 1
+        )
+      }
+    }
 
     Object.keys(implied).forEach((key) => {
       const origKey = key
@@ -266,17 +307,31 @@ module.exports = function validation (yargs, usage, y18n) {
           key = argv[key]
         }
 
-        num = Number(value)
+        num = (typeof value === 'object') ? NaN : Number(value)
         value = isNaN(num) ? value : num
 
         if (typeof value === 'number') {
           value = argv._.length >= value
+        } else if (typeof value === 'object') {
+          let isSatisfied = true
+
+          Object.keys(conditions).forEach((c) => {
+            if (value[c]) {
+              isSatisfied = isSatisfied && conditions[c].satisfy(value[c])
+            }
+          })
+
+          if (!isSatisfied) {
+            implyFail.push(origKey)
+            return
+          }
         } else if (value.match(/^--no-.+/)) {
           value = value.match(/^--no-(.+)/)[1]
           value = !argv[value]
         } else {
           value = argv[value]
         }
+
         if (key && !value) {
           implyFail.push(origKey)
         }
@@ -289,7 +344,11 @@ module.exports = function validation (yargs, usage, y18n) {
       implyFail.forEach((key) => {
         if (implied[key]) {
           implied[key].forEach((value) => {
-            msg += (` ${key} -> ${value}`)
+            if (typeof implied[key] === 'object') {
+              msg += (` ${key} -> ${Object.keys(value).map(k => conditions[k].error(value[k])).join(', and ')}`)
+            } else {
+              msg += (` ${key} -> ${value}`)
+            }
           })
         }
       })

--- a/test/validation.js
+++ b/test/validation.js
@@ -153,6 +153,155 @@ describe('validation tests', () => {
         })
         .argv
     })
+
+    it('allows to pass an object with AND/OR option but fails when missing one', (done) => {
+      yargs('--bar --foo --bar-bar')
+        .option('bar', {
+          implies: {
+            and: ['foo', 'foo-foo'],
+            or: 'bar-bar'
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('allows to pass an object with AND/OR option but succeed if match the criteria', () => {
+      let failCalled = false
+      yargs('--bar --foo --foo-foo')
+        .option('bar', {
+          implies: {
+            and: ['foo-foo'],
+            or: ['foo', 'bar-bar']
+          }
+        })
+        .fail((msg) => {
+          failCalled = true
+        })
+        .argv
+
+      failCalled.should.be.false
+    })
+
+    it('fails if OR condition is satisfied but not AND condition', (done) => {
+      yargs('--bar --bar-bar')
+        .option('bar', {
+          implies: {
+            and: ['foo', 'foo-foo'],
+            or: 'bar-bar'
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails if AND condition is satisfied but not OR condition', (done) => {
+      yargs('--bar --foo')
+        .option('bar', {
+          implies: {
+            and: 'foo',
+            or: 'bar-bar'
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails if ONE option is set, and it matches more than one option', (done) => {
+      yargs('--bar --foo --foo-bar')
+        .option('bar', {
+          implies: {
+            one: ['foo', 'foo-bar']
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails if ONE option is set, and it matches no option', (done) => {
+      yargs('--bar')
+        .option('bar', {
+          implies: {
+            one: ['foo', 'foo-bar']
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('allows to pass an object with ONE option', () => {
+      let failCalled = false
+      yargs('--bar --foo')
+        .option('bar', {
+          implies: {
+            one: ['foo', 'foo-foo']
+          }
+        })
+        .fail((msg) => {
+          failCalled = true
+        })
+        .argv
+      failCalled.should.be.false
+    })
+
+    it('allows to pass an object with OR option', () => {
+      let failCalled = false
+      yargs('--bar --foo')
+        .option('bar', {
+          implies: {
+            or: ['foo', 'foo-foo']
+          }
+        })
+        .fail((msg) => {
+          failCalled = true
+        })
+        .argv
+
+      failCalled.should.be.false
+    })
+
+    it('fails if no arguments in "or" is supplied with implied key', (done) => {
+      yargs('--bar')
+        .option('bar', {
+          implies: {
+            or: ['foo', 'foo-foo']
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails if one of two arguments in "and" is supplied with implied key', (done) => {
+      yargs('--bar --foo')
+        .option('bar', {
+          implies: {
+            and: ['foo', 'foo-foo']
+          }
+        })
+        .fail((msg) => {
+          msg.should.match(/Implications failed/)
+          return done()
+        })
+        .argv
+    })
   })
 
   describe('conflicts', () => {

--- a/yargs.js
+++ b/yargs.js
@@ -416,7 +416,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self.implies = function (key, value) {
-    argsert('<string|object> [number|string|array]', [key, value], arguments.length)
+    argsert('<string|object> [number|string|array|object]', [key, value], arguments.length)
     validation.implies(key, value)
     return self
   }


### PR DESCRIPTION
Hi there !

## Goal

Still far from finished, but I wanted to add some new level of validation with inter-dependencies between arguments. 

Today `implies` only allow for args to require N arguments with no logic behind it. With this PR you can define a behavior for `implies` (AND/OR/ONE).

I'm sorry, the code is a bit messy atm, but some operation would be way easier with `lodash` or something like it, but I won't force a new dependencies for your project so i'll try to clean up as well feel free to review 👍 

## TODO 

* [ ] Documentation
* [x] Fix tests... 
* [x] Add tests...
* [x] Implies accept object with AND / OR / ONE
* [ ] Error messages (better infos + spelling) + tests cases (spelling)

## Examples : 

### When`r` is set `p` is required and one or more of `s` or `v` is required.
```sh
> var yargs = require('./index.js')
undefined
> yargs('-r -s -p').option('r', { implies: { or: ['s', 'v'], and: ['p'] }}).argv
{ _: [],
  help: false,
  version: false,
  r: true,
  s: true,
  p: true,
  '$0': '' }
>
> yargs('-r -s').option('r', { implies: { or: ['s', 'v'], and: ['p'] }}).argv
Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Implications failed:
 r -> need s or v options, and need p options
```

### When `r` is set one, and only one of `s`, `v` option is required.

```sh
➜  yargs git:(master) ✗ node
> var yargs = require('./index.js')
undefined
> yargs('-r -s').option('r', { implies: { one: ['s', 'v']  }}).argv
{ _: [], help: false, version: false, r: true, s: true, '$0': '' }
> yargs('-r').option('r', { implies: { one: ['s', 'v']  }}).argv
Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Implications failed:
 r -> need one s or v option
```

Any suggestions are welcome !