### PR TITLE
chore: Run standard in pretest lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "yargs-test-extends": "^1.0.1"
   },
   "scripts": {
-    "posttest": "standard",
+    "pretest": "standard",
     "test": "nyc --cache mocha --require ./test/before.js --timeout=8000 --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "standard-version"


### PR DESCRIPTION
Static analysis should be done before tests. It saves times and also lints and catches errors through static analysis in tests.

It could also be moved to the test script, before nyc.