### PR TITLE
fix(validation): Use the error as a message when none exists otherwise

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -1152,7 +1152,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
 
   self._runValidation = function runValidation (argv, aliases, positionalMap, parseErrors) {
-    if (parseErrors) throw new YError(parseErrors.message)
+    if (parseErrors) throw new YError(parseErrors.message || parseErrors)
     validation.nonOptionCount(argv)
     validation.requiredArguments(argv)
     if (strict) validation.unknownArguments(argv, aliases, positionalMap)


### PR DESCRIPTION
While exploring yargs I discovered an edge-case error.

`_runValidation` assumes that `parseErrors` is an `Error` object with a `message` property. However, it's legitimate in JavaScript to `throw` arbitrary object. When that object is not an `Error`, it's most commonly a `String`, i.e.: 

    throw 'This is an error.'

See: https://jsfiddle.net/softcraft/gxka09nb/

When `_runValidation` feeds `parseErrors.message` to `YError`, it's `undefined`, and thus `YError` generates an error message with the (quite unhelpful) 'yargs error' string, not the value of `parseErrors`. 

This change will allow `_runValidation` to use the value of `parseErrors` as a fallback if `parseErrors.message` doesn't exist. This allows `throw "error!"` to work successfully. 

(I encountered this problem by throwing a String error from a `coerce()` function.)