### PR TITLE
feat: introduces strictCommands() subset of strict mode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1408,9 +1408,6 @@ Similar to `.strict()`, except that it only applies to unrecognized commands. A
 user can still provide arbitrary options, but unknown positional commands
 will raise an error.
 
-_Note: if you use `.demandCommand()` or `.demandCommand(1)`, in conjunction
-with defining commands, `.strictCommands()` is enabled automatically.
-
 <a name="string"></a>.string(key)
 ------------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1401,6 +1401,16 @@ corresponding description, will be reported as an error.
 
 Unrecognized commands will also be reported as errors.
 
+.strictCommands([enabled=true])
+---------
+
+Similar to `.strict()`, except that it only applies to unrecognized commands. A
+user can still provide arbitrary options, but unknown positional commands
+will raise an error.
+
+_Note: if you use `.demandCommand()` or `.demandCommand(1)`, in conjunction
+with defining commands, `.strictCommands()` is enabled automatically.
+
 <a name="string"></a>.string(key)
 ------------
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -16,13 +16,6 @@ module.exports = function validation (yargs, usage, y18n) {
     const demandedCommands = yargs.getDemandedCommands()
     // don't count currently executing commands
     const _s = argv._.length - yargs.getContext().commands.length
-    const commandKeys = yargs.getCommandInstance().getCommands()
-
-    // for the special case of yargs.demandCommand() and yargs.demandCommand(1), if
-    // yargs has been configured with commands, we automatically enable strictCommands.
-    if (commandKeys.length && demandedCommands._ && demandedCommands._.min === 1 && demandedCommands._.max === Infinity) {
-      yargs.strictCommands()
-    }
 
     if (demandedCommands._ && (_s < demandedCommands._.min || _s > demandedCommands._.max)) {
       if (_s < demandedCommands._.min) {
@@ -142,8 +135,8 @@ module.exports = function validation (yargs, usage, y18n) {
 
     if (unknown.length > 0) {
       usage.fail(__n(
-        'Unknown argument: %s',
-        'Unknown arguments: %s',
+        'Unknown command: %s',
+        'Unknown commands: %s',
         unknown.length,
         unknown.join(', ')
       ))

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -16,6 +16,13 @@ module.exports = function validation (yargs, usage, y18n) {
     const demandedCommands = yargs.getDemandedCommands()
     // don't count currently executing commands
     const _s = argv._.length - yargs.getContext().commands.length
+    const commandKeys = yargs.getCommandInstance().getCommands()
+
+    // for the special case of yargs.demandCommand() and yargs.demandCommand(1), if
+    // yargs has been configured with commands, we automatically enable strictCommands.
+    if (commandKeys.length && demandedCommands._ && demandedCommands._.min === 1 && demandedCommands._.max === Infinity) {
+      yargs.strictCommands()
+    }
 
     if (demandedCommands._ && (_s < demandedCommands._.min || _s > demandedCommands._.max)) {
       if (_s < demandedCommands._.min) {
@@ -117,6 +124,32 @@ module.exports = function validation (yargs, usage, y18n) {
         unknown.length,
         unknown.join(', ')
       ))
+    }
+  }
+
+  self.unknownCommands = function unknownCommands (argv, aliases, positionalMap) {
+    const commandKeys = yargs.getCommandInstance().getCommands()
+    const unknown = []
+    const currentContext = yargs.getContext()
+
+    if ((currentContext.commands.length > 0) || (commandKeys.length > 0)) {
+      argv._.slice(currentContext.commands.length).forEach((key) => {
+        if (commandKeys.indexOf(key) === -1) {
+          unknown.push(key)
+        }
+      })
+    }
+
+    if (unknown.length > 0) {
+      usage.fail(__n(
+        'Unknown argument: %s',
+        'Unknown arguments: %s',
+        unknown.length,
+        unknown.join(', ')
+      ))
+      return true
+    } else {
+      return false
     }
   }
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -966,7 +966,7 @@ describe('validation tests', () => {
         .strictCommands()
         .command('foo', 'foo command')
         .fail((msg) => {
-          msg.should.equal('Unknown argument: blerg')
+          msg.should.equal('Unknown command: blerg')
           return done()
         })
         .parse()
@@ -979,22 +979,29 @@ describe('validation tests', () => {
           yargs.command('bar')
         })
         .fail((msg) => {
-          msg.should.equal('Unknown argument: blarg')
+          msg.should.equal('Unknown command: blarg')
           return done()
         })
         .parse()
     })
 
-    it('enables strict commands if commands used in conjunction with demandCommand', (done) => {
-      yargs('blerg -a 10')
-        .demandCommand()
-        .command('foo', 'foo command')
-        .fail((msg) => {
-          msg.should.equal('Unknown argument: blerg')
-          return done()
-        })
-        .parse()
-    })
+    // TODO(bcoe): consider implementing this behvaior in the next major version of yargs:
+    //
+    // // for the special case of yargs.demandCommand() and yargs.demandCommand(1), if
+    // // yargs has been configured with commands, we automatically enable strictCommands.
+    // if (commandKeys.length && demandedCommands._ && demandedCommands._.min === 1 && demandedCommands._.max === Infinity) {
+    //   yargs.strictCommands()
+    // }
+    // it('enables strict commands if commands used in conjunction with demandCommand', (done) => {
+    //   yargs('blerg -a 10')
+    //     .demandCommand()
+    //     .command('foo', 'foo command')
+    //     .fail((msg) => {
+    //       msg.should.equal('Unknown command: blerg')
+    //       return done()
+    //     })
+    //     .parse()
+    // })
 
     it('does not apply implicit strictCommands to inner commands', () => {
       const parse = yargs('foo blarg --cool beans')
@@ -1013,7 +1020,7 @@ describe('validation tests', () => {
           yargs.command('bar').strictCommands()
         })
         .fail((msg) => {
-          msg.should.equal('Unknown argument: blarg')
+          msg.should.equal('Unknown command: blarg')
           return done()
         })
         .parse()

--- a/yargs.js
+++ b/yargs.js
@@ -167,6 +167,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     validation.freeze()
     command.freeze()
     frozen.strict = strict
+    frozen.strictCommands = strictCommands
     frozen.completionCommand = completionCommand
     frozen.output = output
     frozen.exitError = exitError
@@ -190,6 +191,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     validation.unfreeze()
     command.unfreeze()
     strict = frozen.strict
+    strictCommands = frozen.strictCommands
     completionCommand = frozen.completionCommand
     parseFn = frozen.parseFn
     parseContext = frozen.parseContext
@@ -795,6 +797,14 @@ function Yargs (processArgs, cwd, parentRequire) {
   }
   self.getStrict = () => strict
 
+  let strictCommands = false
+  self.strictCommands = function (enabled) {
+    argsert('[boolean]', [enabled], arguments.length)
+    strictCommands = enabled !== false
+    return self
+  }
+  self.getStrictCommands = () => strictCommands
+
   let parserConfig = {}
   self.parserConfiguration = function parserConfiguration (config) {
     argsert('<object>', [config], arguments.length)
@@ -1219,7 +1229,13 @@ function Yargs (processArgs, cwd, parentRequire) {
     if (parseErrors) throw new YError(parseErrors.message)
     validation.nonOptionCount(argv)
     validation.requiredArguments(argv)
-    if (strict) validation.unknownArguments(argv, aliases, positionalMap)
+    let failedStrictCommands = false
+    if (strictCommands) {
+      failedStrictCommands = validation.unknownCommands(argv, aliases, positionalMap)
+    }
+    if (strict && !failedStrictCommands) {
+      validation.unknownArguments(argv, aliases, positionalMap)
+    }
     validation.customChecks(argv, aliases)
     validation.limitedChoices(argv)
     validation.implications(argv)


### PR DESCRIPTION
I have met your demands @boneskull 

This seemed like a reasonable feature request, and I'm excited to see whether you get use out of it.

Code review appreciated.

---

~BREAKING CHANGE: if you use `.demandCommand()` or `.demandCommand(1)`, in conjunction
with defining commands, `.strictCommands()` is enabled automatically.~

Since the breaking changes to `yargs-parser` were for undocumented behavior (and 15.x.x was actually a regression with regards to the parsing of booleans, I'm going to try to release 15.x.x as a non-breaking change; if the candidate release seems to be breaking too many folks, we can revisit this decision).