### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ It gives you:
 
 Stable version:
 ```bash
-npm i yargs --save
+npm i yargs
 ```
 
 Bleeding edge version with the most recent features:
 ```bash
-npm i yargs@next --save
+npm i yargs@next
 ```
 
 ## Usage :


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358