### PR TITLE
fix: help always displayed for the first command parsed having an async handler

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -256,6 +256,9 @@ module.exports = function command (yargs, usage, validation, globalMiddleware) {
             // fail's throwing would cause an unhandled rejection.
             }
           })
+          .then(() => {
+            yargs.getUsageInstance().clearCachedHelpMessage()
+          })
       } else {
         if (handlerFinishCommand) {
           handlerFinishCommand(handlerResult)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -411,6 +411,12 @@ module.exports = function usage (yargs, y18n) {
     cachedHelpMessage = this.help()
   }
 
+  // however this snapshot must be cleared afterwards
+  // not to be be used by next calls to parse
+  self.clearCachedHelpMessage = function () {
+    cachedHelpMessage = undefined
+  }
+
   // given a set of keys, place any keys that are
   // ungrouped under the 'Options:' grouping.
   function addUngroupedKeys (keys, aliases, groups) {

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -34,8 +34,7 @@ exports.checkOutput = function checkOutput (f, argv, cb) {
     }
     process.emit = function emit (ev, value) {
       if (ev === 'uncaughtException') {
-        done()
-        cb(value)
+        cb(value, done())
         return true
       }
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -3432,7 +3432,7 @@ describe('usage tests', () => {
   })
 
   describe('help message caching', () => {
-    it.only('should display proper usage when an async handler fails', (done) => {
+    it('should display proper usage when an async handler fails', (done) => {
       const y = yargs()
         .command('cmd', 'test command', {}, () => {
           return new Promise((resolve, reject) =>
@@ -3464,7 +3464,7 @@ describe('usage tests', () => {
       )
     })
 
-    it.only('should not display a cached help message for the next parsing', (done) => {
+    it('should not display a cached help message for the next parsing', (done) => {
       const y = yargs()
         .command('cmd', 'test command', {}, () => {
           return new Promise((resolve, reject) =>


### PR DESCRIPTION
Close #1533 

After a call to `.parse()` for a command with an async handler, next calls to parse, if they need to display help, display help for this command.