### PR TITLE
Remove the trailing white spaces from the help output

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -349,7 +349,8 @@ module.exports = function usage (yargs, y18n) {
       ui.div(`${e}\n`)
     }
 
-    return ui.toString()
+    // Remove the trailing white spaces
+    return ui.toString().replace(/\s*$/, '')
   }
 
   // return the maximum width of a string

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -45,7 +45,10 @@ module.exports = function usage (yargs, y18n) {
       // don't output failure message more than once
       if (!failureOutput) {
         failureOutput = true
-        if (showHelpOnFail) yargs.showHelp('error')
+        if (showHelpOnFail) {
+          yargs.showHelp('error')
+          logger.error()
+        }
         if (msg || err) logger.error(msg || err)
         if (failMessage) {
           if (msg || err) logger.error('')

--- a/test/command.js
+++ b/test/command.js
@@ -519,8 +519,7 @@ describe('Command', () => {
         '  usage dream [command] [opts]  Go to sleep and dream',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -541,8 +540,7 @@ describe('Command', () => {
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
         '  --shared   Is the dream shared with others?  [boolean]',
-        '  --extract  Attempt extraction?  [boolean]',
-        ''
+        '  --extract  Attempt extraction?  [boolean]'
       ])
     })
 
@@ -562,8 +560,7 @@ describe('Command', () => {
         '  usage dream [command] [opts]           Go to sleep and dream',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -593,8 +590,7 @@ describe('Command', () => {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -610,8 +606,7 @@ describe('Command', () => {
         'Attempts to (re)apply its own dir',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -628,8 +623,7 @@ describe('Command', () => {
         '  usage nameless  Command name derived from module filename',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
   })
@@ -684,8 +678,7 @@ describe('Command', () => {
         '  command cmd sub  Run the subcommand',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ]
 
       const expectedSub = [
@@ -693,8 +686,7 @@ describe('Command', () => {
         'Run the subcommand',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ]
 
       // no help is output if help isn't last

--- a/test/usage.js
+++ b/test/usage.js
@@ -769,7 +769,7 @@ describe('usage tests', () => {
           .argv
         )
 
-      r.errors[1].should.equal('Not enough arguments following: bar')
+      r.errors[2].should.equal('Not enough arguments following: bar')
     })
   })
 
@@ -1026,8 +1026,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
-        '  -y  [required]',
-        ''
+        '  -y  [required]'
       ])
     })
 
@@ -1049,8 +1048,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help      Show help  [boolean]',
         '  --version   Show version number  [boolean]',
-        '  --some-opt  Some option  [default: 2]',
-        ''
+        '  --some-opt  Some option  [default: 2]'
       ])
     })
 
@@ -1077,8 +1075,7 @@ describe('usage tests', () => {
           'Options:',
           '  --help, -h  Show help  [boolean]',
           '  --version   Show version number  [boolean]',
-          '  --some-opt  Some option  [required]',
-          ''
+          '  --some-opt  Some option  [required]'
         ])
       })
 
@@ -1107,8 +1104,7 @@ describe('usage tests', () => {
           'Options:',
           '  --help, -h  Show help  [boolean]',
           '  --version   Show version number  [boolean]',
-          '  --some-opt  Some option  [required]',
-          ''
+          '  --some-opt  Some option  [required]'
         ])
       })
     })
@@ -1318,7 +1314,7 @@ describe('usage tests', () => {
         )
 
       // should split example usage onto multiple lines.
-      r.errors[0].split('\n').length.should.equal(11)
+      r.errors[0].split('\n').length.should.equal(10)
 
       // should wrap within appropriate boundaries.
       r.errors[0].split('\n').forEach((line, i) => {
@@ -1378,8 +1374,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version   Show version number                                      [boolean]',
         `  -f, --file  ${noColorAddedDescr}                      [string] [required]`,
-        '  -h, --help  Show help                                                [boolean]',
-        ''
+        '  -h, --help  Show help                                                [boolean]'
       ])
     })
 
@@ -1402,8 +1397,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version   Show version number                                      [boolean]',
         `  -f, --file  ${yellowDescription}                      [string] [required]`,
