### PR TITLE
fix: address ambiguity between nargs of 1 and requiresArg

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^17.1.0"
+    "yargs-parser": "^18.0.0"
   },
   "devDependencies": {
     "c8": "^7.0.0",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -2457,6 +2457,36 @@ describe('yargs dsl tests', () => {
       argv._.should.eql(['item2', 'item4'])
     })
 
+    it('should apply nargs with higher precedence than requiresArg: true', () => {
+      const argv = yargs(['-i', 'item1', 'item2', '-i', 'item3', 'item4'])
+        .option('i', {
+          alias: 'items',
+          type: 'array',
+          nargs: 1,
+          requiresArg: true
+        })
+        .argv
+      argv.items.should.eql(['item1', 'item3'])
+      argv.i.should.eql(['item1', 'item3'])
+      argv._.should.eql(['item2', 'item4'])
+    })
+
+    // TODO: make this work with aliases, using a check similar to
+    // checkAllAliases() in yargs-parser.
+    it('should apply nargs with higher precedence than requiresArg()', () => {
+      const argv = yargs(['-i', 'item1', 'item2', '-i', 'item3', 'item4'])
+        .option('items', {
+          alias: 'i',
+          type: 'array',
+          nargs: 1
+        })
+        .requiresArg(['items'])
+        .argv
+      argv.items.should.eql(['item1', 'item3'])
+      argv.i.should.eql(['item1', 'item3'])
+      argv._.should.eql(['item2', 'item4'])
+    })
+
     it('should raise error if not enough values follow nargs key', (done) => {
       yargs
         .option('i', {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -2428,4 +2428,46 @@ describe('yargs dsl tests', () => {
       }, 5)
     })
   })
+
+  // See: https://github.com/yargs/yargs/issues/1098
+  it('should allow array and requires arg to be used in conjunction', () => {
+    const argv = yargs(['-i', 'item1', 'item2', 'item3'])
+      .option('i', {
+        alias: 'items',
+        type: 'array',
+        requiresArg: true
+      })
+      .argv
+    argv.items.should.eql(['item1', 'item2', 'item3'])
+    argv.i.should.eql(['item1', 'item2', 'item3'])
+  })
+
+  // See: https://github.com/yargs/yargs/issues/1570
+  describe('"nargs" with "array"', () => {
+    it('should not consume more than nargs items', () => {
+      const argv = yargs(['-i', 'item1', 'item2', '-i', 'item3', 'item4'])
+        .option('i', {
+          alias: 'items',
+          type: 'array',
+          nargs: 1
+        })
+        .argv
+      argv.items.should.eql(['item1', 'item3'])
+      argv.i.should.eql(['item1', 'item3'])
+      argv._.should.eql(['item2', 'item4'])
+    })
+
+    it('should raise error if not enough values follow nargs key', (done) => {
+      yargs
+        .option('i', {
+          alias: 'items',
+          type: 'array',
+          nargs: 1
+        })
+        .parse(['-i'], (err) => {
+          err.message.should.match(/Not enough arguments following: i/)
+          return done()
+        })
+    })
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -237,7 +237,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.requiresArg = function (keys) {
     argsert('<array|string>', [keys], arguments.length)
-    populateParserHintObject(self.nargs, false, 'narg', keys, 1)
+    populateParserHintObject(self.nargs, false, 'narg', keys, NaN)
     return self
   }
 

--- a/yargs.js
+++ b/yargs.js
@@ -235,9 +235,18 @@ function Yargs (processArgs, cwd, parentRequire) {
     return self
   }
 
-  self.requiresArg = function (keys) {
-    argsert('<array|string>', [keys], arguments.length)
-    populateParserHintObject(self.nargs, false, 'narg', keys, NaN)
+  self.requiresArg = function (keys, value) {
+    argsert('<array|string|object> [number]', [keys], arguments.length)
+    // If someone configures nargs at the same time as requiresArg,
+    // nargs should take precedent,
+    // see: https://github.com/yargs/yargs/pull/1572
+    // TODO: make this work with aliases, using a check similar to
+    // checkAllAliases() in yargs-parser.
+    if (typeof keys === 'string' && options.narg[keys]) {
+      return self
+    } else {
+      populateParserHintObject(self.requiresArg, false, 'narg', keys, NaN)
+    }
     return self
   }
 


### PR DESCRIPTION
In #1054, `requiresArg` was refactored to use a `nargs` of `1` to specify that a value was required following an option (`--x foo` is valid, `--x` is not valid).

The problem with this design decision  was that it created an ambiguity when `array` and `nargs` were used in conjunction, one could not distinguish between:

* an array that should only accept one value.
* an an array that required _at least_ one value.

This behavior lead to issues like https://github.com/yargs/yargs/issues/1570, https://github.com/yargs/yargs/issues/1098, and https://github.com/mochajs/mocha/pull/4196.

---

To solve this problem [`nargs` now accepts the special value `NaN`](https://github.com/yargs/yargs-parser/pull/251), this value is used by `requiresArg` to specify that an `array` accepts "one or more" values following it. A `nargs` of `1` used in conjunction with `array`, continues to indicate that just one value should be accepted by an array.
