### PR TITLE
chore: switch to find-up from read-pkg-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "decamelize": "^1.1.1",
+    "find-up": "^2.1.0",
     "get-caller-file": "^1.0.1",
     "os-locale": "^2.0.0",
-    "read-pkg-up": "^2.0.0",
     "require-directory": "^2.1.1",
     "require-main-filename": "^1.0.1",
     "set-blocking": "^2.0.0",

--- a/yargs.js
+++ b/yargs.js
@@ -1,5 +1,6 @@
 'use strict'
 const argsert = require('./lib/argsert')
+const fs = require('fs')
 const Command = require('./lib/command')
 const Completion = require('./lib/completion')
 const Parser = require('yargs-parser')
@@ -494,17 +495,18 @@ function Yargs (processArgs, cwd, parentRequire) {
   function pkgUp (path) {
     const npath = path || '*'
     if (pkgs[npath]) return pkgs[npath]
-    const readPkgUp = require('read-pkg-up')
+    const findUp = require('find-up')
 
     let obj = {}
     try {
-      obj = readPkgUp.sync({
+      const pkgJsonPath = findUp.sync('package.json', {
         cwd: path || require('require-main-filename')(parentRequire || require),
         normalize: false
       })
+      obj = JSON.parse(fs.readFileSync(pkgJsonPath))
     } catch (noop) {}
 
-    pkgs[npath] = obj.pkg || {}
+    pkgs[npath] = obj || {}
     return pkgs[npath]
   }
 


### PR DESCRIPTION
`read-pkg-up` has a dependency on [WTFPL](https://github.com/sindresorhus/parse-json/pull/12), which causes licensing issues for npm/Node.js.

`find-up` does pretty much what we need, so I don't see any reason to not simply switch to using it directly CC: @zkat. 

