### PR TITLE
docs(advanced): document non-singleton use, .exit() and parsed

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -472,3 +472,12 @@ var argv = require('yargs')
      )
   .argv;
 ```
+
+### Using the non-singleton interface
+
+To use yargs without running as a singleton, do:
+```
+const argv = require('yargs/yargs')(process.argv.slice(2))
+```
+
+This is especially useful when using yargs in a library, as library authors should not pollute the global state.

--- a/docs/api.md
+++ b/docs/api.md
@@ -684,6 +684,11 @@ uses the `.version` functionality, validation fails, or the command handler
 fails. Calling `.exitProcess(false)` disables this behavior, enabling further
 actions after yargs have been validated.
 
+<a name="exit"></a>.exit(code, err)
+---------
+Manually indicate that the program should exit, and provide context about why we
+wanted to exit. Follows the behaviour set by `.exitProcess()`.
+
 <a name="fail"></a>.fail(fn)
 ---------
 
@@ -1136,6 +1141,13 @@ parser.parse(bot.userText, function (err, argv, output) {
 
 ***Note:*** Providing a callback to `parse()` disables the [`exitProcess` setting](#exitprocess) until after the callback is invoked.
 
+<a name="parsed"></a>.parsed
+------------
+If the arguments have not been parsed, this property is `false`.
+
+If the arguments have been parsed, this contain detailed parsed arguments. See
+the documentation in [yargs-parser `.detailed()`][https://github.com/yargs/yargs-parser/blob/master/README.md#requireyargs-parserdetailedargs-opts]
+for details of this object
 
 <a name="pkg-conf"></a>
 .pkgConf(key, [cwd])


### PR DESCRIPTION
This adds the documentation for the non-singleton interface (as described at https://github.com/yargs/yargs/blob/a40cbc9/index.js#L4) to the markdown docs, and the `.parsed` and `.exit()` interfaces, which are useful in non-singleton usage. In particular, I noticed that they are used in [lerna](https://lernajs.io/)'s command line parsing.