### PR TITLE
Fixed import statement in typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,7 @@ The following `.options()` definition:
 
 ```typescript
 #!/usr/bin/env node
-import yargs from 'yargs';
+import * as yargs from 'yargs';
 
 const argv = yargs.options({
   a: { type: 'boolean', default: false },


### PR DESCRIPTION
```
import yargs from 'yargs';

const argv = yargs.options({}).argv;
```
gives
```
err.ts:3:20 - error TS2339: Property 'options' does not exist on type '{ <K extends never, V>(key: K, value: V, description?: string): Argv<Omit<{}, K> & { [key in K]: V; }>; <K extends string, V>(key: K, value: V, description?: string): Argv<{ [key in K]: V; }>; <D extends { [key: string]: any; }>(defaults: D, description?: string): Argv<...>; }'.

3 const argv = yargs.options({}).argv;
                     ~~~~~~~
```
while 
```
import * as yargs from 'yargs';

const argv = yargs.options({}).argv;
```
works ok