### PR TITLE
fix: populate correct value on yargs.parsed and stop warning on access

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ function singletonify (inst) {
         return inst.$0
       })
       Argv.__defineGetter__('parsed', () => {
-        console.warn('In future major releases of yargs, "parsed" will be a private field. Use the return value of ".parse()" or ".argv" instead')
         return inst.parsed
       })
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -232,7 +232,6 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
       let handlerResult
       if (isPromise(innerArgv)) {
-        yargs.getUsageInstance().cacheHelpMessage()
         handlerResult = innerArgv.then(argv => commandHandler.handler(argv))
       } else {
         handlerResult = commandHandler.handler(innerArgv)

--- a/lib/command.js
+++ b/lib/command.js
@@ -174,7 +174,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     let numFiles = currentContext.files.length
     const parentCommands = currentContext.commands.slice()
 
-    // what does yargs look like after the buidler is run?
+    // what does yargs look like after the builder is run?
     let innerArgv = parsed.argv
     let innerYargs = null
     let positionalMap = {}
@@ -230,14 +230,19 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
       innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false)
 
-      const handlerResult = isPromise(innerArgv)
-        ? innerArgv.then(argv => commandHandler.handler(argv))
-        : commandHandler.handler(innerArgv)
+      let handlerResult
+      if (isPromise(innerArgv)) {
+        yargs.getUsageInstance().cacheHelpMessage()
+        handlerResult = innerArgv.then(argv => commandHandler.handler(argv))
+      } else {
+        handlerResult = commandHandler.handler(innerArgv)
+      }
 
       if (isPromise(handlerResult)) {
-        handlerResult.catch(error =>
+        yargs.getUsageInstance().cacheHelpMessage()
+        handlerResult.catch(error => {
           yargs.getUsageInstance().fail(null, error)
-        )
+        })
       }
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -241,7 +241,11 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
       if (isPromise(handlerResult)) {
         yargs.getUsageInstance().cacheHelpMessage()
         handlerResult.catch(error => {
-          yargs.getUsageInstance().fail(null, error)
+          try {
+            yargs.getUsageInstance().fail(null, error)
+          } catch (err) {
+            // fail's throwing would cause an unhandled rejection.
+          }
         })
       }
     }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -148,6 +148,7 @@ module.exports = function usage (yargs, y18n) {
 
   const defaultGroup = 'Options:'
   self.help = function help () {
+    if (cachedHelpMessage) return cachedHelpMessage
     normalizeAliases()
 
     // handle old demanded API
@@ -401,6 +402,13 @@ module.exports = function usage (yargs, y18n) {
         if (~options.number.indexOf(alias)) yargs.number(key)
       })
     })
+  }
+
+  // if yargs is executing an async handler, we take a snapshot of the
+  // help message to display on failure:
+  let cachedHelpMessage
+  self.cacheHelpMessage = function () {
+    cachedHelpMessage = this.help()
   }
 
   // given a set of keys, place any keys that are

--- a/yargs.js
+++ b/yargs.js
@@ -544,10 +544,12 @@ function Yargs (processArgs, cwd, parentRequire) {
     argsert('[string|array] [function|boolean|object] [function]', [args, shortCircuit, _parseFn], arguments.length)
     freeze()
     if (typeof args === 'undefined') {
-      const parsed = self._parseArgs(processArgs)
+      const argv = self._parseArgs(processArgs)
+      const tmpParsed = self.parsed
       unfreeze()
       // TODO: remove this compatibility hack when we release yargs@15.x:
-      return (this.parsed = parsed)
+      self.parsed = tmpParsed
+      return argv
     }
 
     // a context object can optionally be provided, this allows


### PR DESCRIPTION
This should address a couple minor issues that lead to #1144:

1. `self.parsed` was being populated with an `argv` instance rather than a `yargsParser.detailed` instance, leading to the missing fields that raised exceptions.
2. once `1.` was addressed, the help message was incorrect, because `async` handlers prior to this relied on state not being reset; to solve this, we now cache the help message that _would_ be displayed at the time of a promise's invocation.
3. there was one final issue related to our `self.parsed`, TypeScript executes all methods on a class, making our warning message display even though it wasn't explicitly invoked (I've reverted the warning message).

*TypeScript Issue:*

```js
var __importStar = (this && this.__importStar) || function (mod) {
    if (mod && mod.__esModule) return mod;
    var result = {};
    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
    result["default"] = mod;
    return result;
};
```

@gajus could I get you to try this out?

fixes: #1144 