### PR TITLE
chore: 'false' value is no longer set when boolean flag is not passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "string-width": "^2.0.0",
     "which-module": "^2.0.0",
     "y18n": "^3.2.1",
-    "yargs-parser": "^9.0.2"
+    "yargs-parser": "^10.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
BREAKING CHANGE: yargs-parser does not populate 'false' when boolean flag is not passed