### PR TITLE
Support for a custom require function

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ Argv(process.argv.slice(2))
 
 module.exports = Argv
 
-function Argv (processArgs, cwd) {
-  const argv = yargs(processArgs, cwd, require)
+function Argv (processArgs, cwd, parentRequire) {
+  const argv = yargs(processArgs, cwd, parentRequire || require)
   singletonify(argv)
   return argv
 }


### PR DESCRIPTION
The PR to use a custom loader for the commands. Actually all necessary functionality already implemented internally in the Yargs. Thank you guys for the great tool. :)

For example we can use [@std/esm](https://www.npmjs.com/package/@std/esm) as a loader to load the commands written in ES6 modules syntax.
```
const loader = require('@std/esm')(module)
const yargs = require('yargs')

yargs(process.argv.slice(2), undefined, loader)
  .commandDir('cmds', {
    extensions: [ 'js', 'mjs' ]
  })
  .demandCommand()
  .argv
```
cmds/es6.mjs
```
import fs from 'fs'

export const command = 'esm'
export const description = 'The commands can be defined in ES6 modules'

export function handler (argv) {
  console.log("I'm ES6 command!")
}
```