### PR TITLE
feat: options/positionals with leading '+' and '0' no longer parse as numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "string-width": "^3.0.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^12.0.0"
+    "yargs-parser": "^13.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/command.js
+++ b/test/command.js
@@ -1460,12 +1460,9 @@ describe('Command', () => {
   })
 
   // see: https://github.com/yargs/yargs/issues/1099
-  it('does not coerce number from positional configured as string', () => {
-    const argv = yargs.command('$0 <phone>', '', (yargs) => {
-      yargs.positional('phone', {
-        type: 'string'
-      })
-    }).parse('+5550100')
+  it('does not coerce number from positional with leading "+"', () => {
+    const argv = yargs.command('$0 <phone>', '', (yargs) => {})
+      .parse('+5550100')
     argv.phone.should.equal('+5550100')
   })
 })

--- a/test/command.js
+++ b/test/command.js
@@ -1458,4 +1458,14 @@ describe('Command', () => {
       return done()
     })
   })
+
+  // see: https://github.com/yargs/yargs/issues/1099
+  it('does not coerce number from positional configured as string', () => {
+    const argv = yargs.command('$0 <phone>', '', (yargs) => {
+      yargs.positional('phone', {
+        type: 'string'
+      })
+    }).parse('+5550100')
+    argv.phone.should.equal('+5550100')
+  })
 })


### PR DESCRIPTION
see: #1099, #550

BREAKING CHANGE: options with leading '+' or '0' now parse as strings