### PR TITLE
build: continue running coveralls on master

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - master
+name: coverage
+jobs:
+  coveralls:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 13
+      - run: npm install
+      - run: npm test
+      - run: c8 report --reporter=text-lcov | npx coveralls
+    env:
+      COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+      COVERALLS_GIT_BRANCH: "${{ github.ref }}"


### PR DESCRIPTION
experimenting with continuing to run coveralls, but only when landing code to `master`.