### PR TITLE
add link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn add yargs-parser && yarn link && yarn link yargs && cd example && node divide -x 2 -y 4"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![js-standard-style][standard-image]][standard-url]
 [![Conventional Commits][conventional-commits-image]][conventional-commits-url]
 [![Slack][slack-image]][slack-url]
+[![run on repl.it](http://repl.it/badge/github/yargs/yargs)](https://repl.it/github/yargs/yargs)
 
 ## Description :
 Yargs helps you build interactive command line tools, by parsing arguments and generating an elegant user interface.


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-yargs):

![image](https://i.imgur.com/e8c0T3P.png)
