### PR TITLE
docs: describe yargs.async API surface

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -1,0 +1,36 @@
+# Async API
+
+_Note: this document describes an API that has not yet been fully implemented._
+
+yargs exposes an async API surface, making it easier to compose command driven
+applications that perform asynchronous operations.
+
+As an example, perhaps you would like to create a command line application that
+fetches a URL, like curl:
+
+```js
+const fetch = require('node-fetch')
+const yargs = require('yargs').async
+const argv = yargs.command('fetch <url>', 'fetch the contents of a URL', () => {}, async (argv) => {
+  const res = await fetch(argv.url)
+  console.info(`status = ${res.status} ${res.statusText}`)
+  console.info(await res.text())
+}).argv
+await argv // resolves when the command has finished.
+```
+
+## `require('yargs').async`
+
+To create an asynchronous application simply use the `require('yargs').async`
+import, rather than `require('yargs')`. `yargs.async` varies in the following
+ways:
+
+## `.argv`
+
+## `.parse`
+
+## Command Builders
+
+## Command Handlers
+
+## Middleware

--- a/docs/async.md
+++ b/docs/async.md
@@ -1,12 +1,13 @@
 # Async API
 
-_Note: this document describes an API that has not yet been fully implemented._
+_Note: this document describes an API that has not yet been implemented, and
+serves as a design document._
 
 yargs exposes an async API surface, making it easier to compose command driven
 applications that perform asynchronous operations.
 
 As an example, perhaps you would like to create a command line application that
-fetches a URL, like curl:
+fetches the contents of a URL:
 
 ```js
 const fetch = require('node-fetch')
@@ -19,11 +20,15 @@ const argv = yargs.command('fetch <url>', 'fetch the contents of a URL', () => {
 await argv // resolves when the command has finished.
 ```
 
-## `require('yargs').async`
+Detailed specifics of the `yargs.async` API follow:
+
+## `yargs.async`
 
 To create an asynchronous application simply use the `require('yargs').async`
-import, rather than `require('yargs')`. `yargs.async` varies in the following
-ways:
+statement, rather than `require('yargs')`.
+
+The asynchronous API surface varies from the synchronous API surface in a
+variety of ways...
 
 ## `.argv`
 


### PR DESCRIPTION
## Background

@mleguen and @petrgrishin, in #1473, #1488, #1420, and #1487, have kicked off a conversation about what a better thought out asynchronous API surface for yargs would look like ... After dragging my feet initially, I now officially find myself roped in 😆 ... 

and getting a little bit excited about the potential of this cleaning up some of the ugly nooks and crannies of the yargs API.

## What is This?

As [suggested in #1487](https://github.com/yargs/yargs/issues/1487#issuecomment-557979631), I think we should start by collaborating on a document that thoroughly describes yargs' async API surface, before we dive in with the implementation