### PR TITLE
docs: restore removed changelog of v13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project will be documented in this file. See [standa
 * support options/sub-commands in zsh completion ([0a96394](https://github.com/yargs/yargs/commit/0a96394))
 
 
+# [13.2.0](https://github.com/yargs/yargs/compare/v13.1.0...v13.2.0) (2019-02-15)
+
+
+### Features
+
+* zsh auto completion ([#1292](https://github.com/yargs/yargs/issues/1292)) ([16c5d25](https://github.com/yargs/yargs/commit/16c5d25)), closes [#1156](https://github.com/yargs/yargs/issues/1156)
+
 
 <a name="13.1.0"></a>
 # [13.1.0](https://github.com/yargs/yargs/compare/v13.0.0...v13.1.0) (2019-02-12)


### PR DESCRIPTION
In https://github.com/yargs/yargs/commit/4375680c83e76cbf5cfedbfd81c138ce45b90b54, changelog of v13.2.0 was replaced with v13.2.1.