### PR TITLE
[Discussion] Replacing "$0" with the executing file's base name

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -3,6 +3,7 @@
 // failures, etc. keeps logging in one place.
 const stringWidth = require('string-width')
 const objFilter = require('./obj-filter')
+const path = require('path')
 const setBlocking = require('set-blocking')
 const YError = require('./yerror')
 
@@ -165,7 +166,7 @@ module.exports = function usage (yargs, y18n) {
 
     // the usage string.
     if (usages.length && !usageDisabled) {
-      const u = self.getUsage().replace(/\$0/g, yargs.$0)
+      const u = self.getUsage().replace(/\$0/g, path.basename(yargs.$0))
       ui.div(`${u}`)
     }
 
@@ -275,7 +276,7 @@ module.exports = function usage (yargs, y18n) {
       ui.div(__('Examples:'))
 
       examples.forEach((example) => {
-        example[0] = example[0].replace(/\$0/g, yargs.$0)
+        example[0] = example[0].replace(/\$0/g, path.basename(yargs.$0))
       })
 
       examples.forEach((example) => {
@@ -304,7 +305,7 @@ module.exports = function usage (yargs, y18n) {
 
     // the usage string.
     if (epilog) {
-      const e = epilog.replace(/\$0/g, yargs.$0)
+      const e = epilog.replace(/\$0/g, path.basename(yargs.$0))
       ui.div(`${e}\n`)
     }
 

--- a/test/command.js
+++ b/test/command.js
@@ -523,7 +523,7 @@ describe('Command', () => {
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
       r.logs[0].split(/\n+/).should.deep.equal([
-        './command dream [command] [opts]',
+        'command dream [command] [opts]',
         'Commands:',
         '  of-memory <memory>               Dream about a specific memory',
         '  within-a-dream [command] [opts]  Dream within a dream',
@@ -595,7 +595,7 @@ describe('Command', () => {
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
       r.logs.join('\n').split(/\n+/).should.deep.equal([
-        './command cyclic',
+        'command cyclic',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -665,7 +665,7 @@ describe('Command', () => {
           .argv, [ './command' ])
 
       const expectedCmd = [
-        './command cmd <sub>',
+        'command cmd <sub>',
         'Commands:',
         '  sub  Run the subcommand',
         'Options:',
@@ -675,7 +675,7 @@ describe('Command', () => {
       ]
 
       const expectedSub = [
-        './command cmd sub',
+        'command cmd sub',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',

--- a/test/usage.js
+++ b/test/usage.js
@@ -30,7 +30,7 @@ describe('usage tests', () => {
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -x NUM -y NUM',
+          'Usage: usage -x NUM -y NUM',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -54,7 +54,7 @@ describe('usage tests', () => {
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(1)
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
+          'Usage: usage -w NUM -m NUM',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -78,7 +78,7 @@ describe('usage tests', () => {
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(0)
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
+          'Usage: usage -w NUM -m NUM',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -119,7 +119,7 @@ describe('usage tests', () => {
           r.result.should.have.property('z', 20)
           r.result.should.have.property('_').with.length(0)
           r.errors.join('\n').split(/\n+/).should.deep.equal([
-            'Usage: ./usage -x NUM -y NUM',
+            'Usage: usage -x NUM -y NUM',
             'Options:',
             '  --help     Show help  [boolean]',
             '  --version  Show version number  [boolean]',
@@ -142,7 +142,7 @@ describe('usage tests', () => {
           r.result.should.have.property('y', 10)
           r.result.should.have.property('_').with.length(1)
           r.errors.join('\n').split(/\n+/).should.deep.equal([
-            'Usage: ./usage -w NUM -m NUM',
+            'Usage: usage -w NUM -m NUM',
             'Options:',
             '  --help     Show help  [boolean]',
             '  --version  Show version number  [boolean]',
@@ -167,7 +167,7 @@ describe('usage tests', () => {
         r.result.should.have.property('y', 10)
         r.result.should.have.property('_').with.length(0)
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -w NUM -m NUM',
+          'Usage: usage -w NUM -m NUM',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -190,7 +190,7 @@ describe('usage tests', () => {
       r.result.should.have.property('z', 20)
       r.result.should.have.property('_').with.length(0)
       r.errors.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage -x NUM -y NUM',
+        'Usage: usage -x NUM -y NUM',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -347,7 +347,7 @@ describe('usage tests', () => {
     r.result.should.have.property('z', 20)
     r.result.should.have.property('_').with.length(0)
     r.errors.join('\n').split(/\n+/).should.deep.equal([
-      'Usage: ./usage -x NUM -y NUM',
+      'Usage: usage -x NUM -y NUM',
       'Options:',
       '  --help     Show help  [boolean]',
       '  --version  Show version number  [boolean]',
@@ -375,7 +375,7 @@ describe('usage tests', () => {
     r.should.have.property('exit').and.be.ok
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
-      'Usage: ./usage -x NUM -y NUM',
+      'Usage: usage -x NUM -y NUM',
       'Options:',
       '  --help     Show help  [boolean]',
       '  --version  Show version number  [boolean]',
@@ -419,7 +419,7 @@ describe('usage tests', () => {
     r.should.have.property('exit').and.be.ok
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).join('\n').should.equal(
-      'Usage: ./usage -x NUM -y NUM\n' +
+      'Usage: usage -x NUM -y NUM\n' +
       'Options:\n' +
       '  --help     Show help  [boolean]\n' +
       '  --version  Show version number  [boolean]\n' +
@@ -446,7 +446,7 @@ describe('usage tests', () => {
           }
         })
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage -x NUM -y NUM',
+          'Usage: usage -x NUM -y NUM',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -579,7 +579,7 @@ describe('usage tests', () => {
     r.result.should.have.property('moo', true)
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
-      'Usage: ./usage [x] [y] [z] {OPTIONS}',
+      'Usage: usage [x] [y] [z] {OPTIONS}',
       'Options:',
       '  --help     Show help  [boolean]',
       '  --version  Show version number  [boolean]',
@@ -601,7 +601,7 @@ describe('usage tests', () => {
     r.result.should.have.property('moo', true)
     r.should.have.property('errors')
     r.errors.join('\n').split(/\n+/).should.deep.equal([
-      'Usage: ./usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
+      'Usage: usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
       'Options:',
       '  --help     Show help  [boolean]',
       '  --version  Show version number  [boolean]',
@@ -686,7 +686,7 @@ describe('usage tests', () => {
         r.should.have.property('logs').with.length(0)
         r.should.have.property('exit').and.be.ok
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage [options]',
+          'Usage: usage [options]',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -714,7 +714,7 @@ describe('usage tests', () => {
         r.should.have.property('logs').with.length(0)
         r.should.have.property('exit').and.be.ok
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage [options]',
+          'Usage: usage [options]',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -745,7 +745,7 @@ describe('usage tests', () => {
         r.should.have.property('logs').with.length(0)
         r.should.have.property('exit').and.be.ok
         r.errors.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage [options]',
+          'Usage: usage [options]',
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
@@ -794,7 +794,7 @@ describe('usage tests', () => {
       r.result.should.have.property('baz', 30)
       r.should.have.property('errors')
       r.errors.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage [options]',
+        'Usage: usage [options]',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -829,7 +829,7 @@ describe('usage tests', () => {
       r.result.should.have.property('baz', 30)
       r.should.have.property('errors')
       r.errors.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage [options]',
+        'Usage: usage [options]',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -865,7 +865,7 @@ describe('usage tests', () => {
       r.result.should.have.property('q', 40)
       r.should.have.property('errors')
       r.errors.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage [options]',
+        'Usage: usage [options]',
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
@@ -919,8 +919,8 @@ describe('usage tests', () => {
       '  --version  Show version number  [boolean]',
       '  -y  [required]',
       'Examples:',
-      '  ./usage something       description',
-      '  ./usage something else  other description',
+      '  usage something       description',
+      '  usage something else  other description',
       'Missing required argument: y'
     ])
   })
@@ -941,7 +941,7 @@ describe('usage tests', () => {
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
         r.errors.join('\n').split(/\n/).should.deep.equal([
-          'Usage: ./usage -x NUM [-y NUM]',
+          'Usage: usage -x NUM [-y NUM]',
           '',
           'Options:',
           '  --help     Show help  [boolean]',
@@ -971,7 +971,7 @@ describe('usage tests', () => {
         r.result.should.have.property('z', 20)
         r.result.should.have.property('_').with.length(0)
         r.errors.join('\n').split(/\n/).should.deep.equal([
-          'Usage: ./usage -x NUM [-y NUM]',
+          'Usage: usage -x NUM [-y NUM]',
           '',
           'Options:',
           '  --help     Show help  [boolean]',
@@ -1038,7 +1038,7 @@ describe('usage tests', () => {
       r.should.have.property('errors').with.length(0)
       r.should.have.property('logs')
       r.logs.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage options',
+        'Usage: usage options',
         'Options:',
         '  --help      Show help  [boolean]',
         '  --version   Show version number  [boolean]',
@@ -1066,7 +1066,7 @@ describe('usage tests', () => {
         r.should.have.property('errors').with.length(0)
         r.should.have.property('logs')
         r.logs.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage options',
+          'Usage: usage options',
           'Options:',
           '  --help, -h  Show help  [boolean]',
           '  --version   Show version number  [boolean]',
@@ -1096,7 +1096,7 @@ describe('usage tests', () => {
         r.should.have.property('errors').with.length(0)
         r.should.have.property('logs')
         r.logs.join('\n').split(/\n+/).should.deep.equal([
-          'Usage: ./usage options',
+          'Usage: usage options',
           'Options:',
           '  --help, -h  Show help  [boolean]',
           '  --version   Show version number  [boolean]',
@@ -1495,7 +1495,7 @@ describe('usage tests', () => {
         ''
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
-        './usage upload <dest>',
+        'usage upload <dest>',
         '',
         'Options:',
         '  --help     Show help  [boolean]',
@@ -1537,7 +1537,7 @@ describe('usage tests', () => {
         ''
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
-        './usage upload <dest>',
+        'usage upload <dest>',
         '',
         'Options:',
         '  --help     Show help               [boolean]',
@@ -1563,7 +1563,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage upload',
+        'usage upload',
         '',
         'Flags:',
         '  -q  [boolean]',
@@ -1601,7 +1601,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage upload',
+        'usage upload',
         '',
         'Flags:',
         '  -q  [boolean]',
@@ -1635,7 +1635,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage upload',
+        'usage upload',
         '',
         'Awesome Flags:',
         '  -i  [boolean]',
@@ -1673,7 +1673,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage upload',
+        'usage upload',
         '',
         'Awesome Flags:',
         '  -i  [boolean]',
@@ -1756,7 +1756,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage one two [next]',
+        'usage one two [next]',
         '',
         'Options:',
         '  --help     Show help  [boolean]',
@@ -1773,7 +1773,7 @@ describe('usage tests', () => {
         )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage one two [next]',
+        'usage one two [next]',
         '',
         'Options:',
         '  --help     Show help  [boolean]',
@@ -1826,8 +1826,8 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage upload [something]',
-        './usage upload [something else]',
+        'usage upload [something]',
+        'usage upload [something else]',
         '',
         'Options:',
         '  --help     Show help  [boolean]',
@@ -1884,7 +1884,7 @@ describe('usage tests', () => {
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
         '  -y  [required]',
-        'Try \'./usage --long-help\' for more information',
+        'Try \'usage --long-help\' for more information',
         'Missing required argument: y'
       ])
     })
@@ -2571,7 +2571,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list [pattern]',
+        'usage list [pattern]',
         '',
         'Positionals:',
         '  pattern  the pattern to list keys for',
@@ -2594,7 +2594,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list [pattern...]',
+        'usage list [pattern...]',
         '',
         'Positionals:',
         '  pattern  the pattern to list keys for                    [array] [default: []]',
@@ -2617,7 +2617,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list <pattern>',
+        'usage list <pattern>',
         '',
         'Positionals:',
         '  pattern  the pattern to list keys for                               [required]',
@@ -2640,7 +2640,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list [pattern|thingy]',
+        'usage list [pattern|thingy]',
         '',
         'Positionals:',
         '  pattern, thingy  the pattern to list keys for',
@@ -2664,7 +2664,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list [pattern]',
+        'usage list [pattern]',
         '',
         'Positionals:',
         '  pattern  the pattern to list keys for                                 [string]',
@@ -2688,7 +2688,7 @@ describe('usage tests', () => {
       )
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage list [pattern]',
+        'usage list [pattern]',
         '',
         'Positionals:',
         '  pattern  the pattern to list keys for                  [choices: "foo", "bar"]',

--- a/test/validation.js
+++ b/test/validation.js
@@ -793,7 +793,7 @@ describe('validation tests', () => {
       r.should.have.property('exit').and.be.ok
       r.result.should.have.property('_').and.deep.equal(['src', 'dest'])
       r.errors.join('\n').split(/\n+/).should.deep.equal([
-        'Usage: ./usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
+        'Usage: usage [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]',
         'too many arguments are provided'
       ])
     })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -369,7 +369,7 @@ describe('yargs dsl tests', () => {
       })
 
       r.logs[0].split('\n').should.deep.equal([
-        './usage blerg',
+        'usage blerg',
         '',
         'Commands:',
         '  snuh  snuh command',


### PR DESCRIPTION
This PR changes the behavior of the `$0` token (when used within the contents of the `usage`, `epilog` and/or `example` methods), so that it displays the executing file's basename, as opposed to the full path. This has the affect of providing default help text that is closer to what the end-user would actually run, since they would likely be running the CLI on their path (or via an `package.json` script), as opposed to using the CLI's entrypoint script path.

This is a breaking change, but since #975 introduces a breaking change for the `usage` method, I figured I'd put this PR out for discussion's sake. I updated all of the tests to ensure they still pass, but there may be other scenarios that this change would break, so I'd love some feedback.

I'm also not entirely sure this is the right behavior (e.h. as opposed to introducing a new token ala `$$0` or something, etc.), and I'm sure this conversation has been had a bunch of times already, so I'd love feedback and/or pointers to an existing/better solution for this. Thanks!

---

**Before this change (using a Yargs-based CLI named `kyte`):**

<img width="586" alt="screen shot 2017-10-15 at 1 42 25 pm" src="https://user-images.githubusercontent.com/116461/31589008-04238874-b1af-11e7-9d2b-2443e734bcf4.png">

**After this change:**

<img width="578" alt="screen shot 2017-10-15 at 6 16 02 pm" src="https://user-images.githubusercontent.com/116461/31591545-8d94efe6-b1d5-11e7-856e-086f8a155b48.png">

CC @bcoe 