### PR TITLE
Throw on help or version key reuse attempt

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1959,6 +1959,122 @@ describe('yargs dsl tests', () => {
     })
   })
 
+  describe('.version() and .option()', () => {
+    it('prevents .option() from reusing the default version key', () => {
+      expect(() => {
+        yargs(['--version', 'test'])
+          .option('version', {
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'version' key already used by version option/)
+    })
+
+    it('prevents .option() from reusing the default version key as an alias', () => {
+      expect(() => {
+        yargs(['--version', 'test'])
+          .option('someoption', {
+            alias: ['version'],
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'version' key already used by version option/)
+    })
+
+    it('prevents .option() from reusing a custom version key', () => {
+      expect(() => {
+        yargs(['--myversion', 'test'])
+          .version('myversion', '3.1')
+          .option('myversion', {
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'myversion' key already used by version option/)
+    })
+
+    it('prevents .option() from reusing a custom version key as an alias', () => {
+      expect(() => {
+        yargs(['--myversion', 'test'])
+          .version('myversion', '3.1')
+          .option('someoption', {
+            alias: ['myversion'],
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'myversion' key already used by version option/)
+    })
+  })
+
+  describe('.version() and .positional()', () => {
+    it('prevents .positional() from reusing the default version key', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .command('cmd [version]', 'test command', (yargs) => {
+          yargs.positional('version', {
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'version' key already used by version option/)
+    })
+
+    it('prevents .positional() from reusing the default version key as an alias', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .command('cmd [someoption]', 'test command', (yargs) => {
+          yargs.positional('someoption', {
+            alias: ['version'],
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'version' key already used by version option/)
+    })
+
+    it('prevents .positional() from reusing a custom version key', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .version('myversion', '3.1')
+        .command('cmd [myversion]', 'test command', (yargs) => {
+          yargs.positional('myversion', {
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'myversion' key already used by version option/)
+    })
+
+    it('prevents .positional() from reusing a custom version key as an alias', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .version('myversion', '3.1')
+        .command('cmd [someoption]', 'test command', (yargs) => {
+          yargs.positional('someoption', {
+            alias: ['myversion'],
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'myversion' key already used by version option/)
+    })
+  })
+
   describe('.coerce()', () => {
     it('supports string and function args (as option key and coerce function)', () => {
       const argv = yargs(['--file', path.join(__dirname, 'fixtures', 'package.json')])

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1866,6 +1866,48 @@ describe('yargs dsl tests', () => {
           .parse()
       }).to.throw(/'helpme' key already used by help option/)
     })
+
+    it('does not prevent .option() from using help key when help is disabled', () => {
+      let argv = yargs(['--help', 'test'])
+        .help(false)
+        .option('help', {
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ help: 'test' })
+    })
+
+    it('does not prevent .option() from using help key as an alias when help is disabled', () => {
+      let argv = yargs(['--help', 'test'])
+        .help(false)
+        .option('someoption', {
+          alias: ['help'],
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ someoption: 'test' })
+    })
+
+    it('does not prevent .option() from using help key when help uses another key', () => {
+      let argv = yargs(['--help', 'test'])
+        .help('info')
+        .option('help', {
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ help: 'test' })
+    })
+
+    it('does not prevent .option() from using help key as an alias when help uses another key', () => {
+      let argv = yargs(['--help', 'test'])
+        .help('info')
+        .option('someoption', {
+          alias: ['help'],
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ someoption: 'test' })
+    })
   })
 
   describe('.help() and .positional()', () => {
@@ -1874,23 +1916,6 @@ describe('yargs dsl tests', () => {
       checkOutput(() => yargs(['cmd', 'test'])
         .command('cmd [help]', 'test command', (yargs) => {
           yargs.positional('help', {
-            type: 'string'
-          })
-        })
-        .fail((_msg) => {
-          msg = _msg
-        })
-        .parse()
-      )
-      expect(msg).to.match(/'help' key already used by help option/)
-    })
-
-    it('prevents .positional() from reusing the default help key as an alias', () => {
-      let msg
-      checkOutput(() => yargs(['cmd', 'test'])
-        .command('cmd [someoption]', 'test command', (yargs) => {
-          yargs.positional('someoption', {
-            alias: ['help'],
             type: 'string'
           })
         })
@@ -1919,22 +1944,28 @@ describe('yargs dsl tests', () => {
       expect(msg).to.match(/'helpme' key already used by help option/)
     })
 
-    it('prevents .positional() from reusing a custom help key as an alias', () => {
-      let msg
-      checkOutput(() => yargs(['cmd', 'test'])
-        .help('helpme')
-        .command('cmd [someoption]', 'test command', (yargs) => {
-          yargs.positional('someoption', {
-            alias: ['helpme'],
+    it('does not prevent .positional() from using help key when help is disabled', () => {
+      let argv = yargs(['cmd', 'test'])
+        .help(false)
+        .command('cmd [help]', 'test command', (yargs) => {
+          yargs.positional('help', {
             type: 'string'
           })
         })
-        .fail((_msg) => {
-          msg = _msg
+        .parse()
+      expect(argv).to.include({ help: 'test' })
+    })
+
+    it('does not prevent .positional() from using help key when help uses another key', () => {
+      let argv = yargs(['cmd', 'test'])
+        .help('info')
+        .command('cmd [help]', 'test command', (yargs) => {
+          yargs.positional('help', {
+            type: 'string'
+          })
         })
         .parse()
-      )
-      expect(msg).to.match(/'helpme' key already used by help option/)
+      expect(argv).to.include({ help: 'test' })
     })
   })
 
@@ -2003,6 +2034,48 @@ describe('yargs dsl tests', () => {
           .parse()
       }).to.throw(/'myversion' key already used by version option/)
     })
+
+    it('does not prevent .option() from using version key when version is disabled', () => {
+      let argv = yargs(['--version', 'test'])
+        .version(false)
+        .option('version', {
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ version: 'test' })
+    })
+
+    it('does not prevent .option() from using version key as an alias when version is disabled', () => {
+      let argv = yargs(['--version', 'test'])
+        .version(false)
+        .option('someoption', {
+          alias: ['version'],
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ someoption: 'test' })
+    })
+
+    it('does not prevent .option() from using version key when version uses another key', () => {
+      let argv = yargs(['--version', 'test'])
+        .version('myversion', '3.1')
+        .option('version', {
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ version: 'test' })
+    })
+
+    it('does not prevent .option() from using version key as an alias when version uses another key', () => {
+      let argv = yargs(['--version', 'test'])
+        .version('myversion', '3.1')
+        .option('someoption', {
+          alias: ['version'],
+          type: 'string'
+        })
+        .parse()
+      expect(argv).to.include({ someoption: 'test' })
+    })
   })
 
   describe('.version() and .positional()', () => {
@@ -2011,23 +2084,6 @@ describe('yargs dsl tests', () => {
       checkOutput(() => yargs(['cmd', 'test'])
         .command('cmd [version]', 'test command', (yargs) => {
           yargs.positional('version', {
-            type: 'string'
-          })
-        })
-        .fail((_msg) => {
-          msg = _msg
-        })
-        .parse()
-      )
-      expect(msg).to.match(/'version' key already used by version option/)
-    })
-
-    it('prevents .positional() from reusing the default version key as an alias', () => {
-      let msg
-      checkOutput(() => yargs(['cmd', 'test'])
-        .command('cmd [someoption]', 'test command', (yargs) => {
-          yargs.positional('someoption', {
-            alias: ['version'],
             type: 'string'
           })
         })
@@ -2056,22 +2112,28 @@ describe('yargs dsl tests', () => {
       expect(msg).to.match(/'myversion' key already used by version option/)
     })
 
-    it('prevents .positional() from reusing a custom version key as an alias', () => {
-      let msg
-      checkOutput(() => yargs(['cmd', 'test'])
-        .version('myversion', '3.1')
-        .command('cmd [someoption]', 'test command', (yargs) => {
-          yargs.positional('someoption', {
-            alias: ['myversion'],
+    it('does not prevent .positional() from using version key when version is disabled', () => {
+      let argv = yargs(['cmd', 'test'])
+        .version(false)
+        .command('cmd [version]', 'test command', (yargs) => {
+          yargs.positional('version', {
             type: 'string'
           })
         })
-        .fail((_msg) => {
-          msg = _msg
+        .parse()
+      expect(argv).to.include({ version: 'test' })
+    })
+
+    it('does not prevent .positional() from using version key when version uses another key', () => {
+      let argv = yargs(['cmd', 'test'])
+        .version('myversion', '3.1')
+        .command('cmd [version]', 'test command', (yargs) => {
+          yargs.positional('version', {
+            type: 'string'
+          })
         })
         .parse()
-      )
-      expect(msg).to.match(/'myversion' key already used by version option/)
+      expect(argv).to.include({ version: 'test' })
     })
   })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1822,6 +1822,122 @@ describe('yargs dsl tests', () => {
     })
   })
 
+  describe('.help() and .option()', () => {
+    it('prevents .option() from reusing the default help key', () => {
+      expect(() => {
+        yargs(['--help', 'test'])
+          .option('help', {
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'help' key already used by help option/)
+    })
+
+    it('prevents .option() from reusing the default help key as an alias', () => {
+      expect(() => {
+        yargs(['--help', 'test'])
+          .option('someoption', {
+            alias: ['help'],
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'help' key already used by help option/)
+    })
+
+    it('prevents .option() from reusing a custom help key', () => {
+      expect(() => {
+        yargs(['--helpme', 'test'])
+          .help('helpme')
+          .option('helpme', {
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'helpme' key already used by help option/)
+    })
+
+    it('prevents .option() from reusing a custom help key as an alias', () => {
+      expect(() => {
+        yargs(['--helpme', 'test'])
+          .help('helpme')
+          .option('someoption', {
+            alias: ['helpme'],
+            type: 'string'
+          })
+          .parse()
+      }).to.throw(/'helpme' key already used by help option/)
+    })
+  })
+
+  describe('.help() and .positional()', () => {
+    it('prevents .positional() from reusing the default help key', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .command('cmd [help]', 'test command', (yargs) => {
+          yargs.positional('help', {
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'help' key already used by help option/)
+    })
+
+    it('prevents .positional() from reusing the default help key as an alias', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .command('cmd [someoption]', 'test command', (yargs) => {
+          yargs.positional('someoption', {
+            alias: ['help'],
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'help' key already used by help option/)
+    })
+
+    it('prevents .positional() from reusing a custom help key', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .help('helpme')
+        .command('cmd [helpme]', 'test command', (yargs) => {
+          yargs.positional('helpme', {
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'helpme' key already used by help option/)
+    })
+
+    it('prevents .positional() from reusing a custom help key as an alias', () => {
+      let msg
+      checkOutput(() => yargs(['cmd', 'test'])
+        .help('helpme')
+        .command('cmd [someoption]', 'test command', (yargs) => {
+          yargs.positional('someoption', {
+            alias: ['helpme'],
+            type: 'string'
+          })
+        })
+        .fail((_msg) => {
+          msg = _msg
+        })
+        .parse()
+      )
+      expect(msg).to.match(/'helpme' key already used by help option/)
+    })
+  })
+
   describe('.help() with .alias()', () => {
     it('uses multi-char (but not single-char) help alias as command', () => {
       const info = checkOutput(() => yargs('info')

--- a/yargs.js
+++ b/yargs.js
@@ -592,6 +592,13 @@ function Yargs (processArgs, cwd, parentRequire) {
         opt = {}
       }
 
+      if (helpOpt && (
+        (key === helpOpt) ||
+        (opt.alias && opt.alias.includes(helpOpt))
+      )) {
+        throw new YError(`'${helpOpt}' key already used by help option`)
+      }
+
       options.key[key] = true // track manually set keys.
 
       if (opt.alias) self.alias(key, opt.alias)

--- a/yargs.js
+++ b/yargs.js
@@ -599,6 +599,13 @@ function Yargs (processArgs, cwd, parentRequire) {
         throw new YError(`'${helpOpt}' key already used by help option`)
       }
 
+      if (versionOpt && (
+        (key === versionOpt) ||
+        (opt.alias && opt.alias.includes(versionOpt))
+      )) {
+        throw new YError(`'${versionOpt}' key already used by version option`)
+      }
+
       options.key[key] = true // track manually set keys.
 
       if (opt.alias) self.alias(key, opt.alias)


### PR DESCRIPTION
As stated in #1323 , one can be tempted to name a positional `help` or `version`, without knowing `yargs` already uses this keys by default. The resulting weird behavior is not easy to trace back to this.

This PR adds checks to throw an exception when trying to define an option or a positional with a key or an alias already used by the help and version options, and corresponding tests.