### PR TITLE
Async command handlers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -662,10 +662,10 @@ Examples will be printed out as part of the help message.
 <a name="exitprocess"></a>.exitProcess(enable)
 ----------------------------------
 
-By default, yargs exits the process when the user passes a help flag, uses the
-`.version` functionality, or when validation fails. Calling
-`.exitProcess(false)` disables this behavior, enabling further actions after
-yargs have been validated.
+By default, yargs exits the process when the user passes a help flag, the user
+uses the `.version` functionality, validation fails, or the command handler
+fails. Calling `.exitProcess(false)` disables this behavior, enabling further
+actions after yargs have been validated.
 
 <a name="fail"></a>.fail(fn)
 ---------

--- a/lib/command.js
+++ b/lib/command.js
@@ -225,7 +225,13 @@ module.exports = function command (yargs, usage, validation) {
 
     if (commandHandler.handler && !yargs._hasOutput()) {
       yargs._setHasOutput()
-      commandHandler.handler(innerArgv)
+      const handlerResult = commandHandler.handler(innerArgv)
+      if (handlerResult && typeof handlerResult.then === 'function') {
+        handlerResult.then(
+          null,
+          (error) => yargs.getUsageInstance().fail(null, error)
+        )
+      }
     }
 
     if (command) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -46,9 +46,9 @@ module.exports = function usage (yargs, y18n) {
       if (!failureOutput) {
         failureOutput = true
         if (showHelpOnFail) yargs.showHelp('error')
-        if (msg) logger.error(msg)
+        if (msg || err) logger.error(msg || err)
         if (failMessage) {
-          if (msg) logger.error('')
+          if (msg || err) logger.error('')
           logger.error(failMessage)
         }
       }

--- a/test/command.js
+++ b/test/command.js
@@ -1402,4 +1402,17 @@ describe('Command', () => {
       }).to.throw(/.*\.usage\(\) description must start with \$0.*/)
     })
   })
+
+  // addresses https://github.com/yargs/yargs/issues/510
+  it('fails when the promise returned by the command handler rejects', (done) => {
+    const error = new Error()
+    yargs('foo')
+      .command('foo', 'foo command', noop, (yargs) => Promise.reject(error))
+      .fail((msg, err) => {
+        expect(msg).to.equal(null)
+        expect(err).to.equal(error)
+        done()
+      })
+      .argv
+  })
 })


### PR DESCRIPTION
Addresses issue #510 ~~"Allow command handler to accept a promise"~~ "Support async (i.e. promise-returning) command handlers"

> we'd just need to update the argument validation and invocation of a command handler to understand a promise

This PR handles "update [...] invocation of a command handler to understand a promise". Nothing is done if the promise resolves, but if it rejects, it is handled as ["failure"](https://github.com/zenflow/yargs/blob/master/docs/api.md#failfn) with an `err` but no `msg`.

@bcoe Not sure what needs to be done about "update the argument validation"... It seems like there's no change needed; arguments to command handlers, and validation of said arguments, aren't affected by this feature. This feature deals only with what is *returned* by the command handler (a promise, potentially). Am I missing something?

This PR also makes a slight change to the default failure handler, so that if there's no `msg` but there is an `err`, `err` will be logged instead, which will display the full stack trace for debugging.

Thank you for your work on this project, and taking the time to review this change :)