### PR TITLE
fix(usage): translate 'options' group only when displaying help

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -146,7 +146,6 @@ module.exports = function usage (yargs, y18n) {
   const deferY18nLookupPrefix = '__yargsString__:'
   self.deferY18nLookup = str => deferY18nLookupPrefix + str
 
-  const defaultGroup = __('Options:')
   self.help = function help () {
     if (cachedHelpMessage) return cachedHelpMessage
     normalizeAliases()
@@ -245,8 +244,9 @@ module.exports = function usage (yargs, y18n) {
 
     // populate 'Options:' group with any keys that have not
     // explicitly had a group set.
+    const defaultGroup = __('Options:')
     if (!groups[defaultGroup]) groups[defaultGroup] = []
-    addUngroupedKeys(keys, options.alias, groups)
+    addUngroupedKeys(keys, options.alias, groups, defaultGroup)
 
     // display 'Options:' table along with any custom tables:
     Object.keys(groups).forEach((groupName) => {
@@ -433,7 +433,7 @@ module.exports = function usage (yargs, y18n) {
 
   // given a set of keys, place any keys that are
   // ungrouped under the 'Options:' grouping.
-  function addUngroupedKeys (keys, aliases, groups) {
+  function addUngroupedKeys (keys, aliases, groups, defaultGroup) {
     let groupedKeys = []
     let toCheck = null
     Object.keys(groups).forEach((group) => {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -776,6 +776,20 @@ describe('yargs dsl tests', () => {
         r.logs.join(' ').should.match(/COMMANDS!/)
       })
 
+      it('also works on default option group', () => {
+        const r = checkOutput(() => {
+          yargs(['-h'])
+            .help('h')
+            .wrap(null)
+            .updateLocale({
+              'Options:': 'OPTIONS!'
+            })
+            .parse()
+        })
+
+        r.logs.join(' ').should.match(/OPTIONS!/)
+      })
+
       it('allows you to use updateStrings() as an alias for updateLocale()', () => {
         const r = checkOutput(() => {
           yargs(['snuh', '-h'])


### PR DESCRIPTION
To allow modifying its translation with `updateLocale`/`updateStrings`.

Fixes #1598