### PR TITLE
docs(example): add command hierarchy example

### DIFF
--- a/example/cmds/init.js
+++ b/example/cmds/init.js
@@ -1,0 +1,10 @@
+exports.command = 'init [dir]'
+exports.desc = 'Create an empty repo'
+exports.builder = {
+  dir: {
+    default: '.'
+  }
+}
+exports.handler = function (argv) {
+  console.log('init called for dir', argv.dir)
+}

--- a/example/cmds/remote.js
+++ b/example/cmds/remote.js
@@ -1,0 +1,6 @@
+exports.command = 'remote <command>'
+exports.description = 'Manage set of tracked repos'
+exports.builder = function (yargs) {
+  return yargs.commandDir('remote_cmds')
+}
+exports.handler = function (argv) {}

--- a/example/cmds/remote_cmds/add.js
+++ b/example/cmds/remote_cmds/add.js
@@ -1,0 +1,6 @@
+exports.command = 'add <name> <url>'
+exports.desc = 'Add remote named <name> for repo at url <url>'
+exports.builder = {}
+exports.handler = function (argv) {
+  console.log('adding remote %s at url %s', argv.name, argv.url)
+}

--- a/example/cmds/remote_cmds/prune.js
+++ b/example/cmds/remote_cmds/prune.js
@@ -1,0 +1,6 @@
+exports.command = 'prune <name> [names..]'
+exports.desc = 'Delete tracked branches gone stale for remotes'
+exports.builder = {}
+exports.handler = function (argv) {
+  console.log('pruning remotes %s', [].concat(argv.name).concat(argv.names).join(', '))
+}

--- a/example/command_hierarchy.js
+++ b/example/command_hierarchy.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+require('yargs')
+  .commandDir('cmds')
+  .demandCommand()
+  .help()
+  .argv


### PR DESCRIPTION
Add the command hierarchy example from the [advanced topics documentation]
to the actual examples.

[advanced topics documentation]: docs/advanced.md