### PR TITLE
fix!: do not allow additional positionals in strict mode

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -102,7 +102,7 @@ module.exports = function validation (yargs, usage, y18n) {
       }
     })
 
-    if (commandKeys.length > 0) {
+    if ((currentContext.commands.length > 0) || (commandKeys.length > 0)) {
       argv._.slice(currentContext.commands.length).forEach((key) => {
         if (commandKeys.indexOf(key) === -1) {
           unknown.push(key)

--- a/test/validation.js
+++ b/test/validation.js
@@ -335,6 +335,18 @@ describe('validation tests', () => {
         .parse()
     })
 
+    it('fails in strict mode with extra positionals', (done) => {
+      yargs(['kangaroo', 'jumping', 'fast'])
+        .command('kangaroo <status>', 'kangaroo handlers')
+        .strict()
+        .fail((msg) => {
+          msg.should.equal('Unknown argument: fast')
+          return done()
+        })
+        .parse()
+      expect.fail('no parsing failure')
+    })
+
     it('does not fail in strict mode when no commands configured', () => {
       const argv = yargs('koala')
         .demand(1)


### PR DESCRIPTION
The test was disabled for commandless yargs, but as the validation is done on the innermost yargs, it was always disabled.

Closes #1313 