### PR TITLE
Change the label for "Implications failed:" in English

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -29,7 +29,7 @@
   "Invalid values:": "Unzulässige Werte:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Gegeben: %s, Möglichkeiten: %s",
   "Argument check failed: %s": "Argumente-Check fehlgeschlagen: %s",
-  "Implications failed:": "Implikationen fehlgeschlagen:",
+  "Implications failed:": "Fehlende abhängige Argumente:",
   "Not enough arguments following: %s": "Nicht genügend Argumente nach: %s",
   "Invalid JSON config file: %s": "Fehlerhafte JSON-Config Datei: %s",
   "Path to JSON config file": "Pfad zur JSON-Config Datei",

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,7 +29,7 @@
   "Invalid values:": "Invalid values:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Given: %s, Choices: %s",
   "Argument check failed: %s": "Argument check failed: %s",
-  "Implications failed:": "Implications failed:",
+  "Implications failed:": "Missing required argument dependencies:",
   "Not enough arguments following: %s": "Not enough arguments following: %s",
   "Invalid JSON config file: %s": "Invalid JSON config file: %s",
   "Path to JSON config file": "Path to JSON config file",

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,7 +29,7 @@
   "Invalid values:": "Invalid values:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Given: %s, Choices: %s",
   "Argument check failed: %s": "Argument check failed: %s",
-  "Implications failed:": "Missing required argument dependencies:",
+  "Implications failed:": "Missing dependent arguments:",
   "Not enough arguments following: %s": "Not enough arguments following: %s",
   "Invalid JSON config file: %s": "Invalid JSON config file: %s",
   "Path to JSON config file": "Path to JSON config file",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -28,7 +28,7 @@
   "Invalid values:": "Valeurs invalides:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Donné: %s, Choix: %s",
   "Argument check failed: %s": "Echec de la vérification de l'argument: %s",
-  "Implications failed:": "Implications échouées:",
+  "Implications failed:": "Arguments dépendants manquants:",
   "Not enough arguments following: %s": "Pas assez d'arguments suivant: %s",
   "Invalid JSON config file: %s": "Fichier de configuration JSON invalide: %s",
   "Path to JSON config file": "Chemin du fichier de configuration JSON",

--- a/locales/it.json
+++ b/locales/it.json
@@ -29,7 +29,7 @@
   "Invalid values:": "Valori non validi:",
   "Argument: %s, Given: %s, Choices: %s": "Argomento: %s, Richiesto: %s, Scelte: %s",
   "Argument check failed: %s": "Controllo dell'argomento fallito: %s",
-  "Implications failed:": "Argomenti impliciti non soddisfatti:",
+  "Implications failed:": "Argomenti dipendenti mancanti:",
   "Not enough arguments following: %s": "Argomenti insufficienti dopo: %s",
   "Invalid JSON config file: %s": "File di configurazione JSON non valido: %s",
   "Path to JSON config file": "Percorso del file di configurazione JSON",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -29,7 +29,7 @@
   "Invalid values:": "Ongeldige waarden:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Gegeven: %s, Keuzes: %s",
   "Argument check failed: %s": "Argumentcontrole mislukt: %s",
-  "Implications failed:": "Mislukte implicaties:",
+  "Implications failed:": "Ontbrekende afhankelijke argumenten:",
   "Not enough arguments following: %s": "Niet genoeg argumenten na: %s",
   "Invalid JSON config file: %s": "Ongeldig JSON-config-bestand: %s",
   "Path to JSON config file": "Pad naar JSON-config-bestand",

--- a/test/validation.js
+++ b/test/validation.js
@@ -3,6 +3,7 @@
 
 const checkUsage = require('./helpers/utils').checkOutput
 const expect = require('chai').expect
+const english = require('../locales/en.json')
 let yargs = require('../')
 
 require('chai').should()
@@ -13,13 +14,15 @@ describe('validation tests', () => {
   })
 
   describe('implies', () => {
+    const implicationsFailedPattern = new RegExp(english['Implications failed:'])
+
     it("fails if '_' populated, and implied argument not set", (done) => {
       yargs(['cat'])
         .implies({
           1: 'foo' // 1 arg in _ means --foo is required
         })
         .fail((msg) => {
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
           return done()
         })
         .parse()
@@ -32,7 +35,7 @@ describe('validation tests', () => {
           'foo': 1 // --foo means 1 arg in _ is required
         })
         .fail((msg) => {
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
           return done()
         })
         .parse()
@@ -62,7 +65,7 @@ describe('validation tests', () => {
           '--no-bar': 'foo' // when --bar is not given, --foo is required
         })
         .fail((msg) => {
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
           return done()
         })
         .parse()
@@ -74,7 +77,7 @@ describe('validation tests', () => {
           'bar': '--no-foo' // --bar means --foo cannot be given
         })
         .fail((msg) => {
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
           return done()
         })
         .parse()
@@ -89,7 +92,7 @@ describe('validation tests', () => {
         })
         .fail((msg) => {
           failCalled = true
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
         })
         .parse()
       failCalled.should.equal(true)
@@ -121,7 +124,7 @@ describe('validation tests', () => {
         })
         .fail((msg) => {
           failCalled = true
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
         })
         .parse()
       failCalled.should.equal(true)
@@ -150,7 +153,7 @@ describe('validation tests', () => {
           implies: 'foo'
         })
         .fail((msg) => {
-          msg.should.match(/Implications failed/)
+          msg.should.match(implicationsFailedPattern)
           return done()
         })
         .parse()

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -5,12 +5,14 @@ const expect = require('chai').expect
 const fs = require('fs')
 const path = require('path')
 const checkOutput = require('./helpers/utils').checkOutput
+const english = require('../locales/en.json')
 let yargs
 const YError = require('../lib/yerror')
 
 require('chai').should()
 
 const noop = () => {}
+const implicationsFailedPattern = new RegExp(english['Implications failed:'])
 
 describe('yargs dsl tests', () => {
   beforeEach(() => {
@@ -56,7 +58,7 @@ describe('yargs dsl tests', () => {
       .parse()
     )
 
-    r.errors[2].should.match(/Implications failed/)
+    r.errors[2].should.match(implicationsFailedPattern)
   })
 
   it('accepts an object for describes', () => {
@@ -79,7 +81,7 @@ describe('yargs dsl tests', () => {
         x: 'y'
       })
       .fail((msg) => {
-        msg.should.match(/Implications failed/)
+        msg.should.match(implicationsFailedPattern)
         return done()
       })
       .parse()


### PR DESCRIPTION
The word "implications" is extremely confusing here. It is only people who know the Yargs API that understand that these are the dependencies created by the `implies()` method.
Users of the CLI have no idea what we are talking about.

This changes the label of the concept to "required argument dependencies".

This string is used in the code as the prelude to a list of "implications" that have failed, not a warning. The earlier form was more an expression of a warning. The new form is more an expression of a title of a list.