### PR TITLE
revert(deps): update dependency eslint back to v6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cpr": "^3.0.1",
     "cross-spawn": "^7.0.0",
     "es6-promise": "^4.2.5",
-    "eslint": "^7.0.0",
+    "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
     "gts": "^2.0.0-alpha.4",


### PR DESCRIPTION
Reverts temporarily yargs/yargs#1656, as eslint v7 no longer supports node 8, which we did not drop yet.

fix: #1669
refs: 1755aec