### PR TITLE
chore: remove old entries from `files` field in `package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "build",
     "lib/**/*.js",
     "locales",
-    "completion.sh.hbs",
-    "completion.zsh.hbs",
     "LICENSE"
   ],
   "dependencies": {


### PR DESCRIPTION
Was exploring the package locally and noticed these: I believe the completion scripts have been removed into [`completion-templates.ts`](https://github.com/yargs/yargs/blob/master/lib/completion-templates.ts), and am guessing that `build` use to be where the build output went?

It's good to remove them since makes the `package.json` a little smaller, but more importantly prevents publishing unneeded files.

fwiw `LICENSE` & `index.js` can actually be removed too as npm always included `README`, `CHANGELOG`, `LICENCE` and whatever `main` points at.