### PR TITLE
Corrected version specifier in help example

### DIFF
--- a/example/help.js
+++ b/example/help.js
@@ -3,7 +3,7 @@ var yargs = require('../index');
 var argv = yargs
   .usage('This is my awesome program\n\nUsage: $0 [options]')
   .help('help').alias('help', 'h')
-  .version('1.0.1', 'version').alias('version', 'V')
+  .version('version', '1.0.1').alias('version', 'V')
   .options({
     input: {
       alias: 'i',


### PR DESCRIPTION
The name of the flag: `version` and the actual version value: `1.0.1` were switched.