### PR TITLE
fix: properties accessed on singleton now reflect current state of instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function singletonify (inst) {
   Object.keys(inst).forEach((key) => {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
-    } else if (inst[key] === 'function') {
+    } else if (typeof inst[key] === 'function') {
       Argv[key] = inst[key].bind(inst)
     } else {
       Argv.__defineGetter__(key, () => inst[key])

--- a/index.js
+++ b/index.js
@@ -25,8 +25,10 @@ function singletonify (inst) {
   Object.keys(inst).forEach((key) => {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
+    } else if (inst[key] === 'function') {
+      Argv[key] = inst[key].bind(inst)
     } else {
-      Argv[key] = typeof inst[key] === 'function' ? inst[key].bind(inst) : inst[key]
+      Argv.__defineGetter__(key, () => inst[key])
     }
   })
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -837,6 +837,17 @@ describe('yargs dsl tests', () => {
     })
   })
 
+  describe('parsed', () => {
+    it('should be false before parsing', () => {
+      yargs.parsed.should.equal(false)
+    })
+
+    it('should not be false after parsing', () => {
+      yargs.parse()
+      yargs.parsed.should.not.equal(false)
+    })
+  })
+
   // yargs.parse(['foo', '--bar'], function (err, argv, output) {}
   context('function passed as second argument to parse', () => {
     it('does not print to stdout', () => {


### PR DESCRIPTION
`singletonify()` used to set `Argv`'s properties to `inst`'s properties values _at the time of `Argv`'s last call_.

So `Argv`'s properties and the `inst`'s ones could diverge afterwards, such as `parsed` after a call to `parse()`, still being `false` in `Argv.parsed`, not in `inst.parse`.

`singletonify()` now adds setters to `Argv` instead, looking for the value of the corresponding property in `inst` _at the time the property is used_.