### PR TITLE
Add failing test for using positional

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1996,6 +1996,21 @@ describe('yargs dsl tests', () => {
       argv.heroes.should.eql(['batman', 'Iron Man'])
     })
 
+    it('allows using a positional of type string', (done) => {
+      yargs('cmd')
+        .command('cmd deploy <version>', 'a command', (yargs) => {
+          yargs.positional('version', {
+            type: 'string'
+          })
+        }).parse('cmd deploy 123e123', (err, argv) => {
+          if (err) {
+            return done(err)
+          }
+          argv.version.should.eql(['123e123'])
+          return done()
+        })
+    })
+
     it('allows an implied argument to be specified', (done) => {
       yargs()
         .command('cmd <hero>', 'a command', (yargs) => {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -2002,8 +2002,8 @@ describe('yargs dsl tests', () => {
           yargs
             .version(false)
             .positional('version', {
-            type: 'string'
-          })
+              type: 'string'
+            })
         }).parse('cmd deploy 123e123', (err, argv) => {
           if (err) {
             return done(err)

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1999,14 +1999,16 @@ describe('yargs dsl tests', () => {
     it('allows using a positional of type string', (done) => {
       yargs('cmd')
         .command('cmd deploy <version>', 'a command', (yargs) => {
-          yargs.positional('version', {
+          yargs
+            .version(false)
+            .positional('version', {
             type: 'string'
           })
         }).parse('cmd deploy 123e123', (err, argv) => {
           if (err) {
             return done(err)
           }
-          argv.version.should.eql(['123e123'])
+          argv.version.should.eql('123e123')
           return done()
         })
     })


### PR DESCRIPTION
Hello,

We have encountered what appears to be a bug in handling positionals of type string. As you can see from the failed test, yargs is parsing the example as a boolean.

We are unsure if this is a bug or if we are doing someting wrong.

We are happy to provide a fix, if you can confirm this is a bug.