### PR TITLE
feat!: drop support for EOL Node 8

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,0 @@
-releaseType: node
-handleGHRelease: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 13]
+        node: [10, 12, 13, 14]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Having problems? want to contribute? join our [community slack](http://devtoolsc
   * [Customizing Yargs' Parser](/docs/advanced.md#customizing)
 * [Contributing](/contributing.md)
 
+## Supported Node.js Versions
+
+Libraries in this ecosystem make a best effort to track
+[Node.js' release schedule](https://nodejs.org/en/about/releases/). Here's [a
+post on why we think this is important](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
+
 [travis-url]: https://travis-ci.org/yargs/yargs
 [travis-image]: https://img.shields.io/travis/yargs/yargs/master.svg
 [npm-url]: https://www.npmjs.com/package/yargs

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -2583,4 +2583,13 @@ describe('yargs dsl tests', () => {
       argv._.should.eql(['item2', 'item4', 'item6', 'item8'])
     })
   })
+
+  it('throws error for unsupported Node.js versions', () => {
+    process.env.YARGS_MIN_NODE_VERSION = '55'
+    delete require.cache[require.resolve('../yargs')]
+    expect(() => {
+      require('../yargs')
+    }).to.throw(/yargs supports a minimum Node.js version of 55/)
+    delete process.env.YARGS_MIN_NODE_VERSION
+  })
 })

--- a/yargs.js
+++ b/yargs.js
@@ -1,8 +1,15 @@
 'use strict'
 
-// an async function fails early in Node.js versions prior to 8.
-async function requiresNode8OrGreater () {}
-requiresNode8OrGreater()
+// See https://github.com/yargs/yargs#supported-nodejs-versions for our
+// version support policy. The YARGS_MIN_NODE_VERSION is used for testing only.
+const minNodeVersion = (process && process.env && process.env.YARGS_MIN_NODE_VERSION)
+  ? Number(process.env.YARGS_MIN_NODE_VERSION) : 10
+if (process && process.version) {
+  const major = Number(process.version.match(/v([^.]+)/)[1])
+  if (major < minNodeVersion) {
+    throw Error(`yargs supports a minimum Node.js version of ${minNodeVersion}. Read our version support policy: https://github.com/yargs/yargs#supported-nodejs-versions`)
+  }
+}
 
 const { Yargs, rebase } = require('./build/lib/yargs')
 const Parser = require('yargs-parser')


### PR DESCRIPTION
Drops support for end of life Node 8.

Notes:

* `yargs@15.4.0` was released a few days ago, which includes much of @mleguen's work migrating to TypeScript (_we should be mindful that we might need to port a few fixes back to this release line._).
* we should not release `yargs@16.x.x` until we've finished the full TypeScript conversion, this includes @QmarkC's work on yargs-parser.