### PR TITLE
Make strict() work with options containing hyphens

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -96,7 +96,7 @@ module.exports = function validation (yargs, usage, y18n) {
       if (specialKeys.indexOf(key) === -1 &&
         !positionalMap.hasOwnProperty(key) &&
         !yargs._getParseContext().hasOwnProperty(key) &&
-        !aliases.hasOwnProperty(key)
+        !self.isValidAndNotMadeUpAlias(key, aliases)
       ) {
         unknown.push(key)
       }
@@ -118,6 +118,21 @@ module.exports = function validation (yargs, usage, y18n) {
         unknown.join(', ')
       ))
     }
+  }
+
+  // check for a key that is not an alias, or for which every alias is new,
+  // implying that it was invented by the parser, e.g., during camelization
+  self.isValidAndNotMadeUpAlias = function isValidAndNotMadeUpAlias (key, aliases) {
+    if (!aliases.hasOwnProperty(key)) {
+      return false
+    }
+    const newAliases = yargs.parsed.newAliases
+    for (let a of [key, ...aliases[key]]) {
+      if (!newAliases.hasOwnProperty(a) || !newAliases[key]) {
+        return true
+      }
+    }
+    return false
   }
 
   // validate arguments limited to enumerated choices

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -96,7 +96,7 @@ module.exports = function validation (yargs, usage, y18n) {
       if (specialKeys.indexOf(key) === -1 &&
         !positionalMap.hasOwnProperty(key) &&
         !yargs._getParseContext().hasOwnProperty(key) &&
-        !self.isValidAndNotMadeUpAlias(key, aliases)
+        !self.isValidAndSomeAliasIsNotNew(key, aliases)
       ) {
         unknown.push(key)
       }
@@ -122,7 +122,7 @@ module.exports = function validation (yargs, usage, y18n) {
 
   // check for a key that is not an alias, or for which every alias is new,
   // implying that it was invented by the parser, e.g., during camelization
-  self.isValidAndNotMadeUpAlias = function isValidAndNotMadeUpAlias (key, aliases) {
+  self.isValidAndSomeAliasIsNotNew = function isValidAndSomeAliasIsNotNew (key, aliases) {
     if (!aliases.hasOwnProperty(key)) {
       return false
     }

--- a/test/usage.js
+++ b/test/usage.js
@@ -810,6 +810,15 @@ describe('usage tests', () => {
       r.should.have.property('exit').and.equal(true)
     })
 
+    it('fails when an invalid argument is provided with automatic camel case', (done) => {
+      yargs('--foo-bar')
+        .strict()
+        .fail((msg) => {
+          return done()
+        })
+        .argv
+    })
+
     it('should fail given an option argument without a corresponding description', () => {
       const r = checkUsage(() => {
         const opts = {

--- a/test/usage.js
+++ b/test/usage.js
@@ -811,7 +811,7 @@ describe('usage tests', () => {
     })
 
     it('fails when an invalid argument is provided with automatic camel case', (done) => {
-      yargs('--foo-bar')
+      return yargs('--foo-bar')
         .strict()
         .fail((msg) => {
           return done()

--- a/test/usage.js
+++ b/test/usage.js
@@ -810,13 +810,73 @@ describe('usage tests', () => {
       r.should.have.property('exit').and.equal(true)
     })
 
-    it('fails when an invalid argument is provided with automatic camel case', (done) => {
-      return yargs('--foo-bar')
-        .strict()
-        .fail((msg) => {
-          return done()
+    describe('with hyphens in options', () => {
+      it('fails when an invalid argument is provided', (done) => {
+        return yargs('--foo-bar')
+          .strict()
+          .fail((msg) => {
+            return done()
+          })
+          .argv
+      })
+
+      it('accepts valid options', () => {
+        const r = checkUsage(() => {
+          const opts = {
+            '--foo-bar': { description: 'foo bar option' },
+            '--bar-baz': { description: 'bar baz option' }
+          }
+
+          return yargs('--foo-bar --bar-baz')
+            .options(opts)
+            .strict()
+            .parse()
         })
-        .argv
+
+        r.result.should.have.property('foo-bar', true)
+        r.result.should.have.property('fooBar', true)
+        r.result.should.have.property('bar-baz', true)
+        r.result.should.have.property('barBaz', true)
+      })
+
+      it('works with aliases', () => {
+        const r = checkUsage(() => {
+          const opts = {
+            '--foo-bar': { description: 'foo bar option', alias: 'f' },
+            '--bar-baz': { description: 'bar baz option', alias: 'b' }
+          }
+
+          return yargs('--foo-bar -b')
+            .options(opts)
+            .strict()
+            .parse()
+        })
+
+        r.result.should.have.property('foo-bar', true)
+        r.result.should.have.property('fooBar', true)
+        r.result.should.have.property('f', true)
+        r.result.should.have.property('bar-baz', true)
+        r.result.should.have.property('barBaz', true)
+        r.result.should.have.property('b', true)
+      })
+
+      it('accepts mixed options with values', () => {
+        const r = checkUsage(() => {
+          const opts = {
+            '--foo-bar': { description: 'foo bar option', demand: true },
+            '--baz': { description: 'baz option', demand: true }
+          }
+
+          return yargs('--foo-bar 150 --baz')
+            .options(opts)
+            .strict()
+            .parse()
+        })
+
+        r.result.should.have.property('foo-bar', 150)
+        r.result.should.have.property('fooBar', 150)
+        r.result.should.have.property('baz', true)
+      })
     })
 
     it('should fail given an option argument without a corresponding description', () => {


### PR DESCRIPTION
Fixes #1039 #1171 #1236 #1325