### PR TITLE
fix: detect zsh when zsh isnt run as a login prompt

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -8,7 +8,8 @@ module.exports = function completion (yargs, usage, command) {
     completionKey: 'get-yargs-completions'
   }
 
-  const zshShell = process.env.SHELL && process.env.SHELL.indexOf('zsh') !== -1
+  const zshShell = (process.env.SHELL && process.env.SHELL.indexOf('zsh') !== -1) ||
+    (process.env.ZSH_NAME && process.env.ZSH_NAME.indexOf('zsh') !== -1)
   // get a list of completion commands.
   // 'args' is the array of strings from the line to be completed
   self.getCompletion = function getCompletion (args, done) {


### PR DESCRIPTION
I don't run zsh as a login prompt, and I haven't `chsh`'d from bash to zsh, and so yargs was still giving me the bash completion when running it inside of zsh.