### PR TITLE
chore: new translations for command API overhaul

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -36,5 +36,7 @@
   "Show help": "Show help",
   "Show version number": "Show version number",
   "Did you mean %s?": "Did you mean %s?",
-  "Arguments %s and %s are mutually exclusive" : "Arguments %s and %s are mutually exclusive"
+  "Arguments %s and %s are mutually exclusive" : "Arguments %s and %s are mutually exclusive",
+  "Positionals:": "Positionals:",
+  "command": "command"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -35,5 +35,8 @@
   "Path to JSON config file": "JSON 설정파일 경로",
   "Show help": "도움말을 보여줍니다",
   "Show version number": "버전 넘버를 보여줍니다",
-  "Did you mean %s?": "찾고계신게 %s입니까?"
+  "Did you mean %s?": "찾고계신게 %s입니까?",
+  "Arguments %s and %s are mutually exclusive" : "%s와 %s 인자는 같이 사용될 수 없습니다",
+  "Positionals:": "위치:",
+  "command": "명령"
 }

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -2,7 +2,7 @@
   "Commands:": "Comandos:",
   "Options:": "Opções:",
   "Examples:": "Exemplos:",
-  "boolean": "boolean",
+  "boolean": "booleano",
   "count": "contagem",
   "string": "string",
   "number": "número",
@@ -36,5 +36,7 @@
   "Show help": "Exibe ajuda",
   "Show version number": "Exibe a versão",
   "Did you mean %s?": "Você quis dizer %s?",
-  "Arguments %s and %s are mutually exclusive" : "Argumentos %s e %s são mutualmente exclusivos"
+  "Arguments %s and %s are mutually exclusive" : "Argumentos %s e %s são mutualmente exclusivos",
+  "Positionals:": "Posicionais:",
+  "command": "comando"
 }


### PR DESCRIPTION
Sorry for mentioning so many folks. 

I've been undertaking an overhaul of the `.command()` and `.usage()` API (introducing the concept of [`.positional()`](https://github.com/yargs/yargs/blob/f5bc44c66278c28404552c7b292a8f8f53ca4f29/docs/api.md#positionalkey-opt)).

In the process I've introduced a couple more words to the English language file:

```json
{
"Positionals:": "Positionals:",
"command": "command"
}
```

I would love help updating the files for each languages to reflect these new terms.

_... I would also love help testing the new features..._

Given that `yargs@10` represents a pretty large update to the command API, I would also love help testing. The new features are documented here:

https://github.com/yargs/yargs/blob/f5bc44c66278c28404552c7b292a8f8f53ca4f29/docs/api.md#usagemessagecommand-desc-builder-handler

here,

https://github.com/yargs/yargs/blob/f5bc44c66278c28404552c7b292a8f8f53ca4f29/docs/api.md#positionalkey-opt

and finally here:

https://github.com/yargs/yargs/blob/f5bc44c66278c28404552c7b292a8f8f53ca4f29/docs/api.md#positionalkey-opt

you can test out the candidate release by running:

`npm i yargs@next`

Thank you for your contributions to yargs!

@p0v1n0m , @maxrimue, @zkat , @LoicMahieu, @babhishek21, @Hunrik, @rilut, @madrisan, @oti, @disjukr, @sindresorhus, @Tocive, @kamilogorek, @codemonkey3045 , @madcampos, @lvarayut, @feyzo, @andyhu, @RhinoLu

- [x] ko
- [x] jp
- [x] pt-BR
- [x] en
- [x] tr
- [x]  pl-PL
- [x] nl
- [x] id