### PR TITLE
fix: $0 contains first arg on bundled electron app; fixes #685

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -45,9 +45,9 @@ function Yargs (processArgs, cwd, parentRequire) {
   // ignore the node bin, specify this in your
   // bin file with #!/usr/bin/env node
   if (/\b(node|iojs|electron)(\.exe)?$/.test(process.argv[0])) {
-    self.$0 = process.argv.slice(1, 2);
+    self.$0 = process.argv.slice(1, 2)
   } else {
-    self.$0 = process.argv.slice(0, 1);
+    self.$0 = process.argv.slice(0, 1)
   }
 
   self.$0 = self.$0

--- a/yargs.js
+++ b/yargs.js
@@ -42,12 +42,16 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.$0 = process.argv
-    .slice(0, 2)
+  // ignore the node bin, specify this in your
+  // bin file with #!/usr/bin/env node
+  if (/\b(node|iojs|electron)(\.exe)?$/.test(process.argv[0])) {
+    self.$0 = process.argv.slice(1, 2);
+  } else {
+    self.$0 = process.argv.slice(0, 1);
+  }
+
+  self.$0 = self.$0
     .map((x, i) => {
-      // ignore the node bin, specify this in your
-      // bin file with #!/usr/bin/env node
-      if (i === 0 && /\b(node|iojs)(\.exe)?$/.test(x)) return
       const b = rebase(cwd, x)
       return x.match(/^(\/|([a-zA-Z]:)?\\)/) && b.length < x.length ? b : x
     })


### PR DESCRIPTION
Default behavior of yargs is to take the first two args of process.argv
to put into $0 as this is usually the program to execute a script
e.g. 'node app.js' but for bundled electron apps this results in $0
being populated with not only the executing program but also the first
parameter. This fix modifies the check for node/iojs (and adds electron)
so in case of those 3, the executing program is skipped in $0 as it was
before, but in case where a bundled app is executed, the first parameter
is skipped.

This is only a cosmetic change for proper help printouts which use $0
A manual `yargs.parse(process.argv.slice(1))` is still necessary for
electron not to skip the first parameter, during parsing