### PR TITLE
Support multiple epilogs being added

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -122,9 +122,9 @@ module.exports = function usage (yargs, y18n) {
   }
   self.getDescriptions = () => descriptions
 
-  let epilog
+  let epilogs = []
   self.epilog = (msg) => {
-    epilog = msg
+    epilogs.push(msg)
   }
 
   let wrapSet = false
@@ -345,8 +345,8 @@ module.exports = function usage (yargs, y18n) {
     }
 
     // the usage string.
-    if (epilog) {
-      const e = epilog.replace(/\$0/g, base$0)
+    if (epilogs.length > 0) {
+      const e = epilogs.map(epilog => epilog.replace(/\$0/g, base$0)).join('\n')
       ui.div(`${e}\n`)
     }
 
@@ -505,7 +505,7 @@ module.exports = function usage (yargs, y18n) {
     failureOutput = false
     usages = []
     usageDisabled = false
-    epilog = undefined
+    epilogs = []
     examples = []
     commands = []
     descriptions = objFilter(descriptions, (k, v) => !localLookup[k])
@@ -520,7 +520,7 @@ module.exports = function usage (yargs, y18n) {
     frozen.failureOutput = failureOutput
     frozen.usages = usages
     frozen.usageDisabled = usageDisabled
-    frozen.epilog = epilog
+    frozen.epilogs = epilogs
     frozen.examples = examples
     frozen.commands = commands
     frozen.descriptions = descriptions
@@ -531,7 +531,7 @@ module.exports = function usage (yargs, y18n) {
     failureOutput = frozen.failureOutput
     usages = frozen.usages
     usageDisabled = frozen.usageDisabled
-    epilog = frozen.epilog
+    epilogs = frozen.epilogs
     examples = frozen.examples
     commands = frozen.commands
     descriptions = frozen.descriptions

--- a/test/usage.js
+++ b/test/usage.js
@@ -1910,7 +1910,26 @@ describe('usage tests', () => {
     it('should display an epilog message at the end of the usage instructions', () => {
       const r = checkUsage(() => yargs('')
         .epilog('for more info view the manual at http://example.com')
+        .demand('y')
+        .wrap(null)
+        .parse()
+      )
+
+      r.errors.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  -y  [required]',
+        'for more info view the manual at http://example.com',
+        'Missing required argument: y'
+      ])
+    })
+
+    it('supports multiple epilogs', () => {
+      const r = checkUsage(() => yargs('')
+        .epilog('for more info view the manual at http://example.com')
         .epilog('you can also find us on slack at http://devtoolscommunity.herokuapp.com')
+        .epilog('keep up to date by reading our blog at http://yargs.js.org/blog.html')
         .demand('y')
         .wrap(null)
         .parse()
@@ -1923,6 +1942,7 @@ describe('usage tests', () => {
         '  -y  [required]',
         'for more info view the manual at http://example.com',
         'you can also find us on slack at http://devtoolscommunity.herokuapp.com',
+        'keep up to date by reading our blog at http://yargs.js.org/blog.html',
         'Missing required argument: y'
       ])
     })

--- a/test/usage.js
+++ b/test/usage.js
@@ -1910,6 +1910,7 @@ describe('usage tests', () => {
     it('should display an epilog message at the end of the usage instructions', () => {
       const r = checkUsage(() => yargs('')
         .epilog('for more info view the manual at http://example.com')
+        .epilog('you can also find us on slack at http://devtoolscommunity.herokuapp.com')
         .demand('y')
         .wrap(null)
         .parse()
@@ -1921,6 +1922,7 @@ describe('usage tests', () => {
         '  --version  Show version number  [boolean]',
         '  -y  [required]',
         'for more info view the manual at http://example.com',
+        'you can also find us on slack at http://devtoolscommunity.herokuapp.com',
         'Missing required argument: y'
       ])
     })


### PR DESCRIPTION
# Context
We wrap our commands in a function that adds `docs`, `maintainer`, and `slack` properties to the command module object. We use these properties as part of an automatically generated epilog that we add to each command.

# Problem
Currently subsequent calls to `epilog` will overwrite any previous epilog.

# Fix
Store epilogs in an array which is added to on each `epilog` call. Join them with new lines when building usage.