### PR TITLE
fix getCompletion() no longer working for options

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -8,6 +8,11 @@ module.exports = function completion (yargs, usage, command) {
     completionKey: 'get-yargs-completions'
   }
 
+  let aliases
+  self.setParsed = function setParsed (parsed) {
+    aliases = parsed.aliases
+  }
+
   const zshShell = (process.env.SHELL && process.env.SHELL.indexOf('zsh') !== -1) ||
     (process.env.ZSH_NAME && process.env.ZSH_NAME.indexOf('zsh') !== -1)
   // get a list of completion commands.
@@ -16,7 +21,6 @@ module.exports = function completion (yargs, usage, command) {
     const completions = []
     const current = args.length ? args[args.length - 1] : ''
     const argv = yargs.parse(args, true)
-    const aliases = yargs.parsed.aliases
     const parentCommands = yargs.getContext().commands
 
     // a custom completion function can be provided

--- a/test/completion.js
+++ b/test/completion.js
@@ -358,9 +358,24 @@ describe('Completion', () => {
               })
             })
         })
-
         r.logs.should.include('apple')
         r.logs.should.include('foo')
+      })
+      it('returns default completion to callback for options', () => {
+        process.env.SHELL = '/bin/bash'
+        const r = checkUsage(() => {
+          yargs()
+            .option('apple')
+            .option('foo')
+            .completion()
+            .getCompletion(['$0', '-'], (completions) => {
+              ;(completions || []).forEach((completion) => {
+                console.log(completion)
+              })
+            })
+        })
+        r.logs.should.include('--apple')
+        r.logs.should.include('--foo')
       })
     })
   })

--- a/yargs.js
+++ b/yargs.js
@@ -581,6 +581,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (parseFn) exitProcess = false
 
     const parsed = self._parseArgs(args, shortCircuit)
+    completion.setParsed(self.parsed)
     if (parseFn) parseFn(exitError, parsed, output)
     unfreeze()
 


### PR DESCRIPTION
getCompletion() throws when completing an option, as it needs `parsed.aliases`, which is lost (unfreezed) when calling `.parse()` with arguments.

See #1434 

This is a side effect of fixing `.parse()` to be able to call it several times, a few months ago.

This PR provides `parsed` to completion before unfreezing it.