### PR TITLE
feat: Inline code to detect current locale from environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cliui": "^5.0.0",
     "find-up": "^3.0.0",
     "get-caller-file": "^2.0.1",
-    "os-locale": "^3.1.0",
     "require-directory": "^2.1.1",
     "require-main-filename": "^2.0.0",
     "set-blocking": "^2.0.0",

--- a/test/validation.js
+++ b/test/validation.js
@@ -291,7 +291,6 @@ describe('validation tests', () => {
 
     function loadLocale (locale) {
       delete require.cache[require.resolve('../')]
-      delete require.cache[require.resolve('os-locale')]
       yargs = require('../')
       process.env.LC_ALL = locale
     }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -638,7 +638,6 @@ describe('yargs dsl tests', () => {
 
     function loadLocale (locale) {
       delete require.cache[require.resolve('../')]
-      delete require.cache[require.resolve('os-locale')]
       yargs = require('../')
       process.env.LC_ALL = locale
     }
@@ -685,17 +684,6 @@ describe('yargs dsl tests', () => {
       yargs.locale().should.equal('pt_BR')
       loadLocale('en_US.UTF-8')
       r.logs.join(' ').should.match(/Exibe ajuda/)
-    })
-
-    it('handles os-locale throwing an exception', () => {
-      // make os-locale throw.
-      require('os-locale')
-      require.cache[require.resolve('os-locale')].exports.sync = () => { throw Error('an error!') }
-
-      delete require.cache[require.resolve('../')]
-      yargs = require('../')
-
-      yargs.locale().should.equal('en')
     })
 
     it('uses locale string for help option default desc on .locale().help()', () => {

--- a/yargs.js
+++ b/yargs.js
@@ -1181,8 +1181,9 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (!detectLocale) return
 
     try {
-      const osLocale = require('os-locale')
-      self.locale(osLocale.sync({ spawn: false }))
+      const { env } = process
+      const locale = env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE || 'en_US'
+      self.locale(locale.replace(/[.:].*/, ''))
     } catch (err) {
       // if we explode looking up locale just noop
       // we'll keep using the default language 'en'.


### PR DESCRIPTION
This eliminates half the dependencies of yargs without any change in
functionality.  The extra dependencies were used by the os-locale module
to execute detection utilities, this execution functionality was always
disabled by yargs.

Fixes #1354