### PR TITLE
Advanced docs typo 'comand'

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -453,7 +453,7 @@ for detailed documentation of this feature.
 ### Example
 ```
 yargs
-    .comand('cmd', ..., async () => {
+    .command('cmd', ..., async () => {
         await this.model.find()
         return Promise.resolve('result value')
     })


### PR DESCRIPTION
Fixes typo 'comand' -> 'command'
On @mleguen petition: https://github.com/yargs/yargs/pull/1473#discussion_r353603365