-        '  -h, --help  Show help                                                [boolean]',
-        ''
+        '  -h, --help  Show help                                                [boolean]'
       ])
     })
   })
@@ -1505,8 +1499,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
         'usage upload <dest>',
@@ -1516,8 +1509,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
-        '  --force    Force overwrite of remote directory contents  [boolean]',
-        ''
+        '  --force    Force overwrite of remote directory contents  [boolean]'
       ])
     })
 
@@ -1551,8 +1543,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
       commandHelp.logs[0].split('\n').should.deep.equal([
         'usage upload <dest>',
@@ -1563,8 +1554,7 @@ describe('usage tests', () => {
         '  --help     Show help               [boolean]',
         '  --version  Show version number     [boolean]',
         '  --force    Force overwrite of remote',
-        '             directory contents      [boolean]',
-        ''
+        '             directory contents      [boolean]'
       ])
     })
 
@@ -1594,8 +1584,7 @@ describe('usage tests', () => {
         '  -h  Show help  [boolean]',
         '',
         'Options:',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1635,8 +1624,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -1669,8 +1657,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -1711,8 +1698,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -1736,8 +1722,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1758,8 +1743,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1773,8 +1757,7 @@ describe('usage tests', () => {
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1792,8 +1775,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1811,8 +1793,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1831,8 +1812,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1851,8 +1831,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -1869,8 +1848,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1884,8 +1862,7 @@ describe('usage tests', () => {
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -1906,8 +1883,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --version   Show version number  [boolean]',
-        '  -h, --help  Show help  [boolean]',
-        ''
+        '  -h, --help  Show help  [boolean]'
       ])
     })
   })
@@ -2118,8 +2094,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
-        '  -f, --foo  foo option',
-        ''
+        '  -f, --foo  foo option'
       ])
     })
 
@@ -2136,8 +2111,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
-        '  -f, --foo  [required]',
-        ''
+        '  -f, --foo  [required]'
       ])
     })
 
@@ -2155,8 +2129,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
-        '  -f, --foo  bar  [string]',
-        ''
+        '  -f, --foo  bar  [string]'
       ])
     })
 
@@ -2175,8 +2148,7 @@ describe('usage tests', () => {
         'Options:',
         '  --version  Show version number  [boolean]',
         '  -h         Show help  [boolean]',
-        '  -f, --foo  bar  [number]',
-        ''
+        '  -f, --foo  bar  [number]'
       ])
     })
   })
@@ -2199,8 +2171,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
-        '  --foo, -f  foo option',
-        ''
+        '  --foo, -f  foo option'
       ])
     })
 
@@ -2221,8 +2192,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]',
-        '  --foo, -f  foo option',
-        ''
+        '  --foo, -f  foo option'
       ])
     })
 
@@ -2240,8 +2210,7 @@ describe('usage tests', () => {
           'Options:',
           '  --help     Show help  [boolean]',
           '  --version  Show version number  [boolean]',
-          '  --foo, -f  foo option',
-          ''
+          '  --foo, -f  foo option'
         ])
         return done()
       }
@@ -2365,8 +2334,7 @@ describe('usage tests', () => {
         '  --help        Show help  [boolean]',
         '  --version     Show version number  [boolean]',
         '  --answer      does this look good?  [choices: "yes", "no", "maybe"]',
-        '  --confidence  percentage of confidence  [choices: 0, 25, 50, 75, 100]',
-        ''
+        '  --confidence  percentage of confidence  [choices: 0, 25, 50, 75, 100]'
       ])
     })
 
@@ -2388,8 +2356,7 @@ describe('usage tests', () => {
       r.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
   })
@@ -2445,8 +2412,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -2468,8 +2434,7 @@ describe('usage tests', () => {
         '  -h        Show help  [boolean]',
         '',
         'Options:',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -2485,8 +2450,7 @@ describe('usage tests', () => {
       r.logs[0].split('\n').should.deep.equal([
         'Magic Variable:',
         '  -h, --help  Show help  [boolean]',
-        '  --version   Show version number  [boolean]',
-        ''
+        '  --version   Show version number  [boolean]'
       ])
     })
 
@@ -2503,8 +2467,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
 
@@ -2524,8 +2487,7 @@ describe('usage tests', () => {
         '',
         'Heroes:',
         '  --batman',
-        '  --robin',
-        ''
+        '  --robin'
       ])
     })
 
