### PR TITLE
test: throw on warning when in tests

### DIFF
--- a/test/argsert.cjs
+++ b/test/argsert.cjs
@@ -1,7 +1,7 @@
 /* global describe, it */
 const { argsert } = require('../build/index.cjs')
 const { checkOutput } = require('./helpers/utils.cjs')
-const { should } = require('chai')
+const { expect, should } = require('chai')
 
 should()
 
@@ -163,5 +163,16 @@ describe('Argsert', () => {
     })
 
     o.warnings.length.should.equal(0)
+  })
+
+  // See: https://github.com/yargs/yargs/issues/1666
+  it('should throw on warnings, when under test', () => {
+    function foo (...args) {
+      argsert('<*>', [].slice.call(args))
+    }
+
+    expect(() => {
+      foo('bar', undefined, undefined, 33)
+    }).to.throw();
   })
 })

--- a/test/before.cjs
+++ b/test/before.cjs
@@ -1,2 +1,6 @@
 'use strict'
 process.env.LC_ALL = 'en_US'
+// See: https://github.com/yargs/yargs/issues/1666
+console.warn = (message) => {
+  throw Error(message)
+}


### PR DESCRIPTION
In test, throw on warnings so that we catch argsert issues.

Fixes #1666