### PR TITLE
feat: configuration setting for running detailed parse

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -435,7 +435,7 @@ using the [`parserConfiguration()`](/docs/api.md#parserConfiguration) method you
 
 ```js
 yargs.parserConfiguration({
-  "detiled": true,
+  "detailed": true,
   "short-option-groups": true,
   "camel-case-expansion": true,
   "dot-notation": true,

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -435,6 +435,7 @@ using the [`parserConfiguration()`](/docs/api.md#parserConfiguration) method you
 
 ```js
 yargs.parserConfiguration({
+  "detiled": true,
   "short-option-groups": true,
   "camel-case-expansion": true,
   "dot-notation": true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1147,6 +1147,10 @@ command handler, for example.
 
 <a name="parsed"></a>.parsed
 ------------
+
+_Note: The `.parsed` option has known limitations and is deprecated. Instead
+use `yargs.parserConfiguration({detailed: true})` to get a detailed parse._
+
 If the arguments have not been parsed, this property is `false`.
 
 If the arguments have been parsed, this contain detailed parsed arguments. See

--- a/docs/api.md
+++ b/docs/api.md
@@ -1159,7 +1159,9 @@ for details of this object
 
 `obj` accepts the following configuration options:
 
-* `sort-commands` when set to `true` (boolean) will sort the commands added, the default is `false`.
+* `detailed`: when set to `true` (boolean) [detailed parse results are returned](https://github.com/yargs/yargs-parser#requireyargs-parserdetailedargs-opts).
+  (detailed results contain additional information, such as whether arguments have been defaulted).
+* `sort-commands`: when set to `true` (boolean) will sort the commands added, the default is `false`.
 
 For additional configuration options, see [yargs-parser's configuration](https://github.com/yargs/yargs-parser#configuration).
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -234,10 +234,15 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
       innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false)
       let handlerResult
+      let detailedParse = combineDetailedParses(yargs, positionalMap)
       if (isPromise(innerArgv)) {
-        handlerResult = innerArgv.then(argv => commandHandler.handler(argv))
+        handlerResult = innerArgv.then(argv => {
+          if (detailedParse) detailedParse.argv = argv
+          commandHandler.handler(detailedParse || argv)
+        })
       } else {
-        handlerResult = commandHandler.handler(innerArgv)
+        if (detailedParse) detailedParse.argv = innerArgv
+        handlerResult = commandHandler.handler(detailedParse || innerArgv)
       }
 
       if (isPromise(handlerResult)) {
@@ -260,6 +265,19 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     if (numFiles > 0) currentContext.files.splice(numFiles * -1, numFiles)
 
     return innerArgv
+  }
+
+  function combineDetailedParses (yargs, positionalMap) {
+    let detailedParse
+    if (yargs.getParserConfiguration().detailed) {
+      detailedParse = Object.assign({}, yargs.parsed)
+      Object.keys(positionalMap).forEach(k => {
+        if (detailedParse.defaulted[k] && !positionalMap[k].defaulted) {
+          delete detailedParse.defaulted[k]
+        }
+      })
+    }
+    return detailedParse
   }
 
   function shouldUpdateUsage (yargs) {
@@ -378,6 +396,15 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
         }
       })
     }
+
+    // Populate defaulted value from parse on positionalMap. This allows us to
+    // combine the option and positional detailed parse information.
+    Object.keys(positionalMap).forEach(k => {
+      positionalMap[k] = {
+        value: positionalMap[k],
+        defaulted: !!parsed.defaulted[k]
+      }
+    })
   }
 
   self.cmdToParseOptions = function (cmdString) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -177,7 +177,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     // what does yargs look like after the builder is run?
     let innerArgv = parsed.argv
     let innerYargs = null
-    let positionalMap = {}
+    let detailedPositionalParse = {}
     if (command) {
       currentContext.commands.push(command)
       currentContext.fullCommands.push(commandHandler.original)
@@ -215,7 +215,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     }
 
     if (!yargs._hasOutput()) {
-      positionalMap = populatePositionals(commandHandler, innerArgv, currentContext, yargs)
+      detailedPositionalParse = addPositionalsToArgv(commandHandler, innerArgv, currentContext, yargs)
     }
 
     const middlewares = globalMiddleware.slice(0).concat(commandHandler.middlewares)
@@ -223,7 +223,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
     // we apply validation post-hoc, so that custom
     // checks get passed populated positional arguments.