@@ -2546,8 +2508,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -2569,8 +2530,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ])
     })
   })
@@ -2590,8 +2550,7 @@ describe('usage tests', () => {
         '  --help     Show help                                                 [boolean]',
         '  --version  Show version number                                       [boolean]',
         'Examples:',
-        '  안녕하세요 선생님 안녕 친구야  인사하는 어린이 착한 어린이',
-        ''
+        '  안녕하세요 선생님 안녕 친구야  인사하는 어린이 착한 어린이'
       ])
     })
   })
@@ -2618,8 +2577,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2643,8 +2601,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2676,8 +2633,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2702,8 +2658,7 @@ describe('usage tests', () => {
         'Options:',
         '  --help     Show help                                                 [boolean]',
         '  --version  Show version number                                       [boolean]',
-        '  --uuid                                                              [required]',
-        ''
+        '  --uuid                                                              [required]'
       ])
     })
   })
@@ -2729,8 +2684,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2754,8 +2708,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2779,8 +2732,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2804,8 +2756,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2830,8 +2781,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
 
@@ -2856,8 +2806,7 @@ describe('usage tests', () => {
         '',
         'Options:',
         '  --help     Show help                                                 [boolean]',
-        '  --version  Show version number                                       [boolean]',
-        ''
+        '  --version  Show version number                                       [boolean]'
       ])
     })
   })
@@ -2883,8 +2832,7 @@ describe('usage tests', () => {
         '  --help     Show help                                                 [boolean]',
         '  --version  Show version number                                       [boolean]',
         '  --foo      FOO',
-        '  --bar',
-        ''
+        '  --bar'
       ])
     })
     it('--help should display all options (including hidden ones) with --show-hidden', () => {
@@ -2908,8 +2856,7 @@ describe('usage tests', () => {
         '  --version  Show version number                                       [boolean]',
         '  --foo      FOO',
         '  --bar',
-        '  --baz      BAZ',
-        ''
+        '  --baz      BAZ'
       ])
     })
     it('--help should display --custom-show-hidden', () => {
@@ -2934,8 +2881,7 @@ describe('usage tests', () => {
         '  --version             Show version number                            [boolean]',
         '  --foo                 FOO',
         '  --bar',
-        '  --custom-show-hidden  Show hidden options                            [boolean]',
-        ''
+        '  --custom-show-hidden  Show hidden options                            [boolean]'
       ])
     })
     it('--help should display all options with --custom-show-hidden', () => {
@@ -2961,8 +2907,7 @@ describe('usage tests', () => {
         '  --foo                 FOO',
         '  --bar',
         '  --baz                 BAZ',
-        '  --custom-show-hidden  Show hidden options                            [boolean]',
-        ''
+        '  --custom-show-hidden  Show hidden options                            [boolean]'
       ])
     })
   })

--- a/test/validation.js
+++ b/test/validation.js
@@ -679,8 +679,7 @@ describe('validation tests', () => {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --settings  Path to JSON config file',
-        '  --help      Show help  [boolean]',
-        ''
+        '  --help      Show help  [boolean]'
       ])
     })
 
@@ -697,8 +696,7 @@ describe('validation tests', () => {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --config  Path to JSON config file',
-        '  --help    Show help  [boolean]',
-        ''
+        '  --help    Show help  [boolean]'
       ])
     })
 
