### PR TITLE
docs: Restore correct header order

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -954,7 +954,7 @@ Running myCommand!
 ```
 
 
-<a name="middleware"></a>.middleware(callbacks)
+<a name="nargs"></a>.nargs(callbacks)
 --------------------
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -926,7 +926,7 @@ To submit a new translation for yargs:
 
 *The [Microsoft Terminology Search](http://www.microsoft.com/Language/en-US/Search.aspx) can be useful for finding the correct terminology in your locale.*
 
-.middleware(callbacks)
+<a name="middleware"></a>.middleware(callbacks)
 ------------------------------------
 
 Define global middleware functions to be called first, in list order, for all cli command.  

--- a/docs/api.md
+++ b/docs/api.md
@@ -951,7 +951,7 @@ Running myCommand!
 ```
 
 <a name="nargs"></a>.nargs(key, count)
---------------------
+-----------
 
 The number of arguments that should be consumed after a key. This can be a
 useful hint to prevent parsing ambiguity. For example:

--- a/docs/api.md
+++ b/docs/api.md
@@ -926,9 +926,6 @@ To submit a new translation for yargs:
 
 *The [Microsoft Terminology Search](http://www.microsoft.com/Language/en-US/Search.aspx) can be useful for finding the correct terminology in your locale.*
 
-<a name="nargs"></a>.nargs(key, count)
------------
-
 .middleware(callbacks)
 ------------------------------------
 
@@ -953,10 +950,8 @@ I'm another middleware function
 Running myCommand!
 ```
 
-
 <a name="nargs"></a>.nargs(callbacks)
 --------------------
-
 
 The number of arguments that should be consumed after a key. This can be a
 useful hint to prevent parsing ambiguity. For example:

--- a/docs/api.md
+++ b/docs/api.md
@@ -950,7 +950,7 @@ I'm another middleware function
 Running myCommand!
 ```
 
-<a name="nargs"></a>.nargs(callbacks)
+<a name="nargs"></a>.nargs(key, count)
 --------------------
 
 The number of arguments that should be consumed after a key. This can be a


### PR DESCRIPTION
Fixed a likely copy/paste mistake.