### PR TITLE
build: switch to action for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+   push:
+     branches:
+       - master
+ name: release-please
+ jobs:
+   release-please:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: bcoe/release-please-action@v1.0.1
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           release-type: node
+           package-name: release-please-action

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,4 +11,4 @@ on:
          with:
            token: ${{ secrets.GITHUB_TOKEN }}
            release-type: node
-           package-name: release-please-action
+           package-name: yargs


### PR DESCRIPTION
eliminates the need for having a hosted service that backs our release-please logic.