-    if (!yargs._hasOutput()) yargs._runValidation(innerArgv, aliases, positionalMap, yargs.parsed.error)
+    if (!yargs._hasOutput()) yargs._runValidation(innerArgv, aliases, detailedPositionalParse, yargs.parsed.error)
 
     if (commandHandler.handler && !yargs._hasOutput()) {
       yargs._setHasOutput()
@@ -232,9 +232,9 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
       const populateDoubleDash = !!yargs.getOptions().configuration['populate--']
       if (!populateDoubleDash) yargs._copyDoubleDash(innerArgv)
 
-      innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false)
       let handlerResult
-      let detailedParse = combineDetailedParses(yargs, positionalMap)
+      let detailedParse = yargs.getParserConfiguration().detailed ? combineDetailedParses(yargs.parsed, detailedPositionalParse) : null
+      innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false)
       if (isPromise(innerArgv)) {
         handlerResult = innerArgv.then(argv => {
           if (detailedParse) detailedParse.argv = argv
@@ -267,16 +267,13 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     return innerArgv
   }
 
-  function combineDetailedParses (yargs, positionalMap) {
-    let detailedParse
-    if (yargs.getParserConfiguration().detailed) {
-      detailedParse = Object.assign({}, yargs.parsed)
-      Object.keys(positionalMap).forEach(k => {
-        if (detailedParse.defaulted[k] && !positionalMap[k].defaulted) {
-          delete detailedParse.defaulted[k]
-        }
-      })
-    }
+  function combineDetailedParses (detailedOptParse, detailedPositionalParse) {
+    let detailedParse = Object.assign({}, detailedOptParse)
+    Object.keys(detailedPositionalParse).forEach(k => {
+      if (detailedParse.defaulted[k] && !detailedPositionalParse[k].defaulted) {
+        delete detailedParse.defaulted[k]
+      }
+    })
     return detailedParse
   }
 
@@ -312,9 +309,13 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     }
   }
 
-  // transcribe all positional arguments "command <foo> <bar> [apple]"
-  // onto argv.
-  function populatePositionals (commandHandler, argv, context, yargs) {
+  // Pops positional arguments from argv._, and applies yargs-parser to them.
+  // allowing the same configuration to be applied to positional arguments,
+  // as is applied to option arguments.
+  //
+  // Returns detailed parse information from positional parse.
+  // Appends additional arguments to argv.
+  function addPositionalsToArgv (commandHandler, argv, context, yargs) {
     argv._ = argv._.slice(context.commands.length) // nuke the current commands
     const demanded = commandHandler.demanded.slice(0)
     const optional = commandHandler.optional.slice(0)
@@ -334,9 +335,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
 
     argv._ = context.commands.concat(argv._)
 
-    postProcessPositionals(argv, positionalMap, self.cmdToParseOptions(commandHandler.original))
-
-    return positionalMap
+    return runParserOnPositionals(argv, positionalMap, self.cmdToParseOptions(commandHandler.original))
   }
 
   function populatePositional (positional, argv, positionalMap, parseOptions) {
@@ -348,16 +347,17 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     }
   }
 
-  // we run yargs-parser against the positional arguments
+  // we run yargs-parser against the positional arguments,
   // applying the same parsing logic used for flags.
-  function postProcessPositionals (argv, positionalMap, parseOptions) {
+  function runParserOnPositionals (argv, positionalMap, parseOptions) {
+    const detailedPositionalParse = {}
     // combine the parsing hints we've inferred from the command
     // string with explicitly configured parsing hints.
     const options = Object.assign({}, yargs.getOptions())
     options.default = Object.assign(parseOptions.default, options.default)
     options.alias = Object.assign(parseOptions.alias, options.alias)
     options.array = options.array.concat(parseOptions.array)
-    delete options.config //  don't load config when processing positionals.
+    delete options.config // don't load config when processing positionals.
 
     const unparsed = []
     Object.keys(positionalMap).forEach((key) => {
@@ -366,9 +366,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
         unparsed.push(value)
       })
     })
-
-    // short-circuit parse.
-    if (!unparsed.length) return
+    if (!unparsed.length) return detailedPositionalParse
 
     const config = Object.assign({}, options.configuration, {
       'populate--': true
@@ -385,26 +383,30 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
       const positionalKeys = Object.keys(positionalMap)
       Object.keys(positionalMap).forEach((key) => {
         [].push.apply(positionalKeys, parsed.aliases[key])
+        // currently we combine the "defaulted" object from the positional
+        // parse, from the "defaulted" object from the option parse. We may
+        // eventually merge more fields from the two parses.
+        detailedPositionalParse[key] = {
+          value: positionalMap[key],
+          defaulted: !!parsed.defaulted[key]
+        }
       })
 
       Object.keys(parsed.argv).forEach((key) => {
         if (positionalKeys.indexOf(key) !== -1) {
-          // any new aliases need to be placed in positionalMap, which
-          // is used for validation.
-          if (!positionalMap[key]) positionalMap[key] = parsed.argv[key]
+          // any new aliases need to be placed in parsedPositionals, so that
+          // the new keys pass strict validation.
+          if (!detailedPositionalParse[key]) {
+            detailedPositionalParse[key] = {
+              value: parsed.argv[key],
+              defaulted: !!parsed.defaulted[key]
+            }
+          }
           argv[key] = parsed.argv[key]
         }
       })
     }
-
-    // Populate defaulted value from parse on positionalMap. This allows us to
-    // combine the option and positional detailed parse information.
-    Object.keys(positionalMap).forEach(k => {
-      positionalMap[k] = {
-        value: positionalMap[k],
-        defaulted: !!parsed.defaulted[k]
-      }
-    })
+    return detailedPositionalParse
   }
 
   self.cmdToParseOptions = function (cmdString) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -87,14 +87,14 @@ module.exports = function validation (yargs, usage, y18n) {
   }
 
   // check for unknown arguments (strict-mode).
-  self.unknownArguments = function unknownArguments (argv, aliases, positionalMap) {
+  self.unknownArguments = function unknownArguments (argv, aliases, detailedPositionalParse) {
     const commandKeys = yargs.getCommandInstance().getCommands()
     const unknown = []
     const currentContext = yargs.getContext()
 
     Object.keys(argv).forEach((key) => {
       if (specialKeys.indexOf(key) === -1 &&
-        !positionalMap.hasOwnProperty(key) &&
+        !detailedPositionalParse.hasOwnProperty(key) &&
         !yargs._getParseContext().hasOwnProperty(key) &&
         !self.isValidAndSomeAliasIsNotNew(key, aliases)
       ) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -116,7 +116,7 @@ describe('integration tests', () => {
         // our fixtures directory, so that we can test that the
         // nearest package.json is appropriately loaded.
         cpr('./', './test/fixtures/yargs', {
-          filter: /node_modules|example|test|package\.json/
+          filter: /locales|.git|coverage|docs|node_modules|example|test|package\.json/
         }, () => {
           fs.symlinkSync(process.cwd(), './test/fixtures/yargs-symlink')
           return done()

--- a/yargs.js
+++ b/yargs.js
@@ -549,7 +549,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   let parseFn = null
   let parseContext = null
   self.parse = function parse (args, shortCircuit, _parseFn) {
-    argsert('[string|array] [function|boolean|object] [function]', [args, shortCircuit, _parseFn], arguments.length)
+    argsert('[string|array] [function|boolean|object|undefined] [function|undefined]', [args, shortCircuit, _parseFn], arguments.length)
     freeze()
     if (typeof args === 'undefined') {
       const argv = self._parseArgs(processArgs)
@@ -557,7 +557,7 @@ function Yargs (processArgs, cwd, parentRequire) {
       unfreeze()
       // TODO: remove this compatibility hack when we release yargs@15.x:
       self.parsed = tmpParsed
-      return argv
+      return parserConfig.detailed ? self.parsed : argv
     }
 
     // a context object can optionally be provided, this allows
@@ -580,11 +580,12 @@ function Yargs (processArgs, cwd, parentRequire) {
 
     if (parseFn) exitProcess = false
 
-    const parsed = self._parseArgs(args, shortCircuit)
-    if (parseFn) parseFn(exitError, parsed, output)
+    const argv = self._parseArgs(args, shortCircuit)
+    const tmpParsed = self.parsed
+    if (parseFn) parseFn(exitError, parserConfig.detailed ? tmpParsed : argv, output)
     unfreeze()
 
-    return parsed
+    return parserConfig.detailed ? tmpParsed : argv
   }
 
   self._getParseContext = () => parseContext || {}


### PR DESCRIPTION
You can now set `yargs.parserConfiguration({detailed: true})` and receive detailed results from `yargs-parser`.

This provides an interface into @juergba's [defaulted functionality](https://github.com/yargs/yargs-parser/pull/211).

fixes #1334 

CC: @coreyfarrell.