### PR TITLE
chore: forgoing decision to drop Node 6 until April

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "6"
   - "8"
   - "10"
   # - "11" TODO: add 11 in April when 12 goes live.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Chores
 
-* drop Node 6 from testing matrix ([#1287](https://github.com/yargs/yargs/issues/1287)) ([ef16792](https://github.com/yargs/yargs/commit/ef16792))
+* ~drop Node 6 from testing matrix ([#1287](https://github.com/yargs/yargs/issues/1287)) ([ef16792](https://github.com/yargs/yargs/commit/ef16792))~
+  * _opting to not drop Node 6 support until April, [see](https://github.com/nodejs/Release)._
 * update dependencies ([#1284](https://github.com/yargs/yargs/issues/1284)) ([f25de4f](https://github.com/yargs/yargs/commit/f25de4f))
 
 

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -261,9 +261,10 @@ describe('middleware', () => {
     it('throws an error if async function provided', function () {
       expect(() => {
         yargs(['mw'])
-          .middleware([async function (argv) {
+          .middleware([function (argv) {
             argv.mw = 'mw'
             argv.other = true
+            return Promise.resolve(argv)
           }], true)
           .command(
             'mw',


### PR DESCRIPTION
for the benefit of mocha, holding off on decision to drop Node 6 support @boneskull @plroebuck.