### PR TITLE
feat: add usage for single-digit boolean aliases

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -273,7 +273,15 @@ module.exports = function usage (yargs, y18n) {
             // for the special positional group don't
             // add '--' or '-' prefix.
             if (groupName === self.getPositionalGroupName()) return sw
-            else return (/^[^0-9]$/.test(sw) ? '-' : '--') + sw
+            else {
+              return (
+                // matches yargs-parser logic in which single-digits
+                // aliases declared with a boolean type are now valid
+                /^[0-9]$/.test(sw)
+                  ? ~options.boolean.indexOf(key) ? '-' : '--'
+                  : sw.length > 1 ? '--' : '-'
+              ) + sw
+            }
           })
           .join(', ')
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -1204,7 +1204,30 @@ describe('usage tests', () => {
       ])
     })
 
-    it('should use 2 dashes for 1-digit key usage', () => {
+    it('should use 2 dashes for general 1-digit usage', () => {
+      const r = checkUsage(() => yargs(['--help'])
+        .option('1', {
+          type: 'string',
+          description: 'First one',
+          default: 'first'
+        })
+        .wrap(null)
+        .parse()
+      )
+      r.should.have.property('result')
+      r.result.should.have.property('_').with.length(0)
+      r.should.have.property('exit').and.equal(true)
+      r.should.have.property('errors').with.length(0)
+      r.should.have.property('logs')
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --1        First one  [string] [default: "first"]',
+        '  --help     Show help  [boolean]',
+        '  --version  Show version number  [boolean]'
+      ])
+    })
+
+    it('should use single dashes for 1-digit boolean key usage', () => {
       const r = checkUsage(() => yargs(['--help'])
         .option('1', {
           type: 'boolean',
@@ -1220,13 +1243,13 @@ describe('usage tests', () => {
       r.should.have.property('logs')
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --1        Negative one  [boolean]',
+        '  -1         Negative one  [boolean]',
         '  --help     Show help  [boolean]',
         '  --version  Show version number  [boolean]'
       ])
     })
 
-    it('should use 2 dashes for 1-digit alias usage', () => {
+    it('should use single dashes for 1-digit boolean alias usage', () => {
       const r = checkUsage(() => yargs(['--help'])
         .option('negativeone', {
           alias: '1',
@@ -1243,9 +1266,32 @@ describe('usage tests', () => {
       r.should.have.property('logs')
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --help              Show help  [boolean]',
-        '  --version           Show version number  [boolean]',
-        '  --negativeone, --1  Negative one  [boolean]'
+        '  --help             Show help  [boolean]',
+        '  --version          Show version number  [boolean]',
+        '  --negativeone, -1  Negative one  [boolean]'
+      ])
+    })
+
+    it('should use 2 dashes for multiple-digit alias usage', () => {
+      const r = checkUsage(() => yargs(['--help'])
+        .option('onehundred', {
+          alias: '100',
+          type: 'boolean',
+          description: 'one hundred'
+        })
+        .wrap(null)
+        .parse()
+      )
+      r.should.have.property('result')
+      r.result.should.have.property('_').with.length(0)
+      r.should.have.property('exit').and.equal(true)
+      r.should.have.property('errors').with.length(0)
+      r.should.have.property('logs')
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --help               Show help  [boolean]',
+        '  --version            Show version number  [boolean]',
+        '  --onehundred, --100  one hundred  [boolean]'
       ])
     })
 


### PR DESCRIPTION
Add proper usage output for the now supported single-digit boolean aliases which landed in yargs-parser.

ref: https://github.com/yargs/yargs-parser/pull/255

/cc @bcoe @mleguen 

relates to: #1493