### PR TITLE
fix: support merging deeply nested configuration

### DIFF
--- a/lib/apply-extends.js
+++ b/lib/apply-extends.js
@@ -56,7 +56,7 @@ function applyExtends (config, cwd, mergeExtends) {
 
     defaultConfig = isPath ? JSON.parse(fs.readFileSync(pathToDefault, 'utf8')) : require(config.extends)
     delete config.extends
-    defaultConfig = applyExtends(defaultConfig, path.dirname(pathToDefault))
+    defaultConfig = applyExtends(defaultConfig, path.dirname(pathToDefault), mergeExtends)
   }
 
   previouslyVisitedConfigs = []

--- a/test/fixtures/extends/config_deep_2.json
+++ b/test/fixtures/extends/config_deep_2.json
@@ -1,0 +1,7 @@
+{
+ "extends": "./config_deep.json",
+  "a": {
+    "b": 12,
+    "g": 1
+  }
+}

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1402,6 +1402,23 @@ describe('yargs dsl tests', () => {
         argv.test.yes.should.equal(1)
       })
 
+      it('deep merges multiple configs when extending when deep-merge-config=true', () => {
+        const argv = yargs()
+          .parserConfiguration({ 'deep-merge-config': true })
+          .config({
+            extends: './test/fixtures/extends/config_deep_2.json',
+            a: {
+              g: 3
+            }
+          })
+          .parse()
+
+        argv.test.yes.should.equal(1)
+        argv.a.b.should.equal(12)
+        argv.a.c.should.equal(12)
+        argv.a.g.should.equal(3)
+      })
+
       it('does not deep merge objects by default', () => {
         const argv = yargs()
           .config({


### PR DESCRIPTION
There was a bug in #1411 where I've missed passing on the merge config status, that mean that we only merged the first step if you make multiple extends as mentioned in https://github.com/yargs/yargs/pull/1411#issuecomment-529964443

I added a new test case, let me know if you want me to change the old one instead.