### PR TITLE
feat: i18n for ESM and Deno

### DIFF
--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -3,11 +3,11 @@
 
 import { assertNotEquals, assertStrictEquals } from 'https://deno.land/std/testing/asserts.ts'
 import { basename, dirname, extname, posix } from 'https://deno.land/std/path/mod.ts'
-import { sprintf } from 'https://deno.land/std/fmt/printf.ts'
 
 import cliui from 'https://deno.land/x/cliui@v7.0.0-deno/deno.ts'
 import escalade from 'https://deno.land/x/escalade@v3.0.3/sync.ts'
 import Parser from 'https://deno.land/x/yargs_parser@v19.0.1-deno/deno.ts'
+import y18n from 'https://deno.land/x/y18n@v5.0.0-deno/deno.ts'
 import { YError } from '../../build/lib/yerror.js'
 
 const REQUIRE_ERROR = 'require is not supported by ESM'
@@ -15,14 +15,15 @@ const REQUIRE_DIRECTORY_ERROR = 'loading a directory of commands is not supporte
 
 // Deno removes argv[0] and argv[1 from Deno.args:
 const argv = ['deno run', ...Deno.args]
+const __dirname = new URL('.', import.meta.url).pathname
 
 // Yargs supports environment variables with prefixes, e.g., MY_APP_FOO,
 // MY_APP_BAR. Environment variables are also used to detect locale.
 let cwd: string = ''
 let env: {[key: string]: string} = {}
 try {
-  cwd = Deno.cwd()
   env = Deno.env.toObject()
+  cwd = Deno.cwd()
 } catch (err) {
   if (err.name !== 'PermissionDenied') {
     throw err
@@ -94,23 +95,8 @@ export default {
   stringWidth: (str: string) => {
     return [...str].length
   },
-  y18n: {
-    __: (...str: string[]) => {
-      if (str.length === 0) return ''
-      const args = str.slice(1)
-      return sprintf(str[0], ...args)
-    },
-    __n: (str1: string, str2: string, count: number, ...args: string[]) => {
-      if (count === 1) {
-        return sprintf(str1, ...args)
-      } else {
-        return sprintf(str2, ...args)
-      }
-    },
-    getLocale: (): string => {
-      return 'en_US'
-    },
-    setLocale: () => {},
-    updateLocale: () => {}
-  }
+  y18n: y18n({
+    directory: posix.resolve(__dirname, '../../locales'),
+    updateFiles: false
+  })
 }

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -10,11 +10,13 @@ import Parser from 'yargs-parser'
 import { basename, dirname, extname, relative, resolve } from 'path'
 import { getProcessArgvBin } from '../../build/lib/utils/process-argv.js'
 import { YError } from '../../build/lib/yerror.js'
+import y18n from 'y18n'
 
 const REQUIRE_ERROR = 'require is not supported by ESM'
 const REQUIRE_DIRECTORY_ERROR = 'loading a directory of commands is not supported yet for ESM'
 
 const mainFilename = fileURLToPath(import.meta.url).split('node_modules')[0]
+const __dirname = fileURLToPath(import.meta.url)
 
 export default {
   assert: {
@@ -57,24 +59,8 @@ export default {
   stringWidth: (str) => {
     return [...str].length
   },
-  // TODO: replace this with y18n once it's ported to ESM:
-  y18n: {
-    __: (...str) => {
-      if (str.length === 0) return ''
-      const args = str.slice(1)
-      return format(str[0], ...args)
-    },
-    __n: (str1, str2, count, ...args) => {
-      if (count === 1) {
-        return format(str1, ...args)
-      } else {
-        return format(str2, ...args)
-      }
-    },
-    getLocale: () => {
-      return 'en_US'
-    },
-    setLocale: () => {},
-    updateLocale: () => {}
-  }
+  y18n: y18n({
+    directory: resolve(__dirname, '../../../locales'),
+    updateFiles: false
+  })
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "get-caller-file": "^2.0.5",
     "require-directory": "^2.1.1",
     "string-width": "^4.2.0",
-    "y18n": "^4.0.0",
+    "y18n": "^5.0.0",
     "yargs-parser": "^19.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "get-caller-file": "^2.0.5",
     "require-directory": "^2.1.1",
     "string-width": "^4.2.0",
-    "y18n": "^5.0.0",
+    "y18n": "^5.0.1",
     "yargs-parser": "^19.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
y18n has now been ported to ESM/Deno.

See: https://github.com/yargs/yargs/issues/1706