### PR TITLE
missing array choice regression test

### DIFF
--- a/test/yargs.js
+++ b/test/yargs.js
@@ -110,6 +110,18 @@ describe('yargs dsl tests', () => {
     argv.looks.should.eql('good')
   })
 
+  it('should ignore a missing array choice with an empty default', () => {
+    const argv = yargs(['--looks', '--looks', 'good'])
+      .option('looks', {
+        type: 'array',
+        default: [],
+        choices: ['good', 'bad']
+      })
+      .parse()
+
+    argv.looks.should.deep.eql(['good'])
+  })
+
   it('should allow defaultDescription to be set with .option()', () => {
     const optDefaultDescriptions = yargs([])
       .option('port', {


### PR DESCRIPTION
Failing test case for https://github.com/yargs/yargs-parser/issues/205.

If you change yargs-parser to v13.1.1, the test passes.

In use [here](https://github.com/CrowdStrike/faltest/blob/5403b37f6d527764eee5ae60988b1dbdd445d065/packages/cli/src/index.js#L90-L97)