### PR TITLE
fix: populate positionals when unknown-options-as-args is set

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -355,6 +355,7 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
     const unparsed = []
     Object.keys(positionalMap).forEach((key) => {
       positionalMap[key].map((value) => {
+        if (options.configuration['unknown-options-as-args']) options.key[key] = true
         unparsed.push(`--${key}`)
         unparsed.push(value)
       })

--- a/test/command.js
+++ b/test/command.js
@@ -39,14 +39,25 @@ describe('Command', () => {
         .parse()
     })
 
-    it('populates outer argv with positional arguments', () => {
+    it('populates outer argv with positional arguments when unknown-options-as-args is not set', () => {
       const argv = yargs('foo hello world')
         .command('foo <bar> [awesome]')
         .parse()
 
       argv._.should.include('foo')
-      argv.bar.should.equal('hello')
-      argv.awesome.should.equal('world')
+      argv.should.have.property('bar', 'hello')
+      argv.should.have.property('awesome', 'world')
+    })
+
+    it('populates outer argv with positional arguments when unknown-options-as-args is set', () => {
+      const argv = yargs('foo hello world')
+        .command('foo <bar> [awesome]')
+        .parserConfiguration({ 'unknown-options-as-args': true })
+        .parse()
+
+      argv._.should.include('foo')
+      argv.should.have.property('bar', 'hello')
+      argv.should.have.property('awesome', 'world')
     })
 
     it('populates argv with camel-case variants of arguments when possible', () => {


### PR DESCRIPTION
Positionals where no longer populated using `unknown-options-as-args`, as yargs turned them into options before handing them to yargs, but withoud declaring the corresponding option. So they were handled by yargs-parser as unknown options.

The "hidden" options for the positionals are now declared when using `unknown-options-as-args`.

Closes #1444.