### PR TITLE
Vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "decamelize": "^1.2.0",
     "find-up": "^4.1.0",
     "get-caller-file": "^2.0.1",
+    "os-locale": "^4.0.0",
     "require-directory": "^2.1.1",
     "require-main-filename": "^2.0.0",
     "set-blocking": "^2.0.0",


### PR DESCRIPTION
I'm not completely sure of what I'm doing, but 
npm audit 
reported a low vulnerability error derived from mem module used inside the os-locale module which was fixed in mem@>=4.0.0 and updated in os-locale@4.0.0
Make your checks to see if this makes sense