### PR TITLE
Bump decamelize & find-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "dependencies": {
     "cliui": "^4.0.0",
-    "decamelize": "^1.1.1",
-    "find-up": "^2.1.0",
+    "decamelize": "^2.0.0",
+    "find-up": "^3.0.0",
     "get-caller-file": "^1.0.1",
     "os-locale": "^2.0.0",
     "require-directory": "^2.1.1",


### PR DESCRIPTION
The only breaking changes is that support for Node.js 4.x is dropped. Since Yargs currently only supports Node >= 6 this shouldn't be a problem.