### PR TITLE
doc: make `--no-` boolean prefix easier to find in the docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,6 +80,8 @@ Interpret `key` as a boolean. If a non-flag option follows `key` in
 `key` will default to `false`, unless a `default(key, undefined)` is
 explicitly set.
 
+`key` can be set false explicitly using the `--no-` prefix, [more](/docs/tricks.md#negate).
+
 If `key` is an array, interpret all the elements as booleans.
 
 .check(fn, [global=true])


### PR DESCRIPTION
Hi all,

I bumped into #1307 while working on another yargs based project and found myself wondering what the `--no-`prefix did.  I went to the yargs docs, found the api reference and tried searching in there but couldn't find anything.  I ended up searching with github's project search to find what I was after.

So this change is quite simple, make mention of the `--no` boolean prefix on the api doc page and link to the existing doc under parsing tricks.  Hopefully that should make it a little quicker to find.
