### PR TITLE
feat(helpers): rebase, Parser, applyExtends now blessed helpers

### DIFF
--- a/helpers.mjs
+++ b/helpers.mjs
@@ -7,13 +7,8 @@ const applyExtends = (config, cwd, mergeExtends) => {
   return _applyExtends(config, cwd, mergeExtends, shim)
 }
 
-const rebase = (base, dir) => {
-  return shim.path.relative(base, dir)
-}
-
 export {
   applyExtends,
   hideBin,
   Parser,
-  rebase
 }

--- a/helpers.mjs
+++ b/helpers.mjs
@@ -1,1 +1,19 @@
-export { hideBin } from './build/lib/utils/process-argv.js'
+import { applyExtends as _applyExtends } from './build/lib/utils/apply-extends.js'
+import { hideBin } from './build/lib/utils/process-argv.js'
+import Parser from 'yargs-parser'
+import shim from './lib/platform-shims/esm.mjs'
+
+const applyExtends = (config, cwd, mergeExtends) => {
+  return _applyExtends(config, cwd, mergeExtends, shim)
+}
+
+const rebase = (base, dir) => {
+  return shim.path.relative(base, dir)
+}
+
+export {
+  applyExtends,
+  hideBin,
+  Parser,
+  rebase
+}

--- a/index.cjs
+++ b/index.cjs
@@ -2,9 +2,9 @@
 // classic singleton yargs API, to use yargs
 // without running as a singleton do:
 // require('yargs/yargs')(process.argv.slice(2))
-const Yargs = require('./build/index.cjs')
+const { Yargs, processArgv } = require('./build/index.cjs')
 
-Argv(Yargs.processArgv.hideBin(process.argv))
+Argv(processArgv.hideBin(process.argv))
 
 module.exports = Argv
 

--- a/lib/cjs.ts
+++ b/lib/cjs.ts
@@ -1,6 +1,7 @@
 'use strict'
 // Bootstraps yargs for a CommonJS runtime:
 
+import { applyExtends } from './utils/apply-extends'
 import { argsert } from './argsert.js'
 import { isPromise } from './utils/is-promise.js'
 import { objFilter } from './utils/obj-filter.js'
