### PR TITLE
Make Dutch translation consistent, fix Dutch language errors, and make it real Dutch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -929,6 +929,7 @@ Locales currently supported:
 * **ja:** Japanese.
 * **ko:** Korean.
 * **nb:** Norwegian Bokmål.
+* **nl:** Dutch.
 * **pirate:** American Pirate.
 * **pl:** Polish.
 * **pt:** Portuguese.

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,42 +1,42 @@
 {
-  "Commands:": "Opdrachten:",
+  "Commands:": "Commando's:",
   "Options:": "Opties:",
   "Examples:": "Voorbeelden:",
-  "boolean": "boolean",
+  "boolean": "booleaans",
   "count": "aantal",
-  "string": "text",
-  "number": "nummer",
+  "string": "string",
+  "number": "getal",
   "array": "lijst",
   "required": "verplicht",
   "default:": "standaard:",
   "choices:": "keuzes:",
   "aliases:": "aliassen:",
   "generated-value": "gegenereerde waarde",
-  "Not enough non-option arguments: got %s, need at least %s": "Niet genoeg non-optie argumenten. Gekregen: %s, minstens nodig: %s",
-  "Too many non-option arguments: got %s, maximum of %s": "Te veel non-optie argumenten. Gekregen: %s, maximum: %s",
+  "Not enough non-option arguments: got %s, need at least %s": "Niet genoeg niet-optie-argumenten: %s gekregen, minstens %s nodig",
+  "Too many non-option arguments: got %s, maximum of %s": "Te veel niet-optie-argumenten: %s gekregen, maximum is %s",
   "Missing argument value: %s": {
-    "one": "Missing argument value: %s",
-    "other": "Missing argument values: %s"
+    "one": "Missende argumentwaarde: %s",
+    "other": "Missende argumentwaarden: %s"
   },
   "Missing required argument: %s": {
-    "one": "Missend verplichte argument: %s",
+    "one": "Missend verplicht argument: %s",
     "other": "Missende verplichte argumenten: %s"
   },
   "Unknown argument: %s": {
     "one": "Onbekend argument: %s",
     "other": "Onbekende argumenten: %s"
   },
-  "Invalid values:": "Ongeldige waardes:",
+  "Invalid values:": "Ongeldige waarden:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Gegeven: %s, Keuzes: %s",
-  "Argument check failed: %s": "Argument check mislukt: %s",
-  "Implications failed:": "Implicaties mislukt:",
+  "Argument check failed: %s": "Argumentcontrole mislukt: %s",
+  "Implications failed:": "Mislukte implicaties:",
   "Not enough arguments following: %s": "Niet genoeg argumenten na: %s",
-  "Invalid JSON config file: %s": "Ongeldig JSON configuratiebestand: %s",
-  "Path to JSON config file": "Pad naar JSON configuratiebestand",
+  "Invalid JSON config file: %s": "Ongeldig JSON-config-bestand: %s",
+  "Path to JSON config file": "Pad naar JSON-config-bestand",
   "Show help": "Toon help",
-  "Show version number": "Toon versie nummer",
+  "Show version number": "Toon versienummer",
   "Did you mean %s?": "Bedoelde u misschien %s?",
-  "Arguments %s and %s are mutually exclusive": "Argumenten %s en %s zijn onderling uitsluitend",
+  "Arguments %s and %s are mutually exclusive": "Argumenten %s en %s kunnen niet tegelijk gebruikt worden",
   "Positionals:": "Positie-afhankelijke argumenten",
   "command": "commando"
 }


### PR DESCRIPTION
- "Commands:" and "command" should be translated consistently (it was "Opdrachten:" and "commando"); "commando" is much more appropriate in this context than "opdracht"
- In Dutch, there is a difference between "nummer" and "getal". A "nummer" is used for the English "digit" ([0-9]). A "getal" is what is meant here (the type of all numbers)
- the translation of "boolean" is "booleaans"
- "string" was translated as "text". "text" is not a Dutch word. In Dutch, "text" becomes "tekst". But a string is not a text.
https://www.microsoft.com/en-us/language/Search?&searchTerm=number&langID=Dutch&Source=true&productid=All%20Products translates "string" to "tekenreeks", but that is
hypercorrect. Nobody uses that term. In Dutch, we just use the English term "string" colloquially.
- "Non-option argument" should be translated as "niet-optie-argument" ("niet" instead of "non")
- The sentence aspect of "got %s, need at least %s" and "got %s, maximum of %s" was not translated sensibly
- "Missing argument value: %s" was not translated at all
- In the singular, there is no ending-'e' for an adjective if there is no article ("verplicht")
- The plural form "waarden" of "waarde" (value) seems more appropriate here than the alternative "waardes"
- The English word "check" can be used in Dutch to mean "validation", in the 1970's. In this century, we use "controle" colloquially. "Validatie", "verificatie", etc. are possible, but technical jargon
- "Implications failed:" is difficult to translate, because the English form is bad to start with. A literal translation is very awkward in Dutch. This string is used in the code as the
prelude to a list of "implications" that have failed. A better English form would be "Failed implications:", and the new Dutch translation expresses that. Furthermore, the wordt "implications",
in English, as well as in Dutch, is extremely confusing here. It is only people who know the Yargs API that understand that these are the dependencies created by the `implies()` method.
Users of the CLI have no idea what we are talking about. Yet, until a better form is found in English, it is also kept in Dutch.
- In Dutch, we only know compound substantives, not concatenated substantives ("non-option argument" -> "niet-optie-argument", "Argument check" -> "Argumentcontrole", "JSON config file" -> "JSON-config-bestand", "version number" -> "versienummer")
- Since the orginal text talks about the "config file", referring to the name of the file (`config`), the translation should do so too. It was "configuratiebestand", which is Dutch for "configuration file".
- There is no direct translation in Dutch for the idiom "mutually exclusive". The unclear attempt at doing a direct translation was replaced by an idiom that is used in Dutch, that is more descriptive.