### PR TITLE
chore: Allow v4 of y18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "set-blocking": "^2.0.0",
     "string-width": "^2.0.0",
     "which-module": "^2.0.0",
-    "y18n": "^3.2.1",
+    "y18n": "^3.2.1 || ^4.0.0",
     "yargs-parser": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
All v4 of y18n does is drop support for 0.10 and 0.12.  Kept a broad range (3 & 4) to make it easier to dedupe trees.