@@ -25,7 +26,10 @@ if (process && process.version) {
 const Parser = require('yargs-parser')
 const Yargs = YargsWithShim(cjsPlatformShim)
 
-export default Object.assign(Yargs, {
+export default {
+  applyExtends,
+  cjsPlatformShim,
+  Yargs,
   argsert,
   globalMiddlewareFactory,
   isPromise,
@@ -35,4 +39,4 @@ export default Object.assign(Yargs, {
   processArgv,
   rebase,
   YError
-})
+}

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -37,7 +37,8 @@ export default {
     basename,
     dirname,
     extname,
-    relative
+    relative,
+    resolve
   },
   process: {
     argv: () => process.argv,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "import": "./helpers.mjs"
     },
     "./yargs": {
-      "require": "./build/index.cjs"
+      "require": "./yargs.cjs"
     }
   },
   "type": "module",
@@ -28,6 +28,7 @@
     "index.cjs",
     "helpers.mjs",
     "index.mjs",
+    "yargs.mjs",
     "build",
     "locales",
     "LICENSE",
@@ -93,8 +94,6 @@
   "standardx": {
     "ignore": [
       "build",
-      "index.cjs",
-      "yargs.cjs",
       "**/example/**"
     ]
   },

--- a/test/esm/helpers.mjs
+++ b/test/esm/helpers.mjs
@@ -5,27 +5,20 @@ import {
   applyExtends,
   hideBin,
   Parser,
-  rebase,
 } from '../../helpers.mjs'
 
 describe('helpers', () => {
   describe('applyExtends', () => {
     it('exposes applyExtends helper', () => {
       const conf = applyExtends({extends: './package.json', apple: 'red'}, process.cwd(), true);
-      // assert.strictEqual(conf.name, 'yargs') // loads packge.json.
-      // assert.strictEqual(conf.apple, 'red') // keeps config with extends.
+      assert.strictEqual(conf.name, 'yargs') // loads packge.json.
+      assert.strictEqual(conf.apple, 'red') // keeps config with extends.
     })
   })
   describe('Parser', () => {
     it('exposes functional argument parser', () => {
       const argv = Parser('--foo --bar=99')
       assert.strictEqual(argv.bar, 99)
-    })
-  })
-  describe('rebase', () => {
-    it('exposes rebase', () => {
-      const path = rebase('./foo', './foo/bar')
-      // assert.strictEqual(path, 'bar')
     })
   })
   describe('hideBin', () => {

--- a/test/esm/helpers.mjs
+++ b/test/esm/helpers.mjs
@@ -1,0 +1,37 @@
+'use strict'
+
+import * as assert from 'assert'
+import { 
+  applyExtends,
+  hideBin,
+  Parser,
+  rebase,
+} from '../../helpers.mjs'
+
+describe('helpers', () => {
+  describe('applyExtends', () => {
+    it('exposes applyExtends helper', () => {
+      const conf = applyExtends({extends: './package.json', apple: 'red'}, process.cwd(), true);
+      // assert.strictEqual(conf.name, 'yargs') // loads packge.json.
+      // assert.strictEqual(conf.apple, 'red') // keeps config with extends.
+    })
+  })
+  describe('Parser', () => {
+    it('exposes functional argument parser', () => {
+      const argv = Parser('--foo --bar=99')
+      assert.strictEqual(argv.bar, 99)
+    })
+  })
+  describe('rebase', () => {
+    it('exposes rebase', () => {
+      const path = rebase('./foo', './foo/bar')
+      // assert.strictEqual(path, 'bar')
+    })
+  })
+  describe('hideBin', () => {
+    it('hides bin for standard node.js application', () => {
+      const args = hideBin(['node', 'foo.js', '--apple', '--banana'])
+      // assert.deepEqual(args, ['--apple', '--banana'])
+    })
+  })
+})

--- a/test/esm/yargs-test.mjs
+++ b/test/esm/yargs-test.mjs
@@ -2,7 +2,6 @@
 
 import * as assert from 'assert'
 import yargs from '../../index.mjs'
-import { hideBin } from '../../helpers.mjs'
 
 describe('ESM', () => {
   describe('parser', () => {
@@ -20,12 +19,6 @@ describe('ESM', () => {
         err = _err
       }
       assert.match(err.message, /not supported yet for ESM/)
-    })
-  })
-  describe('hideBin', () => {
-    it('hides bin for standard node.js application', () => {
-      const args = hideBin(['node', 'foo.js', '--apple', '--banana'])
-      assert.deepEqual(args, ['--apple', '--banana'])
     })
   })
 })

--- a/test/helpers.cjs
+++ b/test/helpers.cjs
@@ -1,0 +1,33 @@
+'use strict'
+
+const {describe, it} = require('mocha')
+const assert = require('assert')
+const yargs = require('../yargs.cjs');
+const { applyExtends } = require('../yargs.cjs');
+
+const HELPER_COUNT = 3;
+
+describe('helpers', () => {
+  it('does not expose additional helpers beyond blessed list', () => {
+    assert.strictEqual(Object.keys(yargs).length, HELPER_COUNT)
+  })
+  describe('applyExtends', () => {
+    it('exposes applyExtends helper', () => {
+      const conf = applyExtends({extends: './package.json', apple: 'red'}, process.cwd(), true);
+      assert.strictEqual(conf.name, 'yargs') // loads packge.json.
+      assert.strictEqual(conf.apple, 'red') // keeps config with extends.
+    })
+  })
+  describe('Parser', () => {
+    it('exposes functional argument parser', () => {
+      const argv = yargs.Parser('--foo --bar=99')
+      assert.strictEqual(argv.bar, 99)
+    })
+  })
+  describe('rebase', () => {
+    it('exposes rebase', () => {
+      const path = yargs.rebase('./foo', './foo/bar')
+      assert.strictEqual(path, 'bar')
+    })
+  })
+})

--- a/test/helpers.cjs
+++ b/test/helpers.cjs
@@ -5,7 +5,7 @@ const assert = require('assert')
 const yargs = require('../yargs.cjs');
 const { applyExtends } = require('../yargs.cjs');
 
-const HELPER_COUNT = 3;
+const HELPER_COUNT = 2;
 
 describe('helpers', () => {
   it('does not expose additional helpers beyond blessed list', () => {
@@ -22,12 +22,6 @@ describe('helpers', () => {
     it('exposes functional argument parser', () => {
       const argv = yargs.Parser('--foo --bar=99')
       assert.strictEqual(argv.bar, 99)
-    })
-  })
-  describe('rebase', () => {
-    it('exposes rebase', () => {
-      const path = yargs.rebase('./foo', './foo/bar')
-      assert.strictEqual(path, 'bar')
     })
   })
 })

--- a/yargs.cjs
+++ b/yargs.cjs
@@ -6,5 +6,4 @@ Yargs.applyExtends = (config, cwd, mergeExtends) => {
   return applyExtends(config, cwd, mergeExtends, cjsPlatformShim)
 }
 Yargs.Parser = Parser
-Yargs.rebase = rebase
 module.exports = Yargs

--- a/yargs.cjs
+++ b/yargs.cjs
@@ -1,7 +1,6 @@
-// CJS import shim for older versions of Node.js.
-// this can be removed once all supported Node.js versions support
-// export maps:
-const {applyExtends, cjsPlatformShim, Parser, rebase, Yargs} = require('./build/index.cjs')
+// TODO: consolidate on using a helpers file at some point in the future, which
+// is the approach currently used to export Parser and  applyExtends for ESM:
+const {applyExtends, cjsPlatformShim, Parser, Yargs} = require('./build/index.cjs')
 Yargs.applyExtends = (config, cwd, mergeExtends) => {
   return applyExtends(config, cwd, mergeExtends, cjsPlatformShim)
 }

--- a/yargs.cjs
+++ b/yargs.cjs
@@ -1,0 +1,10 @@
+// CJS import shim for older versions of Node.js.
+// this can be removed once all supported Node.js versions support
+// export maps:
+const {applyExtends, cjsPlatformShim, Parser, rebase, Yargs} = require('./build/index.cjs')
+Yargs.applyExtends = (config, cwd, mergeExtends) => {
+  return applyExtends(config, cwd, mergeExtends, cjsPlatformShim)
+}
+Yargs.Parser = Parser
+Yargs.rebase = rebase
+module.exports = Yargs

--- a/yargs.js
+++ b/yargs.js
@@ -1,5 +1,0 @@
-// CJS import shim for older versions of Node.js.
-// this can be removed once all supported Node.js versions support
-// export maps:
-const Yargs = require('./build/index.cjs')
-module.exports = Yargs


### PR DESCRIPTION
@boneskull asked whether it was okay to use `applyExtends` as  a helper in `mocha`. I feel this is fine, but wanted to be more explicit about the helpers that yargs exports. Here's what's currently supported for both  ESM and  CJS:

* Parser:  the yargs-parser instance.
* applyExtends: helper for supporting `extends` behavior in config.

BREAKING CHANGE: rebase helper (which was just path.resolve) is no longer exposed.