### PR TITLE
fix(yargs): correct support of bundled electron apps

### DIFF
--- a/lib/process-argv.js
+++ b/lib/process-argv.js
@@ -1,10 +1,23 @@
 function getProcessArgvBinIndex () {
-  // Built Electron app: app argv1 argv2 ... argvn
-  // (process.defaultApp is set to false by electron for built app for this purpose,
-  // see https://github.com/electron/electron/issues/4690#issuecomment-217435222)
-  if (process.defaultApp === false) return 0
-  // Default: node app.js argv1 argv2 ... argvn
+  // The binary name is the first command line argument for:
+  // - bundled Electron apps: bin argv1 argv2 ... argvn
+  if (isBundledElectronApp()) return 0
+  // or the second one (default) for:
+  // - standard node apps: node bin.js argv1 argv2 ... argvn
+  // - unbundled Electron apps: electron bin.js argv1 arg2 ... argvn
   return 1
+}
+
+function isBundledElectronApp () {
+  // process.defaultApp is either set by electron in an electron unbundled app, or undefined
+  // see https://github.com/electron/electron/blob/master/docs/api/process.md#processdefaultapp-readonly
+  return isElectronApp() && !process.defaultApp
+}
+
+function isElectronApp () {
+  // process.versions.electron is either set by electron, or undefined
+  // see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  return !!process.versions.electron
 }
 
 function getProcessArgvWithoutBin () {


### PR DESCRIPTION
Fix the first attempt at detecting bundled electron apps, whose arguments start at `process.argv[1]`, not `process.argv[2]`, by handling `process.versions.electron` and `process.defaultApp`.

Fixes: #685 