### PR TITLE
docs(api): mark the `.defaults` alias as deprecated more clearly

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -427,11 +427,11 @@ flag occurrences rather than `true` or `false`. Default value is thus `0`.
 
 <a name="default"></a>.default(key, value, [description])
 ---------------------------------------------------------
-.defaults(key, value, [description])
+.defaults(key, value, [description]) [DEPRECATED]
 ------------------------------------
 
-**Note:** The `.defaults()` alias is deprecated. It will be
-removed in the next major version.
+**Note:** The `.defaults()` alias is deprecated. It will be removed in the next
+major version. Use `.default()` instead.
 
 Set `argv[key]` to `value` if no option was specified in `process.argv`.
 


### PR DESCRIPTION
`.demand` and `.reset` have this “[DEPRECATED]” tag in their titles, so `.defaults` should too for consistency.