### PR TITLE
doc(typescript): suggest both import syntax

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,9 @@ The following `.options()` definition:
 
 ```typescript
 #!/usr/bin/env node
-import yargs from 'yargs';
+import * as yargs from 'yargs';
+// or with the "esModuleInterop" compiler option set to "true":
+// import yargs from 'yargs';
 
 const argv = yargs.options({
   a: { type: 'boolean', default: false },


### PR DESCRIPTION
As stated in #1455 , the typescript example in the documentation is misleading, as the import syntax used (`import yargs`) only works when "esModuleInterop" is set to "true", which is not the default typescript configuration.

So this PR suggests both syntax, with the default syntax being the one working with the default typescript configuration (`import * as yargs`).