### PR TITLE
test: accept differently formatted output

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -522,7 +522,7 @@ describe('yargs dsl tests', () => {
           builder (yargs) { return yargs },
           handler (argv) {}
         })
-      }).to.throw(/No command name given for module: { desc: 'A command with no name',\n {2}builder: \[Function(: builder)?],\n {2}handler: \[Function(: handler)?] }/)
+      }).to.throw(/No command name given for module: {(\n )? desc: 'A command with no name',\n {2}builder: \[Function(: builder)?],\n {2}handler: \[Function(: handler)?](\n| )}/)
     })
   })
 


### PR DESCRIPTION
The default for Node.js's `util.inspect` `compact` option might soon
change to `3` which slightly changes the default output for objects.
This change accepts both formats so that the test passes in all Node.js
versions.

Refs: https://github.com/nodejs/node/pull/27109