### PR TITLE
fix: show hidden options in help

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -2314,10 +2314,12 @@ describe('usage tests', () => {
       const r = checkUsage(() => yargs(['--help'])
           .option('answer', {
             type: 'string',
-            choices: ['yes', 'no', 'maybe']
+            choices: ['yes', 'no', 'maybe'],
+            hidden: true
           })
           .option('confidence', {
-            choices: [0, 25, 50, 75, 100]
+            choices: [0, 25, 50, 75, 100],
+            hidden: true
           })
           .wrap(null)
           .argv
@@ -2694,6 +2696,33 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help                                                 [boolean]',
         '  --version  Show version number                                       [boolean]',
+        ''
+      ])
+    })
+  })
+
+  describe('hidden options', () => {
+    it('--help should display all options except for hidden ones', () => {
+      const r = checkUsage(() => yargs('--help')
+          .options({
+            foo: {
+              describe: 'FOO'
+            },
+            bar: {},
+            baz: {
+              describe: 'BAZ',
+              hidden: true
+            }
+          })
+          .argv
+        )
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --help     Show help                                                 [boolean]',
+        '  --version  Show version number                                       [boolean]',
+        '  --foo      FOO',
+        '  --bar',
         ''
       ])
     })

--- a/yargs.js
+++ b/yargs.js
@@ -647,7 +647,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       }
 
       const desc = opt.describe || opt.description || opt.desc
-      if (desc) {
+      if (!opt.hidden) {
         self.describe(key, desc)
       }
 


### PR DESCRIPTION
Options with `description: false` will now show up help

fixes #851