### PR TITLE
Use chai 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "yargs-parser": "^8.1.0"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
+    "chai": "^4.1.2",
     "chalk": "^1.1.3",
     "coveralls": "^2.11.11",
     "cpr": "^2.0.0",

--- a/test/command.js
+++ b/test/command.js
@@ -5,7 +5,6 @@ const expect = require('chai').expect
 const checkOutput = require('./helpers/utils').checkOutput
 
 require('chai').should()
-
 const noop = () => {}
 
 describe('Command', () => {
@@ -19,11 +18,11 @@ describe('Command', () => {
         .command('foo <bar> [awesome]', 'my awesome command', yargs => yargs)
       const command = y.getCommandInstance()
       const handlers = command.getCommandHandlers()
-      handlers.foo.demanded.should.include({
+      handlers.foo.demanded.should.deep.include({
         cmd: ['bar'],
         variadic: false
       })
-      handlers.foo.optional.should.include({
+      handlers.foo.optional.should.deep.include({
         cmd: ['awesome'],
         variadic: false
       })
@@ -94,7 +93,7 @@ describe('Command', () => {
         .command(['foo [awesome]', 'wat <yo>'], 'my awesome command')
       const command = y.getCommandInstance()
       const handlers = command.getCommandHandlers()
-      handlers.foo.optional.should.include({
+      handlers.foo.optional.should.deep.include({
         cmd: ['awesome'],
         variadic: false
       })


### PR DESCRIPTION
This fix is required to package chai for Debian.

From a Debian packager:
> (...) in debian, we want to use a single version of chai for all
modules we ship and some modules need chai 4. So we need to port all
modules still using chai < 4 to chain 4.x.

I've updated the tests accordingly, and tested for stylistic differences. Please let me know if anything else is to be done!