### PR TITLE
Use find-up@5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "cliui": "^6.0.0",
     "decamelize": "^3.2.0",
-    "find-up": "^4.1.0",
+    "find-up": "^5.0.0",
     "get-caller-file": "^2.0.1",
     "require-directory": "^2.1.1",
     "require-main-filename": "^2.0.0",


### PR DESCRIPTION
Hello, I noticed that a [bot produced PR](https://github.com/yargs/yargs/pull/1715) that updated this dependency was closed without comment. I thought I would try again.

`find-up@5` removes support for nodejs < 10 which is consistent with the engine requirements here in `yargs`.  See: https://github.com/sindresorhus/find-up/releases/tag/v5.0.0  

Thank you!