### PR TITLE
extend *.rc files in addition to json

### DIFF
--- a/lib/apply-extends.js
+++ b/lib/apply-extends.js
@@ -21,7 +21,7 @@ function applyExtends (config, cwd) {
 
   if (config.hasOwnProperty('extends')) {
     if (typeof config.extends !== 'string') return defaultConfig
-    const isPath = /\.json$/.test(config.extends)
+    const isPath = /\.json|\..*rc$/.test(config.extends)
     let pathToDefault = null
     if (!isPath) {
       try {

--- a/test/fixtures/extends/.myotherrc
+++ b/test/fixtures/extends/.myotherrc
@@ -1,0 +1,4 @@
+{
+    "extends": "./config_1.json",
+    "c": 201
+}

--- a/test/fixtures/extends/.myrc
+++ b/test/fixtures/extends/.myrc
@@ -1,0 +1,4 @@
+{
+    "extends": "./.myotherrc",
+    "a": 5
+}

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1292,11 +1292,11 @@ describe('yargs dsl tests', () => {
             a: 3
           })
           .argv
-  
-          argv.a.should.equal(3)
-          argv.b.should.equal(22)
-          argv.c.should.equal(201)
-          argv.z.should.equal(15)
+
+        argv.a.should.equal(3)
+        argv.b.should.equal(22)
+        argv.c.should.equal(201)
+        argv.z.should.equal(15)
       })
     })
   })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1284,6 +1284,20 @@ describe('yargs dsl tests', () => {
         argv.a.should.equal(2)
         argv.extends.should.equal('batman')
       })
+
+      it('allows files with .*rc extension to be extended', () => {
+        const argv = yargs()
+          .config({
+            extends: './test/fixtures/extends/.myrc',
+            a: 3
+          })
+          .argv
+  
+          argv.a.should.equal(3)
+          argv.b.should.equal(22)
+          argv.c.should.equal(201)
+          argv.z.should.equal(15)
+      })
     })
   })
 


### PR DESCRIPTION
fixes #1035 

This simply updates the regex to include *.*rc files. It does not handle the situation with rc files that are formatted in INI format. That seems to be a separate discussion.