@@ -715,8 +713,7 @@ describe('validation tests', () => {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --settings  pork chop sandwiches',
-        '  --help      Show help  [boolean]',
-        ''
+        '  --help      Show help  [boolean]'
       ])
     })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -56,7 +56,7 @@ describe('yargs dsl tests', () => {
         .argv
       )
 
-    r.errors[1].should.match(/Implications failed/)
+    r.errors[2].should.match(/Implications failed/)
   })
 
   it('accepts an object for describes', () => {
@@ -173,7 +173,7 @@ describe('yargs dsl tests', () => {
           .argv
         )
 
-      r.errors[3].should.match(/pork chop sandwiches/)
+      r.errors[4].should.match(/pork chop sandwiches/)
     })
 
     it('calling with no arguments should default to displaying help', () => {
@@ -183,7 +183,7 @@ describe('yargs dsl tests', () => {
           .argv
         )
 
-      r.errors[1].should.match(/required argument/)
+      r.errors[2].should.match(/required argument/)
     })
   })
 
@@ -352,7 +352,7 @@ describe('yargs dsl tests', () => {
           .argv
       })
 
-      r.errors[1].should.match(/Did you mean goat/)
+      r.errors[2].should.match(/Did you mean goat/)
     })
 
     it('does not recommend a similiar command if no similar command exists', () => {
@@ -375,7 +375,7 @@ describe('yargs dsl tests', () => {
           .argv
       })
 
-      r.errors[1].should.match(/Did you mean goat/)
+      r.errors[2].should.match(/Did you mean goat/)
     })
 
     // see: https://github.com/yargs/yargs/issues/822
@@ -420,8 +420,7 @@ describe('yargs dsl tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -446,8 +445,7 @@ describe('yargs dsl tests', () => {
         '',
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  -h         Show help  [boolean]',
-        ''
+        '  -h         Show help  [boolean]'
       ])
     })
 
@@ -1123,8 +1121,7 @@ describe('yargs dsl tests', () => {
           '',
           'Options:',
           '  --help     Show help  [boolean]',
-          '  --version  Show version number  [boolean]',
-          ''
+          '  --version  Show version number  [boolean]'
         ])
 
         output2.split('\n').should.deep.equal([
@@ -1134,8 +1131,7 @@ describe('yargs dsl tests', () => {
           '',
           'Options:',
           '  --help     Show help  [boolean]',
-          '  --version  Show version number  [boolean]',
-          ''
+          '  --version  Show version number  [boolean]'
         ])
       })
 
@@ -1179,8 +1175,7 @@ describe('yargs dsl tests', () => {
           '',
           'Options:',
           '  --help     Show help  [boolean]',
-          '  --version  Show version number  [boolean]',
-          ''
+          '  --version  Show version number  [boolean]'
         ])
       })
 
@@ -1680,8 +1675,7 @@ describe('yargs dsl tests', () => {
       const expected = [
         'Options:',
         '  --help     Show help  [boolean]',
-        '  --version  Show version number  [boolean]',
-        ''
+        '  --version  Show version number  [boolean]'
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
@@ -1701,8 +1695,7 @@ describe('yargs dsl tests', () => {
       const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  --help     Show help  [boolean]',
-        ''
+        '  --help     Show help  [boolean]'
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
@@ -1727,8 +1720,7 @@ describe('yargs dsl tests', () => {
       const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  --info     Show help  [boolean]',
-        ''
+        '  --info     Show help  [boolean]'
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
@@ -1749,8 +1741,7 @@ describe('yargs dsl tests', () => {
       const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  --info     Display info  [boolean]',
-        ''
+        '  --info     Display info  [boolean]'
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
@@ -1770,8 +1761,7 @@ describe('yargs dsl tests', () => {
       const expected = [
         'Options:',
         '  --version  Show version number  [boolean]',
-        '  --info     Display info  [boolean]',
-        ''
+        '  --info     Display info  [boolean]'
       ]
       option.logs[0].split('\n').should.deep.equal(expected)
       command.logs[0].split('\n').should.deep.equal(expected)
@@ -1793,8 +1783,7 @@ describe('yargs dsl tests', () => {
       info.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --version           Show version number  [boolean]',
-        '  -h, --help, --info  Show help  [boolean]',
-        ''
+        '  -h, --help, --info  Show help  [boolean]'
       ])
       h.result.should.have.property('_').and.deep.equal(['h'])
     })


### PR DESCRIPTION
- e5deaf7 Add tests
- b07abdc Remove the trailing white spaces from the help output
- 6a13023 Print a new line between the help and the error on fail if showHelpOnFail is enabled