### PR TITLE
feat: formalize existing callback argument to showHelp

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -951,7 +951,7 @@ To submit a new translation for yargs:
 <a name="middleware"></a>.middleware(callbacks, [applyBeforeValidation])
 ------------------------------------
 
-Define global middleware functions to be called first, in list order, for all cli command.  
+Define global middleware functions to be called first, in list order, for all cli command.
 
 The `callbacks` parameter can be a function or a list of functions.  Each callback gets passed a reference to argv.
 
@@ -1310,10 +1310,12 @@ Generate a bash completion script. Users of your application can install this
 script in their `.bashrc`, and yargs will provide completion shortcuts for
 commands and options.
 
-.showHelp(consoleLevel='error')
+.showHelp()
 ---------------------------
 
-Print the usage data using the [`console`](https://nodejs.org/api/console.html) function `consoleLevel` for printing.
+Print the usage data to stderr.
+
+Later on, `argv` can be retrieved with `yargs.argv`.
 
 Example:
 
@@ -1323,13 +1325,27 @@ var yargs = require("yargs")
 yargs.showHelp(); //prints to stderr using console.error()
 ```
 
-Or, to print the usage data to `stdout` instead, you can specify the use of `console.log`:
+.showHelp(consoleLevel)
+---------------------------
+
+Print the usage data using the specified [`console`](https://nodejs.org/api/console.html) function for printing.
+
+Example:
 
 ```js
 yargs.showHelp("log"); //prints to stdout using console.log()
 ```
 
-Later on, `argv` can be retrieved with `yargs.argv`.
+.showHelp(printCallback)
+---------------------------
+
+Print the usage data using the specified callback, which accepts a single argument - the string to print.
+
+Example:
+
+```js
+yargs.showHelp(s => myStream.write(s)); //prints to myStream
+```
 
 .showHelpOnFail(enable, [message])
 ----------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -1310,14 +1310,12 @@ Generate a bash completion script. Users of your application can install this
 script in their `.bashrc`, and yargs will provide completion shortcuts for
 commands and options.
 
-.showHelp()
+.showHelp([consoleLevel | printCallback])
 ---------------------------
 
-Print the usage data to stderr.
+Print the usage data.
 
-Later on, `argv` can be retrieved with `yargs.argv`.
-
-Example:
+If no argument is provided, usage data is printed using `console.error`.
 
 ```js
 var yargs = require("yargs")
@@ -1325,27 +1323,19 @@ var yargs = require("yargs")
 yargs.showHelp(); //prints to stderr using console.error()
 ```
 
-.showHelp(consoleLevel)
----------------------------
-
-Print the usage data using the specified [`console`](https://nodejs.org/api/console.html) function for printing.
-
-Example:
+If a string is specified, usage data is printed using the [`console`](https://nodejs.org/api/console.html) function `consoleLevel`.
 
 ```js
 yargs.showHelp("log"); //prints to stdout using console.log()
 ```
 
-.showHelp(printCallback)
----------------------------
-
-Print the usage data using the specified callback, which accepts a single argument - the string to print.
-
-Example:
+If a function is specified, it is called with a single argument - the usage data as a string.
 
 ```js
 yargs.showHelp(s => myStream.write(s)); //prints to myStream
 ```
+
+Later on, `argv` can be retrieved with `yargs.argv`.
 
 .showHelpOnFail(enable, [message])
 ----------------------------------

--- a/test/usage.js
+++ b/test/usage.js
@@ -2345,7 +2345,7 @@ describe('usage tests', () => {
       ])
     })
 
-    it('should print the help to stdout when no arguments were specified', () => {
+    it('should print the help using console.error when no arguments were specified', () => {
       const r = checkUsage(() => {
         const y = yargs(['--foo'])
           .options('foo', {

--- a/test/usage.js
+++ b/test/usage.js
@@ -2345,7 +2345,27 @@ describe('usage tests', () => {
       ])
     })
 
-    it('should call the correct console.log method', () => {
+    it('should print the help to stdout when no arguments were specified', () => {
+      const r = checkUsage(() => {
+        const y = yargs(['--foo'])
+          .options('foo', {
+            alias: 'f',
+            describe: 'foo option'
+          })
+          .wrap(null)
+
+        y.showHelp()
+      })
+
+      r.errors.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]',
+        '  --foo, -f  foo option'
+      ])
+    })
+
+    it('should call the correct console.log method when specified', () => {
       const r = checkUsage(() => {
         const y = yargs(['--foo'])
           .options('foo', {
@@ -2366,7 +2386,7 @@ describe('usage tests', () => {
       ])
     })
 
-    it('should provide a help string to handler when provided', (done) => {
+    it('should call the callback to print when specified', (done) => {
       const y = yargs(['--foo'])
         .options('foo', {
           alias: 'f',
@@ -2374,8 +2394,8 @@ describe('usage tests', () => {
         })
         .wrap(null)
 
-      y.showHelp(testHandler)
-      function testHandler (msg) {
+      y.showHelp(printCallback)
+      function printCallback (msg) {
         msg.split(/\n+/).should.deep.equal([
           'Options:',
           '  --help     Show help  [boolean]',


### PR DESCRIPTION
This PR adds doc and test for an existing feature: Supplying a print callback to `usage.showHelp` instead of a `console` function name.

We use the callback in our code to explicitly specify the stdout/stderr stream dependencies of yargs - tests can use it instead of mocking the console.

Thanks for making this great library!