### PR TITLE
fix!: update to yargs-parser with fix for array default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^3.0.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^15.0.0"
+    "yargs-parser": "^16.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
BREAKING CHANGE: yargs-parser@16.0.0 drops support for Node 6