### PR TITLE
Revert "feat: requiresArg is now simply an alias for nargs(1) (#1054)…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules/
 test.js
 coverage
 package-lock.json
+yarn.lock
 .npmrc

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -54,6 +54,40 @@ module.exports = function validation (yargs, usage, y18n) {
     }
   }
 
+  // make sure that any args that require an
+  // value (--foo=bar), have a value.
+  self.missingArgumentValue = function missingArgumentValue (argv) {
+    const options = yargs.getOptions()
+    if (options.requiresArg.length > 0) {
+      const missingRequiredArgs = []
+      const defaultValues = new Set([true, false, ''])
+
+      options.requiresArg.forEach((key) => {
+        // if the argument is not set in argv no need to check
+        // whether a right-hand-side has been provided.
+        if (!argv.hasOwnProperty(key)) return
+
+        const value = argv[key]
+        // if a value is explicitly requested,
+        // flag argument as missing if it does not
+        // look like foo=bar was entered.
+        if (defaultValues.has(value) ||
+          (Array.isArray(value) && !value.length)) {
+          missingRequiredArgs.push(key)
+        }
+      })
+
+      if (missingRequiredArgs.length > 0) {
+        usage.fail(__n(
+          'Missing argument value: %s',
+          'Missing argument values: %s',
+          missingRequiredArgs.length,
+          missingRequiredArgs.join(', ')
+        ))
+      }
+    }
+  }
+
   // make sure all the required arguments are present.
   self.requiredArguments = function requiredArguments (argv) {
     const demandedOptions = yargs.getDemandedOptions()

--- a/test/usage.js
+++ b/test/usage.js
@@ -693,7 +693,7 @@ describe('usage tests', () => {
           '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
-          'Not enough arguments following: f'
+          'Missing argument value: foo'
         ])
       })
 
@@ -722,7 +722,7 @@ describe('usage tests', () => {
           '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
-          'Not enough arguments following: bar'
+          'Missing argument values: foo, bar'
         ])
       })
     })
@@ -754,7 +754,7 @@ describe('usage tests', () => {
           '  --version  Show version number  [boolean]',
           '  --foo, -f  foo option',
           '  --bar, -b  bar option',
-          'Not enough arguments following: f'
+          'Missing argument value: foo'
         ])
       })
     })
@@ -769,7 +769,7 @@ describe('usage tests', () => {
         .parse()
       )
 
-      r.errors[2].should.equal('Not enough arguments following: bar')
+      r.errors[2].should.equal('Missing argument values: foo, bar')
     })
   })
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -477,7 +477,7 @@ describe('validation tests', () => {
         .option('w', { type: 'string', requiresArg: true })
         .parse('-w', (err, argv, output) => {
           expect(err).to.not.equal(undefined)
-          expect(err).to.have.property('message', 'Not enough arguments following: w')
+          expect(err).to.have.property('message', 'Missing argument value: w')
           return done()
         })
     })
@@ -487,7 +487,7 @@ describe('validation tests', () => {
         .option('w', { type: 'boolean', requiresArg: true })
         .parse('-w', (err, argv, output) => {
           expect(err).to.not.equal(undefined)
-          expect(err).to.have.property('message', 'Not enough arguments following: w')
+          expect(err).to.have.property('message', 'Missing argument value: w')
           return done()
         })
     })
@@ -497,7 +497,7 @@ describe('validation tests', () => {
         .option('w', { type: 'array', requiresArg: true })
         .parse('-w', (err, argv, output) => {
           expect(err).to.not.equal(undefined)
-          expect(err).to.have.property('message', 'Not enough arguments following: w')
+          expect(err).to.have.property('message', 'Missing argument value: w')
           return done()
         })
     })
@@ -519,6 +519,28 @@ describe('validation tests', () => {
         .command('woo')
         .parse('woo', (err, argv, output) => {
           expect(err).to.equal(null)
+          return done()
+        })
+    })
+
+    it('does not prevent array argument from being parsed completely (#1098)', (done) => {
+      yargs()
+        .option('w', { type: 'array', requiresArg: true })
+        .command('woo')
+        .parse('-w foo bar -- positional', (err, argv, output) => {
+          expect(err).to.equal(null)
+          expect(argv.w).to.have.lengthOf(2)
+          return done()
+        })
+    })
+
+    it('does not prevent array argument from being parsed completely with subcommand (#1098)', (done) => {
+      yargs()
+        .option('w', { type: 'array', requiresArg: true })
+        .command('woo')
+        .parse('woo -w foo bar -- positional', (err, argv, output) => {
+          expect(err).to.equal(null)
+          expect(argv.w).to.have.lengthOf(2)
           return done()
         })
     })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -276,6 +276,7 @@ describe('yargs dsl tests', () => {
         defaultDescription: {},
         choices: {},
         coerce: {},
+        requiresArg: [],
         skipValidation: [],
         count: [],
         normalize: [],


### PR DESCRIPTION
…", add test cases for the regression

This reverts commit a3ddacc87e6cbb8a275f97d746511fe1d1f93044 merged with #1054 , which introduced #1098 

#1054 incorrectly reimplemented `requiresArg` in terms of `nargs` based on an incorrect understanding of what these features do. It broke `requiresArg`, and fixing it must not wait for `nargs` to be redesigned so that it can be used to correctly implement the semantics of `requiresArg`.