### PR TITLE
Add tests for argsert warning to display positional information

### DIFF
--- a/test/argsert.js
+++ b/test/argsert.js
@@ -83,6 +83,30 @@ describe('Argsert', () => {
     o.warnings[0].should.match(/Too many arguments provided. Expected max 2 but received 3./)
   })
 
+  it('warn with argument position if wrong type is provided for argument', () => {
+    const o = checkOutput(() => {
+      function foo (opts) {
+        argsert('<string> <string> <string>', [].slice.call(arguments))
+      }
+
+      foo('hello', 'ayy', {})
+    })
+
+    o.warnings[0].should.match(/Invalid third argument. Expected string but received obj./)
+  })
+
+  it('warn with generic argument position if wrong type is provided for seventh or greater argument', () => {
+    const o = checkOutput(() => {
+      function foo (opts) {
+        argsert('<string> <string> <string> <string> <string> <string> <string>', [].slice.call(arguments))
+      }
+
+      foo('a', 'b', 'c', 'd', 'e', 'f', 10)
+    })
+
+    o.warnings[0].should.match(/Invalid manyith argument. Expected string but received number./)
+  })
+
   it('configures function to accept 0 parameters, if only arguments object is provided', () => {
     const o = checkOutput(() => {
       function foo (expected) {


### PR DESCRIPTION
Contribution towards code coverage for #1465 

This gets `lib/argsert.js` to 100% coverage. Technically only one test increased coverage, but I think there is value in both tests as there wasn't actually coverage of any positions aside from first.

Before:
![image](https://user-images.githubusercontent.com/9942473/67736235-e44ac880-f9d4-11e9-8fb8-32b57e0288fe.png)

After:
![image](https://user-images.githubusercontent.com/9942473/67736251-f593d500-f9d4-11e9-97ae-163ff71c9d68.png)
