### PR TITLE
fix(typescript): yargs-parser was breaking @types/yargs

### DIFF
--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -1,4 +1,4 @@
-import { Parser } from 'yargs-parser/build/lib/yargs-parser-types.d.js'
+import { Parser } from './yargs-parser-types.js'
 
 /**
  * An object whose all properties have the same type.

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -4,7 +4,7 @@ import { Dictionary, assertNotStrictEqual, PlatformShim, Y18N } from './typings/
 import { objFilter } from './utils/obj-filter.js'
 import { YargsInstance } from './yargs-factory.js'
 import { YError } from './yerror.js'
-import { DetailedArguments } from 'yargs-parser/build/lib/yargs-parser-types.js'
+import { DetailedArguments } from './typings/yargs-parser-types.js'
 import setBlocking from './utils/set-blocking.js'
 
 export function usage (yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -4,7 +4,7 @@ import { levenshtein as distance } from './utils/levenshtein.js'
 import { objFilter } from './utils/obj-filter.js'
 import { UsageInstance } from './usage.js'
 import { YargsInstance, Arguments } from './yargs-factory.js'
-import { DetailedArguments } from 'yargs-parser/build/lib/yargs-parser-types.js'
+import { DetailedArguments } from './typings/yargs-parser-types.js'
 
 const specialKeys = ['$0', '--', '_']
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "require-directory": "^2.1.1",
     "string-width": "^4.2.0",
     "y18n": "^5.0.1",
-    "yargs-parser": "^19.0.4"
+    "yargs-parser": "^20.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",


### PR DESCRIPTION
By shipping types in yargs-parser, we were breaking `@types/yargs` which relies on `@types/yargs-parser`.

For now let's avoid shipping types in both libraries.