### PR TITLE
chore!: drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
-  # - "11" TODO: add 11 in April when 12 goes live.
-  - "node"
+  - "12"
+  - "13"
 
 os:
   - linux

--- a/yargs.js
+++ b/yargs.js
@@ -1,4 +1,9 @@
 'use strict'
+
+// an async function creates an earl error in Node.js versions prior to 8.
+async function requiresNode8OrGreater () {}
+requiresNode8OrGreater()
+
 const argsert = require('./lib/argsert')
 const fs = require('fs')
 const Command = require('./lib/command')


### PR DESCRIPTION
Get back to tracking the Node.js release cycle a bit closer.

fixes #1438 