### PR TITLE
fix: allows camel-case, variadic arguments, and strict mode to be combined

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -358,6 +358,9 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
       Object.keys(parsed.argv).forEach((key) => {
         if (positionalKeys.indexOf(key) !== -1) {
+          // any new aliases need to be placed in positionalMap, which
+          // is used for validation.
+          if (!positionalMap[key]) positionalMap[key] = parsed.argv[key]
           argv[key] = parsed.argv[key]
         }
       })

--- a/test/command.js
+++ b/test/command.js
@@ -184,6 +184,17 @@ describe('Command', () => {
       argv.file.should.equal('file1')
       argv._.should.include('file2')
     })
+
+    // addresses: https://github.com/yargs/yargs/issues/1246
+    it('allows camel-case, variadic arguments, and strict mode to be combined', () => {
+      const argv = yargs('ls one two three')
+        .command('ls [expandMe...]')
+        .strict()
+        .parse()
+
+      argv.expandMe.should.deep.equal(['one', 'two', 'three'])
+      argv['expand-me'].should.deep.equal(['one', 'two', 'three'])
+    })
   })
 
   describe('missing positional arguments', () => {


### PR DESCRIPTION
fixes: #1246 

CC: @vasco-santos, @boneskull 