### PR TITLE
fix(positional): positional strings no longer drop decimals

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -221,7 +221,7 @@ export function command (
       // to simplify the parsing of positionals in commands,
       // we temporarily populate '--' rather than _, with arguments
       const populateDoubleDash = !!yargs.getOptions().configuration['populate--']
-      if (!populateDoubleDash) yargs._copyDoubleDash(innerArgv)
+      yargs._postProcess(innerArgv, populateDoubleDash)
 
       innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false)
       let handlerResult

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -6,7 +6,7 @@ import { basename, dirname, extname, posix } from 'https://deno.land/std/path/mo
 
 import cliui from 'https://deno.land/x/cliui@v7.0.0-deno/deno.ts'
 import escalade from 'https://deno.land/x/escalade@v3.0.3/sync.ts'
-import Parser from 'https://deno.land/x/yargs_parser@v19.0.1-deno/deno.ts'
+import Parser from 'https://deno.land/x/yargs_parser@v20.2.0-deno/deno.ts'
 import y18n from 'https://deno.land/x/y18n@v5.0.0-deno/deno.ts'
 import { YError } from '../../build/lib/yerror.js'
 

--- a/lib/typings/yargs-parser-types.ts
+++ b/lib/typings/yargs-parser-types.ts
@@ -51,6 +51,8 @@ export interface Configuration {
     'nargs-eats-options': boolean;
     /** The prefix to use for negated boolean variables. Default is `'no-'` */
     'negation-prefix': string;
+    /** Should positional values that look like numbers be parsed? Default is `true` */
+    'parse-positional-numbers': boolean;
     /** Should keys that look like numbers be treated as such? Default is `true` */
     'parse-numbers': boolean;
     /** Should unparsed flags be stored in -- or _? Default is `false` */
@@ -132,6 +134,7 @@ export interface Parser {
     detailed(args: ArgsInput, opts?: Partial<Options>): DetailedArguments;
     camelCase(str: string): string;
     decamelize(str: string, joinString?: string): string;
+    looksLikeNumber(x: null | undefined | number | string): boolean;
 }
 export declare type StringFlag = Dictionary<string[]>;
 export declare type BooleanFlag = Dictionary<boolean>;

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1218,7 +1218,7 @@ function Yargs (processArgs: string | string[] = [], cwd = shim.process.cwd(), p
       'populate--': true
     })
     const parsed = shim.Parser.detailed(args, Object.assign({}, options, {
-      configuration: {'parse-positional-numbers': false, ...config}
+      configuration: { 'parse-positional-numbers': false, ...config }
     })) as DetailedArguments
 
     let argv = parsed.argv as Arguments
@@ -1365,17 +1365,17 @@ function Yargs (processArgs: string | string[] = [], cwd = shim.process.cwd(), p
 
   // Applies a couple post processing steps that are easier to perform
   // as a final step, rather than
-  self._postProcess = function (argv: Arguments | Promise<Arguments>, populateDoubleDash: boolean, calledFromCommand=false): any {
+  self._postProcess = function (argv: Arguments | Promise<Arguments>, populateDoubleDash: boolean, calledFromCommand = false): any {
     if (isPromise(argv)) return argv
     if (calledFromCommand) return argv
     if (!populateDoubleDash) {
       argv = self._copyDoubleDash(argv)
     }
-    const parsePositionalNumbers = self.getParserConfiguration()['parse-positional-numbers'] || self.getParserConfiguration()['parse-positional-numbers'] === undefined;
+    const parsePositionalNumbers = self.getParserConfiguration()['parse-positional-numbers'] || self.getParserConfiguration()['parse-positional-numbers'] === undefined
     if (parsePositionalNumbers) {
       argv = self._parsePositionalNumbers(argv)
     }
-    return argv;
+    return argv
   }
 
   // to simplify the parsing of positionals in commands,
@@ -1398,7 +1398,7 @@ function Yargs (processArgs: string | string[] = [], cwd = shim.process.cwd(), p
   // This allows commands to configure number parsing on a positional by
   // positional basis:
   self._parsePositionalNumbers = function (argv: Arguments): any {
-    const args: (string | number)[] = argv['--'] ? argv['--'] : argv['_']
+    const args: (string | number)[] = argv['--'] ? argv['--'] : argv._
 
     for (let i = 0, arg; (arg = args[i]) !== undefined; i++) {
       if (shim.Parser.looksLikeNumber(arg) && Number.isSafeInteger(Math.floor(parseFloat(`${arg}`)))) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "require-directory": "^2.1.1",
     "string-width": "^4.2.0",
     "y18n": "^5.0.1",
-    "yargs-parser": "^20.0.0"
+    "yargs-parser": "^20.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/test/deno/yargs.test.ts
+++ b/test/deno/yargs.test.ts
@@ -1,10 +1,11 @@
 /* global Deno */
 
 import {
+  assertEquals,
   assertMatch
 } from 'https://deno.land/std/testing/asserts.ts'
 import yargs from '../../deno.ts'
-import { Arguments } from '../../types.ts'
+import { Arguments, YargsType } from '../../types.ts'
 
 Deno.test('demandCommand(1) throw error if no command provided', () => {
   let err: Error|null = null
@@ -24,4 +25,16 @@ Deno.test('guesses version # based on package.json', () => {
       output = _output
     })
   assertMatch('' + output, /[0-9]+\.[0-9]+\.[0-9]+/)
+})
+
+// Handling of strings that look like numbers, see:
+// https://github.com/yargs/yargs/issues/1758
+Deno.test('does not drop .0 if positional is configured as string', async () => {
+  const argv = await yargs(['cmd', '33.0'])
+    .command('cmd [str]', 'a command', (yargs: YargsType) => {
+      return yargs.positional('str', {
+        type: 'string'
+      })
+    }).parse() as Arguments
+  assertEquals(argv.str, '33.0')
 })

--- a/test/esm/yargs-test.mjs
+++ b/test/esm/yargs-test.mjs
@@ -21,4 +21,17 @@ describe('ESM', () => {
       assert.match(err.message, /not supported yet for ESM/)
     })
   })
+  // Handling of strings that look like numbers, see:
+  // https://github.com/yargs/yargs/issues/1758
+  describe('bug #1758', () => {
+    it('does not drop .0 if positional is configured as string', () => {
+      const argv = yargs('cmd 33.0')
+        .command('cmd [str]', 'a command', (yargs) => {
+          return yargs.positional('str', {
+            type: 'string'
+          })
+        }).parse()
+      assert.strictEqual(argv.str, '33.0')
+    })
+  })
 })

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -1799,7 +1799,7 @@ describe('yargs dsl tests', () => {
       argv.noBaz.should.equal(2)
     })
 
-    it.only('supports --unknown-options-as-args', () => {
+    it('supports --unknown-options-as-args', () => {
       const argv = yargs('--foo.bar 1 --no-baz 2')
         .parserConfiguration({ 'unknown-options-as-args': true })
         .parse()


### PR DESCRIPTION
This moves the coercion of positional values to numbers to a post processing step, so that we can turn off this behavior during the first pass of parsing before we consume positionals.

Related work in yargs-parser: https://github.com/yargs/yargs-parser/pull/321

Fixes #1758 