### PR TITLE
[feature] add optional errorHandler

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -406,3 +406,18 @@ some of yargs' parsing features:
 
 See the [yargs-parser](https://github.com/yargs/yargs-parser#configuration) module
 for detailed documentation of this feature.
+
+### error Handlers
+
+it is possible to pass an `errorHandler` to commands, to deal with thrown Exceptions or rejected Promises.
+
+```js
+exports.command = 'prune <name> [names..]'
+exports.desc = 'Delete tracked branches gone stale for remotes'
+exports.errorHandler = function(error) {
+  //deal with your error here
+}
+exports.handler = function (argv) {
+  throw new Error("something went wrong");
+}
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -183,7 +183,7 @@ var argv = require('yargs')
   .argv
 ```
 
-.command(cmd, desc, [builder], [handler])
+.command(cmd, desc, [builder], [handler], [errorHandler])
 -----------------------------------------
 .command(cmd, desc, [module])
 -----------------------------
@@ -252,6 +252,31 @@ yargs
   .help()
   .argv
 ```
+
+You can also provide an error handler function, which will be executed with thrown `Error`  or rejected Promises if any.
+
+```js
+yargs
+  .command(
+    'get',
+    'make a get HTTP request',
+    function (yargs) {
+      return yargs.option('u', {
+        alias: 'url',
+        describe: 'the URL to make an HTTP request to'
+      })
+    },
+    function (argv) {
+      throw new Error('test')
+    },
+    function (error) {
+      console.log('error catched', error);
+    }
+  )
+  .help()
+  .argv
+```
+
 
 Please see [Advanced Topics: Commands](https://github.com/yargs/yargs/blob/master/docs/advanced.md#commands) for a thorough
 discussion of the advanced features exposed in the Command API.

--- a/lib/command.js
+++ b/lib/command.js
@@ -14,7 +14,7 @@ module.exports = function command (yargs, usage, validation) {
   let handlers = {}
   let aliasMap = {}
   let defaultCommand
-  self.addHandler = function addHandler (cmd, description, builder, handler) {
+  self.addHandler = function addHandler (cmd, description, builder, handler, errorHandler) {
     let aliases = []
     handler = handler || (() => {})
 
@@ -24,13 +24,13 @@ module.exports = function command (yargs, usage, validation) {
     } else if (typeof cmd === 'object') {
       let command = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
       if (cmd.aliases) command = [].concat(command).concat(cmd.aliases)
-      self.addHandler(command, extractDesc(cmd), cmd.builder, cmd.handler)
+      self.addHandler(command, extractDesc(cmd), cmd.builder, cmd.handler, cmd.errorHandler)
       return
     }
 
     // allow a module to be provided instead of separate builder and handler
     if (typeof builder === 'object' && builder.builder && typeof builder.handler === 'function') {
-      self.addHandler([cmd].concat(aliases), description, builder.builder, builder.handler)
+      self.addHandler([cmd].concat(aliases), description, builder.builder, builder.handler, builder.errorHandler)
       return
     }
 
@@ -55,6 +55,7 @@ module.exports = function command (yargs, usage, validation) {
       defaultCommand = {
         original: cmd.replace(DEFAULT_MARKER, '').trim(),
         handler,
+        errorHandler,
         builder: builder || {},
         demanded: parsedCommand.demanded,
         optional: parsedCommand.optional
@@ -81,6 +82,7 @@ module.exports = function command (yargs, usage, validation) {
     handlers[parsedCommand.cmd] = {
       original: cmd,
       handler,
+      errorHandler,
       builder: builder || {},
       demanded: parsedCommand.demanded,
       optional: parsedCommand.optional
@@ -223,7 +225,26 @@ module.exports = function command (yargs, usage, validation) {
 
     if (commandHandler.handler && !yargs._hasOutput()) {
       yargs._setHasOutput()
-      commandHandler.handler(innerArgv)
+      try {
+        var result = commandHandler.handler(innerArgv)
+        // deal with returned promises
+        if (result && result.catch) {
+          result.catch(function (error) {
+            if (commandHandler.errorHandler) {
+              commandHandler.errorHandler(error)
+            } else {
+              throw error
+            }
+          })
+        }
+      } catch (error) {
+        // deal with thrown errors
+        if (commandHandler.errorHandler) {
+          commandHandler.errorHandler(error)
+        } else {
+          throw error
+        }
+      }
     }
 
     if (command) currentContext.commands.pop()

--- a/test/command.js
+++ b/test/command.js
@@ -495,6 +495,21 @@ describe('Command', () => {
       const cmdCommands = y.getCommandInstance().getCommands()
       cmdCommands.should.deep.equal(['foo', 'bar'])
     })
+
+    it('accepts an errorHandler', () => {
+      const module = {
+        command: ['foo <qux>', 'bar'],
+        aliases: ['baz', 'nat'],
+        describe: 'i\'m not feeling very creative at the moment',
+        builder (yargs) { return yargs },
+        errorHandler (error) { console.log(error) },
+        handler (argv) {}
+      }
+
+      const y = yargs([]).command(module)
+      const handlers = y.getCommandInstance().getCommandHandlers()
+      handlers.foo.errorHandler.should.equal(module.errorHandler)
+    })
   })
 
   describe('commandDir', () => {

--- a/test/fixtures/error-handler-reject.js
+++ b/test/fixtures/error-handler-reject.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+require('../../index')
+.command(
+  '*',
+  'example',
+  function (yargs) { return yargs },
+  function (argv) {
+    return Promise.reject(new Error('test'))
+  },
+  function (error) {
+    console.log('error catched : ' + error.message)
+  }
+)
+.argv

--- a/test/fixtures/error-handler-throw.js
+++ b/test/fixtures/error-handler-throw.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+require('../../index')
+.command(
+  '*',
+  'example',
+  function (yargs) { return yargs },
+  function (argv) {
+    throw new Error('test')
+  },
+  function (error) {
+    console.log('error catched : ' + error.message)
+  }
+)
+.argv

--- a/test/integration.js
+++ b/test/integration.js
@@ -108,6 +108,30 @@ describe('integration tests', () => {
     })
   })
 
+  it('handles errors when simply thrown', function (done) {
+    testCmd('./error-handler-throw.js', [], (code, stdout) => {
+      if (code) {
+        done(new Error(`cmd exited with code ${code}`))
+        return
+      }
+
+      stdout.should.match(/error catched : test/)
+      return done()
+    })
+  })
+
+  it('handles errors when a promise rejects', function (done) {
+    testCmd('./error-handler-reject.js', [], (code, stdout) => {
+      if (code) {
+        done(new Error(`cmd exited with code ${code}`))
+        return
+      }
+
+      stdout.should.match(/error catched : test/)
+      return done()
+    })
+  })
+
   if (process.platform !== 'win32') {
     describe('load root package.json', () => {
       before(function (done) {

--- a/yargs.js
+++ b/yargs.js
@@ -337,9 +337,9 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.command = function (cmd, description, builder, handler) {
-    argsert('<string|array|object> [string|boolean] [function|object] [function]', [cmd, description, builder, handler], arguments.length)
-    command.addHandler(cmd, description, builder, handler)
+  self.command = function (cmd, description, builder, handler, errorHandler) {
+    argsert('<string|array|object> [string|boolean] [function|object] [function] [function]', [cmd, description, builder, handler, errorHandler], arguments.length)
+    command.addHandler(cmd, description, builder, handler, errorHandler)
     return self
   }
 


### PR DESCRIPTION
to be able the handle errors individually thrown by handlers:

```js
require('yargs')
.command(
  '*',
  'example',
  function (yargs) { return yargs },
  function (argv) {
    throw new Error('test')
  },
  function (error) {
    console.log('error catched : ' + error.message)
  }
)
.argv
```

it can handle both, thrown Errors and returned rejected Promises

this fixes #953 