### PR TITLE
Don't set stateful completionCommand in showCompletionScript

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -923,8 +923,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   self.showCompletionScript = function ($0, cmd) {
     argsert('[string] [string]', [$0, cmd], arguments.length)
     $0 = $0 || self.$0
-    completionCommand = cmd || completionCommand || 'completion'
-    _logger.log(completion.generateCompletionScript($0, completionCommand))
+    _logger.log(completion.generateCompletionScript($0, cmd || completionCommand || 'completion'))
     return self
   }
 


### PR DESCRIPTION
I tried to write a test case for this but couldn't find one that reproduced the issue. I _think_ the issue only exists when using `yargs` as a singleton. The issue is that two completion scripts are logged, one from the explicit call to `showCompletionScript` and the second from [`yargs.js#1108`](https://github.com/yargs/yargs/blob/9febcbe61be4098cbb112843b899e80d2a6bb35c/yargs.js#L1108).