### PR TITLE
Allow completionCommand to be set via showCompletionScript

### DIFF
--- a/test/completion.js
+++ b/test/completion.js
@@ -158,6 +158,13 @@ describe('Completion', () => {
 
       r.logs[0].should.match(/\.\/test.js --get-yargs-completions/)
     })
+
+    it('allows $0 and cmd to be set', () => {
+      const r = checkUsage(() => yargs([])
+        .showCompletionScript('/path/to/my/app', 'show-completions-script'), ['test.js'])
+
+      r.logs[0].should.match(/Installation: \/path\/to\/my\/app show-completions-script/)
+    })
   })
 
   describe('completion()', () => {

--- a/test/completion.js
+++ b/test/completion.js
@@ -161,7 +161,7 @@ describe('Completion', () => {
 
     it('allows $0 and cmd to be set', () => {
       const r = checkUsage(() => yargs([])
-        .showCompletionScript('/path/to/my/app', 'show-completions-script'), ['test.js'])
+        .showCompletionScript('/path/to/my/app', 'show-completions-script'))
 
       r.logs[0].should.match(/Installation: \/path\/to\/my\/app show-completions-script/)
     })

--- a/yargs.js
+++ b/yargs.js
@@ -907,7 +907,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     }
 
     // register the completion command.
-    completionCommand = cmd || 'completion'
+    completionCommand = cmd || completionCommand || 'completion'
     if (!desc && desc !== false) {
       desc = 'generate completion script'
     }
@@ -919,9 +919,10 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.showCompletionScript = function ($0) {
-    argsert('[string]', [$0], arguments.length)
+  self.showCompletionScript = function ($0, cmd) {
+    argsert('[string] [string]', [$0, cmd], arguments.length)
     $0 = $0 || self.$0
+    completionCommand = cmd || completionCommand || 'completion'
     _logger.log(completion.generateCompletionScript($0, completionCommand))
     return self
   }


### PR DESCRIPTION
### Problem
When using `showCompletionScript` the variable `completionCommand` is `null` resulting in a bad installation instruction. For example:

`yargs.showCompletionScript('/usr/local/bin/my-app');`
```shell
###-begin-my-app-completions-###
#
# yargs command completion script
#
# Installation: /usr/local/bin/my-app null >> ~/.bashrc
#    or /usr/local/bin/my-app null >> ~/.bash_profile on OSX.
#
_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    type_list=$(/usr/local/bin/my-app --get-yargs-completions "${args[@]}")

    COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=()
    fi

    return 0
}
complete -o default -F _yargs_completions my-app
###-end-my-app-completions-###
```

Notice that `null` is printed for the command.

It's possible to set the `completionCommand` variable by calling `yargs.completion()` but this will also log the completion script resulting in two scripts being logged when used in conjunction with `showCompletionScript`:

`yargs.completion().showCompletionScript('/usr/local/bin/my-app');`
```shell
###-begin-my-app-completions-###
#
# yargs command completion script
#
# Installation: /usr/local/bin/my-app completion >> ~/.bashrc
#    or /usr/local/bin/my-app completion >> ~/.bash_profile on OSX.
#
_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    type_list=$(/usr/local/bin/my-app --get-yargs-completions "${args[@]}")

    COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=()
    fi

    return 0
}
complete -o default -F _yargs_completions my-app
###-end-my-app-completions-###

###-begin-my-app-completions-###
#
# yargs command completion script
#
# Installation: my-app completion >> ~/.bashrc
#    or my-app completion >> ~/.bash_profile on OSX.
#
_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    type_list=$(my-app --get-yargs-completions "${args[@]}")

    COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=()
    fi

    return 0
}
complete -o default -F _yargs_completions my-app
###-end-my-app-completions-###
```

In this case the first completion script output is correct but the second one is incorrect.

### Fix
Add a second parameter to `showCompletionScript` that allows the developer to set the completion command variable.

`yargs.showCompletionScript('/usr/local/bin/my-app', 'completion');`
```shell
###-begin-my-app-completions-###
#
# yargs command completion script
#
# Installation: /usr/local/bin/my-app completion >> ~/.bashrc
#    or /usr/local/bin/my-app completion >> ~/.bash_profile on OSX.
#
_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    type_list=$(/usr/local/bin/my-app --get-yargs-completions "${args[@]}")

    COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=()
    fi

    return 0
}
complete -o default -F _yargs_completions my-app
###-end-my-app-completions-###
```

It will default to "completion" in the same way that `completion()` does.