### PR TITLE
Downgrade decamelize dependency to 1.2.0 to decrease package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "cliui": "^4.0.0",
-    "decamelize": "^2.0.0",
+    "decamelize": "^1.2.0",
     "find-up": "^3.0.0",
     "get-caller-file": "^1.0.1",
     "os-locale": "^3.0.0",


### PR DESCRIPTION
I noticed the package install size creeping up quite a bit in the last versions: https://packagephobia.now.sh/result?p=yargs

After taking a look at it a big cause is the `decamelize` dependency, replacing it with `kebab-case` decreases the package install size from around 1400 kB to 670 kB.