### PR TITLE
fix(docs): use recommended cjs import syntax for ts examples

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,9 +7,7 @@ The following `.options()` definition:
 
 ```typescript
 #!/usr/bin/env node
-import * as yargs from 'yargs';
-// or with the "esModuleInterop" compiler option set to "true":
-// import yargs from 'yargs';
+import yargs = require('yargs');
 
 const argv = yargs.options({
   a: { type: 'boolean', default: false },

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -23,7 +23,7 @@ console.log(yargs.parse())
 
 Or for typescript users, `src/index.ts`:
 ```ts
-import * as yargs from 'yargs';
+import yargs = require('yargs');
 
 console.log(yargs.parse());
 ```


### PR DESCRIPTION
Fix typescript examples to use the right import syntax for a commonjs module such as yargs.

See explanation in typescript documentation [here](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require):

> Both CommonJS and AMD generally have the concept of an exports object which contains all exports from a module.
>
> [...]
>
> When exporting a module using export =, TypeScript-specific import module = require("module") must be used to import the module.