### PR TITLE
feat(deps): introduce yargs-parser with support for unknown-options-as-args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 * make it possible to merge configurations when extending other config. ([#1411](https://github.com/yargs/yargs/issues/1411)) ([5d7ad98](https://github.com/yargs/yargs/commit/5d7ad98))
-* **deps:** yargs-parser with support for collect-unknown-options ([#1421](https://github.com/yargs/yargs/issues/1421)) ([d388a7c](https://github.com/yargs/yargs/commit/d388a7c))
 
 ## [14.0.0](https://github.com/yargs/yargs/compare/v13.3.0...v14.0.0) (2019-07-30)
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^3.0.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^14.0.0"
+    "yargs-parser": "^15.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1725,12 +1725,27 @@ describe('yargs dsl tests', () => {
   })
 
   describe('parserConfiguration', () => {
-    it('overrides the default parser configuration ', () => {
+    it('overrides the default parser configuration', () => {
       const argv = yargs('--foo.bar 1 --no-baz 2')
         .parserConfiguration({ 'boolean-negation': false, 'dot-notation': false })
         .parse()
       expect(argv['foo.bar']).to.equal(1)
       argv.noBaz.should.equal(2)
+    })
+
+    it('supports --unknown-options-as-args', () => {
+      const argv = yargs('--foo.bar 1 --no-baz 2')
+        .parserConfiguration({ 'unknown-options-as-args': true })
+        .parse()
+      argv._.should.deep.eql(['--foo.bar', '1', '--no-baz', '2'])
+      const argv2 = yargs('foo --foo.bar --cool 1 --no-baz 2')
+        .command('foo', 'my foo command', (yargs) => {
+          yargs.boolean('cool')
+        }, () => {})
+        .parserConfiguration({ 'unknown-options-as-args': true })
+        .parse()
+      argv2._.should.deep.eql(['foo', '--foo.bar', '1', '--no-baz', '2'])
+      argv2.cool.should.equal(true)
     })
   })
 


### PR DESCRIPTION
introduces unknown-options-as-args feature, which allows unknown options to be treated as arguments (either being collected inside of `_`, or passed as values to proceeding options).

CC: @henderea, @mleguen, @kellyselden