### PR TITLE
chore: drop Node 6 from testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
+  # - "11" TODO: add 11 in April when 12 goes live.
   - "node"
 
 os:


### PR DESCRIPTION
Would have waited until April, but CI is having build failures on 6; motivating me to drop support early.

BREAKING CHANGE: dropping Node 6 which hits end of life in April