### PR TITLE
fix: #1335: async middleware called twice

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -40,8 +40,7 @@ function applyMiddleware (argv, yargs, middlewares, beforeValidation) {
   const beforeValidationError = new Error('middleware cannot return a promise when applyBeforeValidation is true')
   return middlewares
     .reduce((accumulation, middleware) => {
-      if (middleware.applyBeforeValidation !== beforeValidation &&
-          !isPromise(accumulation)) {
+      if (middleware.applyBeforeValidation !== beforeValidation) {
         return accumulation
       }
 

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -160,10 +160,10 @@ describe('middleware', () => {
             )
           }
         )
-        .middleware(async (argv) => {
+        .middleware((argv) => new Promise((resolve) => {
           callCount++
-          return argv
-        })
+          resolve(argv)
+        }))
         .parse()
 
       if (!(argv instanceof Promise)) done('argv should be a Promise')

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -145,6 +145,36 @@ describe('middleware', () => {
         .exitProcess(false)
         .parse()
     })
+
+    it('calls an async middleware only once for nested subcommands', (done) => {
+      let callCount = 0
+      let argv = yargs('cmd subcmd')
+        .command(
+          'cmd',
+          'cmd command',
+          function (yargs) {
+            yargs.command(
+              'subcmd',
+              'subcmd command',
+              function (yargs) {}
+            )
+          }
+        )
+        .middleware(async (argv) => {
+          callCount++
+          return argv
+        })
+        .parse()
+
+      if (!(argv instanceof Promise)) done('argv should be a Promise')
+
+      argv
+        .then(() => {
+          callCount.should.equal(1)
+          done()
+        })
+        .catch(err => done(err))
+    })
   })
 
   // see: https://github.com/yargs/yargs/issues/1281


### PR DESCRIPTION
Closes #1335

Async middleware where called:
- once for the innermost subcommand (expected)
- then once for every parent of this subcommand (unexpected)

Due to an incorrect check in the first run of middleware (before validation).

CI will probably fail as #1411 introduced a broken test in master.