### PR TITLE
Consistent bash-completion if a command is not found

### DIFF
--- a/completion.sh.hbs
+++ b/completion.sh.hbs
@@ -19,10 +19,10 @@ _yargs_completions()
 
     # if no match was found, fall back to filename completion
     if [ ${#COMPREPLY[@]} -eq 0 ]; then
-      COMPREPLY=( $(compgen -f -- "${cur_word}" ) )
+      COMPREPLY=()
     fi
 
     return 0
 }
-complete -F _yargs_completions {{app_name}}
+complete -o default -F _yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###


### PR DESCRIPTION
Hey,
it seems that if a command is not found, the fallback file autocompletion does not work the same as the standard bash autocompletion:

**CURRENT**
`some-cmd folder-na(tab)` -> `some-cmd folder-name `
currently the folder name is inserted, including a space at the end

**PROPOSED**
`some-cmd folder-na(tab)` -> `some-cmd folder-name/`
In the current bash versions the folder name is inserted with a slash at the end, allowing you to chain folder paths

With this change bash will decide how to handle the autocompletion.

### tested on
MacOS 10.14

### references
https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html
https://stackoverflow.com/a/22827323
