### PR TITLE
feat(deps)!: pull in yargs-parser@17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^16.1.0"
+    "yargs-parser": "^17.0.0"
   },
   "devDependencies": {
     "c8": "^7.0.0",


### PR DESCRIPTION
BREAKING CHANGE: yargs-parser@17.0.0 no longer implicitly creates arrays out of boolean
arguments when duplicates are provided