### PR TITLE
fix(docs): TypeScript import to prevent a future major release warning

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,7 @@ The following `.options()` definition:
 
 ```typescript
 #!/usr/bin/env node
-import * as yargs from 'yargs';
+import yargs from 'yargs';
 
 const argv = yargs.options({
   a: { type: 'boolean', default: false },


### PR DESCRIPTION
Importing using `import yargs from 'yargs';` prevents a warning log to console about the `parsed` property being dropped in a future major version.

In future major releases of yargs, "parsed" will be a private field. Use the return value of ".parse()" or ".argv" instead

Closes #1439