### PR TITLE
Fix NPM registry data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "James Halliday",
   "main": "./index.js",
   "contributors": [
-    {"name": "Yargs Contributors", "url": "https://yargs.js.org/"}
+    {"name": "Yargs Contributors", "url": "https://github.com/yargs/yargs/graphs/contributors"}
   ],
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "yargs",
   "version": "12.0.2",
   "description": "yargs the modern, pirate-themed, successor to optimist.",
+  "author": "James Halliday",
   "main": "./index.js",
+  "contributors": [
+    {"name": "Yargs Contributors", "url": "https://yargs.js.org/"}
+  ],
   "files": [
     "index.js",
     "yargs.js",
@@ -49,9 +53,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/yargs/yargs.git"
+    "url": "https://github.com/yargs/yargs.git"
   },
-  "homepage": "http://yargs.js.org/",
+  "homepage": "https://yargs.js.org/",
   "standard": {
     "ignore": [
       "**/example/**"


### PR DESCRIPTION
Hello - I noticed that the NPM registry entry for 'yargs' lists your homepage and repo with an HTTP URL rather than HTTPS, and therefore it shows as "insecure" in modern browsers. This PR fixes it to use HTTPS. Also, this adds the missing "author" field for NPM.