### PR TITLE
fix(docs): fix incorrect parserConfiguration documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -435,13 +435,11 @@ using the [`parserConfiguration()`](/docs/api.md#parserConfiguration) method you
 
 ```js
 yargs.parserConfiguration({
-  "yargs": {
-    "short-option-groups": true,
-    "camel-case-expansion": true,
-    "dot-notation": true,
-    "parse-numbers": true,
-    "boolean-negation": true
-  }
+  "short-option-groups": true,
+  "camel-case-expansion": true,
+  "dot-notation": true,
+  "parse-numbers": true,
+  "boolean-negation": true
 })
 ```
 


### PR DESCRIPTION
Looks like somebody copied the parser options from `package.json` and accidentally copied a bit too much. Hope I can save the next guy the 15 minutes it took me to figure this out...