### PR TITLE
Removed "default: false" on verbose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ require('yargs') // eslint-disable-line
     serve(argv.port)
   })
   .option('verbose', {
-    alias: 'v'
+    alias: 'v',
+    type: 'count',
+    description: 'Run with verbose logging. Additition 'v's (-vv, -vvv, etc) to run with even more verbose logging.'
   })
   .argv
 ```

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ require('yargs') // eslint-disable-line
     serve(argv.port)
   })
   .option('verbose', {
-    alias: 'v',
-    default: false
+    alias: 'v'
   })
   .argv
 ```


### PR DESCRIPTION
Proposal to remove "default: false" on verbose in the README.

I was mildly confused when I copied the example and called it with `-v`, expecting no value to default the value to true. However it appears as if the default value overrides both the "not passed" value, and the "passed with no value" parameter. This makes me believe "default: false" should never be used, as the default of default is effectively false.

At the very least I believe it shouldn't be part of the example in the README, especially on conjunction with the verbose parameter, which makes a program that uses verbose differently than any program I have ever seen.