### PR TITLE
Fix #969 by expanding context and adding a .yargsOptions function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1334,3 +1334,12 @@ Format usage output to wrap at `columns` many columns.
 By default wrap will be set to `Math.min(80, windowWidth)`. Use `.wrap(null)` to
 specify no column limit (no right-align). Use `.wrap(yargs.terminalWidth())` to
 maximize the width of yargs' usage instructions.
+
+<a name="yargsOptions"></a>.yargsOptions(options)
+-------------------------------------------------
+
+Change the internal behaviour of yargs.
+
+`options` is an object. Valid keys include:
+
+- `printTypes`: Boolean indicating if types should be printed in the help message (Default = `true`).

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -271,6 +271,7 @@ module.exports = function usage (yargs, y18n) {
         const kswitch = switches[key]
         let desc = descriptions[key] || ''
         let type = null
+        const context = yargs.getContext()
 
         if (~desc.lastIndexOf(deferY18nLookupPrefix)) desc = __(desc.substring(deferY18nLookupPrefix.length))
 
@@ -282,7 +283,7 @@ module.exports = function usage (yargs, y18n) {
         if (~options.number.indexOf(key)) type = `[${__('number')}]`
 
         const extra = [
-          type,
+          context.printTypes ? type : null,
           (key in demandedOptions) ? `[${__('required')}]` : null,
           options.choices && options.choices[key] ? `[${__('choices:')} ${
             self.stringifiedValues(options.choices[key])}]` : null,

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -129,6 +129,64 @@ describe('yargs dsl tests', () => {
     expect(r.errors).to.deep.equal([])
   })
 
+  describe('yargsOptions', () => {
+    it('should show types in the help message by default', () => {
+      const r = checkOutput(() => yargs('--help')
+        .option('a', {type: 'boolean', describe: 'Set -a'})
+        .option('b', {type: 'array', describe: 'Set -b'})
+        .option('c', {type: 'number', describe: 'Set -c'})
+        .option('d', {type: 'string', describe: 'Set -d'})
+        .wrap(null)
+        .argv
+      )
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -a         Set -a  [boolean]',
+        '  -b         Set -b  [array]',
+        '  -c         Set -c  [number]',
+        '  -d         Set -d  [string]',
+        ''
+      ])
+    })
+
+    it('should not print types when printTypes is false', () => {
+      const r = checkOutput(() => yargs('--help')
+        .yargsOptions({
+          printTypes: false
+        })
+        .option('a', {type: 'boolean', describe: 'Set -a'})
+        .option('b', {type: 'array', describe: 'Set -b'})
+        .option('c', {type: 'number', describe: 'Set -c'})
+        .option('d', {type: 'string', describe: 'Set -d'})
+        .wrap(null)
+        .argv
+      )
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --help     Show help',
+        '  --version  Show version number',
+        '  -a         Set -a',
+        '  -b         Set -b',
+        '  -c         Set -c',
+        '  -d         Set -d',
+        ''
+      ])
+    })
+
+    it('should throw an error when an invalid option is given', () => {
+      expect(() => {
+        yargs('--help')
+          .yargsOptions({
+            nonexistantProperty: 'abc'
+          })
+          .wrap(null)
+          .argv
+      }).to.throw(/Unrecognized key nonexistantProperty/)
+    })
+  })
+
   describe('showHelpOnFail', () => {
     it('should display custom failure message, if string is provided as first argument', () => {
       const r = checkOutput(() => yargs([])

--- a/yargs.js
+++ b/yargs.js
@@ -89,7 +89,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   let options
   self.resetOptions = self.reset = function resetOptions (aliases) {
     context.resets++
-    context
+    context.printTypes = true
     aliases = aliases || {}
     options = options || {}
     // put yargs back into an initial state, this


### PR DESCRIPTION
#969 was a feature request for a way to disable printing type information in the help message. Several maintainers were reluctant to add yet another toggle to the API. I solved this by creating a new function that can be reused for other toggles/value setters. It might even be possible to depreciate several toggles in the current API.

`.yargsOptions` is used for setting internal yargs options to change the default behavior. It allows the user to change properties of the internal `context` object and will throw an error if an unrecognized key is given.

The only key `.yargsOptions` will currently accept is `printTypes`. `printTypes` is a new property I added to `context`. When false, the options will not have their types printed in the help message.

I have added documentation and unit tests for `.yargsOptions` and `printTypes`.

If you do decide to keep `.yargsOptions`, things like `detectLocale`, `exitProcess`, and `strict` could be removed as functions and replaced with keys for `.yargsOptions`.

I choose the name yargsOptions because options and config were already taken. If you can think of a better name, go for it.