### PR TITLE
docs: update argument type descriptions of .options()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1111,7 +1111,7 @@ Valid `opt` keys include:
 - `coerce`: function, coerce or transform parsed command line values into another value, see [`coerce()`](#coerce)
 - `config`: boolean, interpret option as a path to a JSON config file, see [`config()`](#config)
 - `configParser`: function, provide a custom config parsing function, see [`config()`](#config)
-- `conflicts`: string or object, require certain keys not to be set, see [`conflicts()`](#conflicts)
+- `conflicts`: string or array of strings, require certain keys not to be set, see [`conflicts()`](#conflicts)
 - `count`: boolean, interpret option as a count of boolean flags, see [`count()`](#count)
 - `default`: value, set a default value for the option, see [`default()`](#default)
 - `defaultDescription`: string, use this description for the default value in help content, see [`default()`](#default)
@@ -1120,7 +1120,7 @@ Valid `opt` keys include:
 - `global`: boolean, indicate that this key should not be [reset](#reset) when a command is invoked, see [`global()`](#global)
 - `group`: string, when displaying usage instructions place the option under an alternative group heading, see [`group()`](#group)
 - `hidden`: don't display option in help output.
-- `implies`: string or object, require certain keys to be set, see [`implies()`](#implies)
+- `implies`: string or array of strings, require certain keys to be set, see [`implies()`](#implies)
 - `nargs`: number, specify how many arguments should be consumed for the option, see [`nargs()`](#nargs)
 - `normalize`: boolean, apply `path.normalize()` to the option, see [`normalize()`](#normalize)
 - `number`: boolean, interpret option as a number, [`number()`](#number)

--- a/docs/api.md
+++ b/docs/api.md
@@ -820,43 +820,6 @@ var yargs = require("yargs")(['--info'])
   .argv
 ```
 
-<a name="scriptName"></a>.scriptName($0)
-------------------
-
-Set the name of your script ($0). Default is the base filename executed by node (`process.argv[1]`)
-
-Example:
-
-```js
-var yargs = require("yargs")
-  .scriptName("my-script")
-  .help()
-  .argv
-```
-
-<a name="showHidden"></a>.showHidden()
------------------------------------------
-.showHidden([option | boolean])
------------------------------------------
-.showHidden([option, [description]])
------------------------------------------
-
-Configure the `--show-hidden` option that displays the hidden keys (see [`hide()`](#hide)).
-
-If the first argument is a boolean, it enables/disables this option altogether. i.e. hidden keys will be permanently hidden if first argument is `false`.
-
-If the first argument is a string it changes the key name ("--show-hidden").
-
-Second argument changes the default description ("Show hidden options")
-
-Example:
-
-```js
-var yargs = require("yargs")(['--help'])
-  .showHidden('show-hidden', 'Show hidden options')
-  .argv
-```
-
 <a name="implies"></a>.implies(x, y)
 --------------
 
@@ -1303,6 +1266,20 @@ if (command === 'hello') {
 }
 ```
 
+<a name="scriptName"></a>.scriptName($0)
+------------------
+
+Set the name of your script ($0). Default is the base filename executed by node (`process.argv[1]`)
+
+Example:
+
+```js
+var yargs = require("yargs")
+  .scriptName("my-script")
+  .help()
+  .argv
+```
+
 .showCompletionScript()
 ----------------------
 
@@ -1363,6 +1340,29 @@ $ node line_count.js
 Missing argument value: f
 
 Specify --help for available options
+```
+
+<a name="showHidden"></a>.showHidden()
+-----------------------------------------
+.showHidden([option | boolean])
+-----------------------------------------
+.showHidden([option, [description]])
+-----------------------------------------
+
+Configure the `--show-hidden` option that displays the hidden keys (see [`hide()`](#hide)).
+
+If the first argument is a boolean, it enables/disables this option altogether. i.e. hidden keys will be permanently hidden if first argument is `false`.
+
+If the first argument is a string it changes the key name ("--show-hidden").
+
+Second argument changes the default description ("Show hidden options")
+
+Example:
+
+```js
+var yargs = require("yargs")(['--help'])
+  .showHidden('show-hidden', 'Show hidden options')
+  .argv
 ```
 
 <a name="skipValidation"></a>.skipValidation(key)


### PR DESCRIPTION
I believe this could be an oversight?

Source: [`.option()` calls](https://github.com/yargs/yargs/blob/07c8537aa727d3c9b026523ee255758d76939cb3/yargs.js#L611), [`.conflicts()`](https://github.com/yargs/yargs/blob/07c8537aa727d3c9b026523ee255758d76939cb3/yargs.js#L444), [`.implies()`](https://github.com/yargs/yargs/blob/07c8537aa727d3c9b026523ee255758d76939cb3/yargs.js#L438)