### PR TITLE
Show hidden options 

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -138,7 +138,7 @@ module.exports = function usage (yargs, y18n) {
   self.deferY18nLookup = str => deferY18nLookupPrefix + str
 
   const defaultGroup = 'Options:'
-  self.help = function help () {
+  self.help = function help (opts) {
     normalizeAliases()
 
     // handle old demanded API
@@ -151,6 +151,7 @@ module.exports = function usage (yargs, y18n) {
       .concat(Object.keys(demandedOptions))
       .concat(Object.keys(demandedCommands))
       .concat(Object.keys(options.default))
+      .filter(key => options.hiddenOptions.indexOf(key) < 0 || (opts && opts.hidden))
       .reduce((acc, key) => {
         if (key !== '_') acc[key] = true
         return acc
@@ -375,11 +376,11 @@ module.exports = function usage (yargs, y18n) {
     return groupedKeys
   }
 
-  self.showHelp = (level) => {
+  self.showHelp = (level, opts) => {
     const logger = yargs._getLoggerInstance()
     if (!level) level = 'error'
     const emit = typeof level === 'function' ? level : logger[level]
-    emit(self.help())
+    emit(self.help(opts))
   }
 
   self.functionDescription = (fn) => {

--- a/test/usage.js
+++ b/test/usage.js
@@ -2726,5 +2726,45 @@ describe('usage tests', () => {
         ''
       ])
     })
+    it('--help should display all options (including hidden ones) with showHelp(log, {hidden: true})', () => {
+      const r = checkUsage(() => {
+        const argv = yargs('--help --show-hidden')
+          .help(false)
+          .options({
+            foo: {
+              describe: 'FOO'
+            },
+            bar: {},
+            baz: {
+              describe: 'BAZ',
+              hidden: true
+            },
+            'help': {
+              describe: 'Show help',
+              type: 'boolean'
+            },
+            'show-hidden': {
+              describe: 'Show hidden options',
+              type: 'boolean'
+            }
+          })
+          .argv
+
+        if (yargs.help) {
+          yargs.showHelp('log', {hidden: argv.showHidden})
+        }
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --version      Show version number                                   [boolean]',
+        '  --foo          FOO',
+        '  --bar',
+        '  --baz          BAZ',
+        '  --help         Show help                                             [boolean]',
+        '  --show-hidden  Show hidden options                                   [boolean]',
+        ''
+      ])
+    })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -246,6 +246,7 @@ describe('yargs dsl tests', () => {
         config: {},
         configObjects: [],
         envPrefix: 'YARGS', // preserved as global
+        hiddenOptions: [],
         demandedCommands: {},
         demandedOptions: {},
         local: [

--- a/yargs.js
+++ b/yargs.js
@@ -93,7 +93,8 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     const arrayOptions = [
       'array', 'boolean', 'string', 'requiresArg', 'skipValidation',
-      'count', 'normalize', 'number'
+      'count', 'normalize', 'number',
+      'hiddenOptions'
     ]
 
     const objectOptions = [
@@ -647,8 +648,9 @@ function Yargs (processArgs, cwd, parentRequire) {
       }
 
       const desc = opt.describe || opt.description || opt.desc
-      if (!opt.hidden) {
-        self.describe(key, desc)
+      self.describe(key, desc)
+      if (opt.hidden) {
+        options.hiddenOptions.push(key)
       }
 
       if (opt.requiresArg) {
@@ -738,10 +740,10 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
   self.getStrict = () => strict
 
-  self.showHelp = function (level) {
-    argsert('[string|function]', [level], arguments.length)
+  self.showHelp = function (level, opts) {
+    argsert('[string|function] [object]', [level, opts], arguments.length)
     if (!self.parsed) self._parseArgs(processArgs) // run parser, if it has not already been executed.
-    usage.showHelp(level)
+    usage.showHelp(level, opts)
     return self
   }
 


### PR DESCRIPTION
In #962 a new option was added `{hidden: true}` that hides an option from `--help` (instead of by omitting the description)

To show these hidden options, one of the suggestion was to use `--yargs-show-hidden` (@gajus). 

How about instead, modify the `showHelp` like this:

```js
yargs.showHelp('log', {showHidden: [true|false]})
```

This gives the user more control. Like maybe they wouldn't want to show hidden commands at all. Or maybe they'd want it behind a custom flag. This way they can implement it themselves. 

It however require that the user implements the `--help` themselves too:

```js
const argv = yargs
  .options({
    baz: {
      describe: 'BAZ',
      hidden: true
    },
    'show-hidden': {
      describe: 'Show hidden options',
      type: 'boolean'
    },
  })
  .help(false)
  .argv

if (yargs.help) {
  yargs.showHelp('log', {hidden: argv.showHidden})
}
```
