### PR TITLE
Remove file extension on usage output

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -147,7 +147,7 @@ module.exports = function usage (yargs, y18n) {
     normalizeAliases()
 
     // handle old demanded API
-    const base$0 = path.basename(yargs.$0)
+    const base$0 = path.basename(yargs.$0, path.extname(yargs.$0))
     const demandedOptions = yargs.getDemandedOptions()
     const demandedCommands = yargs.getDemandedCommands()
     const groups = yargs.getGroups()


### PR DESCRIPTION
Before, at least on Windows, the `Commands:` section included the file extension, e.g.:

```
C:\Users\emile>athom
athom.js <command>

Commands:
  athom.js app      App related commands
```

With this change, the `.js` will be automatically stripped:

```
C:\Users\emile>athom
athom <command>

Commands:
  athom app      App related commands
```