### PR TITLE
fix: __proto__ will now be replaced with ___proto___ in parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^18.1.0"
+    "yargs-parser": "^18.1.1-beta.0"
   },
   "devDependencies": {
     "c8": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^18.1.1-beta.0"
+    "yargs-parser": "^18.1.1"
   },
   "devDependencies": {
     "c8": "^7.0.0",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -2500,4 +2500,35 @@ describe('yargs dsl tests', () => {
         })
     })
   })
+
+  // See: https://github.com/nodejs/node/issues/31951
+  describe('should not pollute the prototype', () => {
+    it('does not pollute, when .parse() is called', function () {
+      yargs.parse(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200'])
+      Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
+      expect({}.foo).to.equal(undefined)
+      expect({}.bar).to.equal(undefined)
+    })
+
+    it('does not pollute, when .argv is called', function () {
+      yargs(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200']).argv // eslint-disable-line
+      Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
+      expect({}.foo).to.equal(undefined)
+      expect({}.bar).to.equal(undefined)
+    })
+
+    // TODO(bcoe): due to replacement of __proto__ with ___proto___ parser
+    // hints are not properly applied, we should move to an alternate approach
+    // in the future:
+    it('does not pollute, when options are set', function () {
+      yargs
+        .option('__proto__', {
+          describe: 'pollute pollute',
+          nargs: 33
+        })
+        .default('__proto__', { hello: 'world' })
+        .parse(['--foo'])
+        Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
+    })
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -259,6 +259,7 @@ function Yargs (processArgs, cwd, parentRequire) {
   function populateParserHintArray (type, keys, value) {
     keys = [].concat(keys)
     keys.forEach((key) => {
+      key = sanitizeKey(key)
       options[type].push(key)
     })
   }
@@ -314,8 +315,8 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   function populateParserHintObject (builder, isArray, type, key, value) {
     if (Array.isArray(key)) {
+      const temp = Object.create(null)
       // an array of keys with one value ['x', 'y', 'z'], function parse () {}
-      const temp = {}
       key.forEach((k) => {
         temp[k] = value
       })
@@ -326,6 +327,7 @@ function Yargs (processArgs, cwd, parentRequire) {
         builder(k, key[k])
       })
     } else {
+      key = sanitizeKey(key)
       // a single key value pair 'x', parse() {}
       if (isArray) {
         options[type][key] = (options[type][key] || []).concat(value)
@@ -333,6 +335,13 @@ function Yargs (processArgs, cwd, parentRequire) {
         options[type][key] = value
       }
     }
+  }
+
+  // TODO(bcoe): in future major versions move more objects towards
+  // Object.create(null):
+  function sanitizeKey (key) {
+    if (key === '__proto__') return '___proto___'
+    return key
   }
 
   function deleteFromParserHintObject (optionKey) {


### PR DESCRIPTION
* \_\_proto\_\_ will now be replaced with \_\_\_proto\_\_\_ in parse ([#258](https://www.github.com/yargs/yargs-parser/issues/258)), patching a potential 
prototype pollution vulnerability. This was reported by the Snyk Security Research Team.([63810ca](https://www.github.com/yargs/yargs-parser/commit/63810ca1ae1a24b08293a4d971e70e058c7a41e2))