### PR TITLE
Don't alter the user supplied script name

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -151,7 +151,7 @@ module.exports = function usage (yargs, y18n) {
     normalizeAliases()
 
     // handle old demanded API
-    const base$0 = path.basename(yargs.$0)
+    const base$0 = yargs.customScriptName ? yargs.$0 : path.basename(yargs.$0)
     const demandedOptions = yargs.getDemandedOptions()
     const demandedCommands = yargs.getDemandedCommands()
     const groups = yargs.getGroups()

--- a/test/usage.js
+++ b/test/usage.js
@@ -1250,6 +1250,24 @@ describe('usage tests', () => {
       r.errors.should.have.length(0)
       r.exit.should.equal(true)
     })
+
+    it('should not alter the user supplied scriptName', () => {
+      const r = checkUsage(() => yargs(['--help'])
+        .scriptName('./custom')
+        .command('command')
+        .parse()
+      )
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        './custom [command]',
+        'Commands:',
+        '  ./custom command',
+        'Options:',
+        '  --help     Show help                                                 [boolean]',
+        '  --version  Show version number                                       [boolean]'
+      ])
+      r.errors.should.have.length(0)
+      r.exit.should.equal(true)
+    })
   })
 
   it('should succeed when rebase', () => {

--- a/yargs.js
+++ b/yargs.js
@@ -37,7 +37,8 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   if (!cwd) cwd = process.cwd()
 
-  self.scriptName = function scriptName (scriptName) {
+  self.scriptName = function (scriptName) {
+    self.customScriptName = true
     self.$0 = scriptName
     return self
   }


### PR DESCRIPTION
### Context
We have a central script (`./tvui`) in the root of our repository that is used to manage everything. It is executed directly, not through `yarn` or `npm-scripts`.

### Problem
Using `yargs.scriptName('./tvui')` results in just `tvui` being shown in all of the commands/examples. This seems to happen due to the `path.basename` call in [`lib/usage.js#154`](https://github.com/yargs/yargs/blob/e3981fd3a5f65427b4d8daae7331f956c4d2d70d/lib/usage.js#L154).

### Fix
Track that the script name was set using the `scriptName` function and don't perform a `path.basename` on it.