### PR TITLE
fix: show 2 dashes on help for single digit option key or alias

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -272,7 +272,7 @@ module.exports = function usage (yargs, y18n) {
             // for the special positional group don't
             // add '--' or '-' prefix.
             if (groupName === self.getPositionalGroupName()) return sw
-            else return (sw.length > 1 ? '--' : '-') + sw
+            else return (/^[^0-9]$/.test(sw) ? '-' : '--') + sw
           })
           .join(', ')
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -1121,6 +1121,51 @@ describe('usage tests', () => {
       ])
     })
 
+    it.only('should use 2 dashes for 1-digit key usage', () => {
+      const r = checkUsage(() => yargs(['--help'])
+        .option('1', {
+          type: 'boolean',
+          description: 'Negative one'
+        })
+        .wrap(null)
+        .parse()
+      )
+      r.should.have.property('result')
+      r.result.should.have.property('_').with.length(0)
+      r.should.have.property('exit').and.equal(true)
+      r.should.have.property('errors').with.length(0)
+      r.should.have.property('logs')
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --1        Negative one  [boolean]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]'
+      ])
+    })
+
+    it.only('should use 2 dashes for 1-digit alias usage', () => {
+      const r = checkUsage(() => yargs(['--help'])
+        .option('negativeone', {
+          alias: '1',
+          type: 'boolean',
+          description: 'Negative one'
+        })
+        .wrap(null)
+        .parse()
+      )
+      r.should.have.property('result')
+      r.result.should.have.property('_').with.length(0)
+      r.should.have.property('exit').and.equal(true)
+      r.should.have.property('errors').with.length(0)
+      r.should.have.property('logs')
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --help              Show help  [boolean]',
+        '  --version           Show version number  [boolean]',
+        '  --negativeone, --1  Negative one  [boolean]'
+      ])
+    })
+
     describe('when exitProcess is false', () => {
       it('should not validate arguments (required argument)', () => {
         const r = checkUsage(() => yargs(['--help'])

--- a/test/usage.js
+++ b/test/usage.js
@@ -1121,7 +1121,7 @@ describe('usage tests', () => {
       ])
     })
 
-    it.only('should use 2 dashes for 1-digit key usage', () => {
+    it('should use 2 dashes for 1-digit key usage', () => {
       const r = checkUsage(() => yargs(['--help'])
         .option('1', {
           type: 'boolean',
@@ -1143,7 +1143,7 @@ describe('usage tests', () => {
       ])
     })
 
-    it.only('should use 2 dashes for 1-digit alias usage', () => {
+    it('should use 2 dashes for 1-digit alias usage', () => {
       const r = checkUsage(() => yargs(['--help'])
         .option('negativeone', {
           alias: '1',


### PR DESCRIPTION
To be coherent with what yargs/parser considers as an option single dash key, do not display '-1' but '--1' when '1' is used as an option key or an alias.

See #1454 