### PR TITLE
test: cover missing filter arg in obj-filter

### DIFF
--- a/test/obj-filter.js
+++ b/test/obj-filter.js
@@ -1,0 +1,16 @@
+'use strict'
+/* global describe, it */
+
+const objFilter = require('../lib/obj-filter')
+
+require('chai').should()
+
+describe('ObjFilter', () => {
+  it('returns a new reference to the original object if no filter function is given', () => {
+    const original = { foo: 'bar', baz: 'foo' }
+    const result = objFilter(original)
+
+    original.should.not.equal(result)
+    original.should.deep.equal(result)
+  })
+})


### PR DESCRIPTION
This is a contribution to https://github.com/yargs/yargs/issues/1465

BEFORE
 obj-filter.js           |      100 |       75 |    66.67 |      100 |              4,10 |

AFTER
  obj-filter.js           |      100 |    88.89 |      100 |      100 |                10 |
