### PR TITLE
fix! yargs.parsed now populated before returning, when yargs.parse() called with no args

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,13 @@ function singletonify (inst) {
     } else if (typeof inst[key] === 'function') {
       Argv[key] = inst[key].bind(inst)
     } else {
-      Argv.__defineGetter__(key, () => inst[key])
+      Argv.__defineGetter__('$0', () => {
+        return inst.$0
+      })
+      Argv.__defineGetter__('parsed', () => {
+        console.warn('In future major releases of yargs, "parsed" will be a private field. Use the return value of ".parse()" or ".argv" instead')
+        return inst.parsed
+      })
     }
   })
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -28,7 +28,8 @@ describe('yargs dsl tests', () => {
     process.env._ = '/usr/local/bin/ndm'
     process.execPath = '/usr/local/bin/ndm'
     const argv = yargs([]).parse()
-    argv['$0'].should.eql('ndm')
+    argv['$0'].should.equal('ndm')
+    yargs.$0.should.equal('ndm')
   })
 
   it('accepts an object for aliases', () => {
@@ -862,12 +863,18 @@ describe('yargs dsl tests', () => {
 
   describe('parsed', () => {
     it('should be false before parsing', () => {
+      const warn = global.console.warn
+      global.console.warn = () => {}
       yargs.parsed.should.equal(false)
+      global.console.warn = warn
     })
 
     it('should not be false after parsing', () => {
+      const warn = global.console.warn
+      global.console.warn = () => {}
       yargs.parse()
       yargs.parsed.should.not.equal(false)
+      global.console.warn = warn
     })
   })
 

--- a/yargs.js
+++ b/yargs.js
@@ -545,7 +545,8 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (typeof args === 'undefined') {
       const parsed = self._parseArgs(processArgs)
       unfreeze()
-      return parsed
+      // TODO: remove this compatibility hack when we release yargs@15.x:
+      return (this.parsed = parsed)
     }
 
     // a context object can optionally be provided, this allows
@@ -1028,7 +1029,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     // Deprecated
     let pkgConfig = pkgUp()['yargs']
     if (pkgConfig) {
-      console.warn('Configuring yargs through package.json is deprecated and will be removed in the next major release, please use the JS API instead.')
+      console.warn('Configuring yargs through package.json is deprecated and will be removed in a future major release, please use the JS API instead.')
       options.configuration = Object.assign({}, pkgConfig, options.configuration)
     }
 


### PR DESCRIPTION
BREAKING CHANGE: we now only officially support yargs.$0 parameter and discourage direct access to yargs.parsed

https://github.com/yargs/yargs/pull/1369 and https://github.com/yargs/yargs/pull/1366 are incompatible, because `1369` unfreezes properties before returning (at which point yargs.parsed is the original value of `false`).

I would like to discourage users from accessing these properties on yargs, I've added a hack to make behavior the same as before, but now warn when `yargs.parsed` is accessed in singleton mode.