### PR TITLE
Use process.defaultApp to detect built electron app

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1273,7 +1273,8 @@ if (command === 'hello') {
 <a name="scriptName"></a>.scriptName($0)
 ------------------
 
-Set the name of your script ($0). Default is the base filename executed by node (`process.argv[1]`)
+Set the name of your script ($0). Default is the base filename executed by node
+(`process.argv[1]` or `process.argv[0]` for built electron apps)
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
 // without running as a singleton do:
 // require('yargs/yargs')(process.argv.slice(2))
 const yargs = require('./yargs')
+const processArgv = require('./lib/process-argv')
 
-Argv(process.argv.slice(2))
+Argv(processArgv.getProcessArgvWithoutBin())
 
 module.exports = Argv
 

--- a/lib/process-argv.js
+++ b/lib/process-argv.js
@@ -1,0 +1,20 @@
+function getProcessArgvBinIndex () {
+  // Built Electron app: app argv1 argv2 ... argvn
+  // (see https://github.com/electron/electron/issues/4690#issuecomment-217435222)
+  if (process.defaultApp === false) return 0
+  // Default: node app.js argv1 argv2 ... argvn
+  return 1
+}
+
+function getProcessArgvWithoutBin () {
+  return process.argv.slice(getProcessArgvBinIndex() + 1)
+}
+
+function getProcessArgvBin () {
+  return process.argv[getProcessArgvBinIndex()]
+}
+
+module.exports = {
+  getProcessArgvBin,
+  getProcessArgvWithoutBin
+}

--- a/lib/process-argv.js
+++ b/lib/process-argv.js
@@ -1,6 +1,7 @@
 function getProcessArgvBinIndex () {
   // Built Electron app: app argv1 argv2 ... argvn
-  // (see https://github.com/electron/electron/issues/4690#issuecomment-217435222)
+  // (process.defaultApp is set to false by electron for built app for this purpose,
+  // see https://github.com/electron/electron/issues/4690#issuecomment-217435222)
   if (process.defaultApp === false) return 0
   // Default: node app.js argv1 argv2 ... argvn
   return 1

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -15,11 +15,17 @@ const noop = () => {}
 const implicationsFailedPattern = new RegExp(english['Implications failed:'])
 
 describe('yargs dsl tests', () => {
+  const oldProcess = {}
+
   beforeEach(() => {
+    oldProcess.argv = process.argv
+    oldProcess.defaultApp = process.defaultApp
     yargs = require('../')
   })
 
   afterEach(() => {
+    process.argv = oldProcess.argv
+    process.defaultApp = oldProcess.defaultApp
     delete require.cache[require.resolve('../')]
   })
 
@@ -30,6 +36,15 @@ describe('yargs dsl tests', () => {
     const argv = yargs([]).parse()
     argv['$0'].should.equal('ndm')
     yargs.$0.should.equal('ndm')
+  })
+
+  it('should not remove the 1st argument of built electron apps', () => {
+    delete require.cache[require.resolve('../')]
+    process.argv = ['/usr/local/bin/app', '-f', 'toto']
+    process.defaultApp = false
+    yargs = require('../')
+    const argv = yargs.parse()
+    argv['f'].should.equal('toto')
   })
 
   it('accepts an object for aliases', () => {

--- a/yargs.js
+++ b/yargs.js
@@ -18,6 +18,7 @@ const setBlocking = require('set-blocking')
 const applyExtends = require('./lib/apply-extends')
 const { globalMiddlewareFactory } = require('./lib/middleware')
 const YError = require('./lib/yerror')
+const processArgv = require('./lib/process-argv')
 
 exports = module.exports = Yargs
 function Yargs (processArgs, cwd, parentRequire) {
@@ -64,7 +65,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     })
     .join(' ').trim()
 
-  if (process.env._ !== undefined && process.argv[1] === process.env._) {
+  if (process.env._ !== undefined && processArgv.getProcessArgvBin() === process.env._) {
     self.$0 = process.env._.replace(
       `${path.dirname(process.execPath)}/`, ''
     )


### PR DESCRIPTION
If process.defaultApp is false (for built electron app), remove only the first element of process.argv (the app binary) and not the two first elements (node + the app script).

See https://github.com/electron/electron/issues/4690#issuecomment-217435222 for mor info.

Solve part of #685 
