### PR TITLE
ES6 class as a command

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -26,7 +26,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     if (Array.isArray(cmd)) {
       aliases = cmd.slice(1)
       cmd = cmd[0]
-    } else if (typeof cmd === 'object') {
+    } else if (typeof cmd === 'object' || typeof cmd === 'function') {
       let command = (Array.isArray(cmd.command) || typeof cmd.command === 'string') ? cmd.command : moduleName(cmd)
       if (cmd.aliases) command = [].concat(command).concat(cmd.aliases)
       self.addHandler(command, extractDesc(cmd), cmd.builder, cmd.handler, cmd.middlewares)

--- a/lib/command.js
+++ b/lib/command.js
@@ -34,7 +34,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     }
 
     // allow a module to be provided instead of separate builder and handler
-    if (typeof builder === 'object' && builder.builder && typeof builder.handler === 'function') {
+    if ((typeof builder === 'object' || typeof builder === 'function') && builder.builder && typeof builder.handler === 'function') {
       self.addHandler([cmd].concat(aliases), description, builder.builder, builder.handler, builder.middlewares)
       return
     }


### PR DESCRIPTION
Currently, we can use Node.js module as a yargs command. However, ES6 class cannot be applied to `.command()` because yargs judges whether module or not with `typeof cmd === 'object'` but ES6 class is `'function'`.

Many Node.js modules return `object` as a top level module, so they have no problem when someone want to use them as yargs commands. However some modules return ES6 class, and we cannot make them as yargs commands.

In this Pull Request, I propose that not only plain objects but also ES6 classes are accepted as yargs commands.

For example, suppose XyzBank class.

```javascript
class XyzBank {
  constructor(spec) {
  }
  withdraw(amount) {
  }
  deposit(amount) {
  }

  /* helper methods for yargs */
  static get command() {
    return 'xyz <command>'
  }
  static get description() {
    return 'banking operation for Xyz bank'
  }
  static builder(yargs) {
    return yargs
      .middleware(argv => argv._obj = new XyzBank(argv))
      .command({
        command:  'withdraw <amount>',
        describe: 'withdraw money',
        handler:  async (argv) => await argv._obj.withdraw(argv.amount)
      })
      .command({
        command:  'deposit <amount>',
        describe: 'deposit money',
        handler:  async (argv) => await argv._obj.desposit(argv.amount)
      })
  }
}

module.exports = XyzBank;
```

Then, we can instantiate this class as usual, and we also use it as a yargs command.

```javascript
yargs.command('$0', 'default command', require('./banks/xyzbank');
```

or

```javascript
yargs.commandDir('./banks')
```

Such capability should be convenient for many yargs users.
