### PR TITLE
fix: parse array rather than string, so that quotes are safe

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -318,15 +318,16 @@ module.exports = function command (yargs, usage, validation) {
 
     const unparsed = []
     Object.keys(positionalMap).forEach((key) => {
-      [].push.apply(unparsed, positionalMap[key].map((value) => {
-        return `--${key} ${value}`
-      }))
+      positionalMap[key].map((value) => {
+        unparsed.push(`--${key}`)
+        unparsed.push(value)
+      })
     })
 
     // short-circuit parse.
     if (!unparsed.length) return
 
-    const parsed = Parser.detailed(unparsed.join(' '), options)
+    const parsed = Parser.detailed(unparsed, options)
 
     if (parsed.error) {
       yargs.getUsageInstance().fail(parsed.error.message, parsed.error)


### PR DESCRIPTION
converting the positional commands being parsed to a string resulted in some edge-cases when parsing positional arguments of the form "Foo Bar".