### PR TITLE
Bump engines to Node.js 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   ],
   "license": "MIT",
   "engine": {
-    "node": ">=4"
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
This change was mentioned in the release notes for 12.0.0, so it shouldn't be a breaking change...