### PR TITLE
Fix promise check to accept any spec conform object

### DIFF
--- a/lib/is-promise.js
+++ b/lib/is-promise.js
@@ -1,3 +1,3 @@
 module.exports = function isPromise (maybePromise) {
-  return maybePromise instanceof Promise
+  return !!maybePromise && !!maybePromise.then && (typeof maybePromise.then === 'function')
 }

--- a/test/is-promise.js
+++ b/test/is-promise.js
@@ -1,0 +1,34 @@
+'use strict'
+/* global describe, it */
+
+const { expect } = require('chai')
+const isPromise = require('../lib/is-promise')
+
+describe('isPromise', () => {
+  it('returns `false` on non promise value', () => {
+    expect(isPromise('hello there.')).to.be.equal(false)
+  })
+
+  it('returns `true` on es6 promise', () => {
+    const esPromise = new Promise(() => {})
+    expect(isPromise(esPromise)).to.be.equal(true)
+  })
+
+  it('returns `true` on some other thenable', () => {
+    const thenable = { then: () => {} }
+    expect(isPromise(thenable)).to.be.equal(true)
+  })
+
+  it('returns `false` if some falsy value is passed', () => {
+    expect(isPromise(null)).to.be.equal(false)
+  })
+
+  it('returns `false` if passed object has no `then` property', () => {
+    expect(isPromise({})).to.be.equal(false)
+  })
+
+  it('returns `false` if `then` is not a function', () => {
+    const obj = { then: 4711 }
+    expect(isPromise(obj)).to.be.equal(false)
+  })
+})


### PR DESCRIPTION
I came across this problem when I was creating a CLI tool which uses [NodeGit](https://www.nodegit.org/) internally. NodeGit is using its own fork of es6 promises and so yargs failed to handle my async code because it didn't return an instance of `Promise`. But yargs should accept all promises as long as they are spec conform, regardless if its an native promise, a polyfill, a bluebird promise or any custom implementation.

So, I fixed the code to look for thenable objects instead of making an instanceof check.