### PR TITLE
docs: Use correct completion callback signature

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -320,7 +320,7 @@ But wait, there's more! You can return an asynchronous promise.
 
 ```js
 var argv = require('yargs')
-  .completion('completion', function(current, argv, done) {
+  .completion('completion', function(current, argv) {
     return new Promise(function (resolve, reject) {
       setTimeout(function () {
         resolve(['apple', 'banana'])


### PR DESCRIPTION
The completion function checks that the number of arguments is less than 3 before performing the logic that resolves a promise, so passing `done` here will cause the promise to not resolve.