### PR TITLE
docs: document onFinishCommand option

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -453,15 +453,14 @@ for detailed documentation of this feature.
 ## Command finish hook
 ### Example
 ```js
-yargs
-    .command('cmd', ..., async () => {
+yargs(process.argv.slice(2))
+    .command('cmd', 'a command', () => {}, async () => {
         await this.model.find()
         return Promise.resolve('result value')
     })
     .onFinishCommand(async (resultValue) => {
         await this.db.disconnect()
-        process.exit()
-    }).argv;
+    }).argv
 ```
 
 ## Middleware

--- a/docs/api.md
+++ b/docs/api.md
@@ -1211,6 +1211,23 @@ Valid `opt` keys include:
     - `'number'`: synonymous for `number: true`, see [`number()`](#number)
     - `'string'`: synonymous for `string: true`, see [`string()`](#string)
 
+.onFinishCommand([handler])
+------------
+
+Called after the completion of any command. `handler` is invoked with the
+result returned by the command:
+
+```js
+yargs(process.argv.slice(2))
+    .command('cmd', 'a command', () => {}, async () => {
+        await this.model.find()
+        return Promise.resolve('result value')
+    })
+    .onFinishCommand(async (resultValue) => {
+        await this.db.disconnect()
+    }).argv
+```
+
 .parse([args], [context], [parseCallback])
 ------------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1124,6 +1124,23 @@ var argv = require('yargs')
   .argv
 ```
 
+.onFinishCommand([handler])
+------------
+
+Called after the completion of any command. `handler` is invoked with the
+result returned by the command:
+
+```js
+yargs(process.argv.slice(2))
+    .command('cmd', 'a command', () => {}, async () => {
+        await this.model.find()
+        return Promise.resolve('result value')
+    })
+    .onFinishCommand(async (resultValue) => {
+        await this.db.disconnect()
+    }).argv
+```
+
 <a name="option"></a>.option(key, [opt])
 -----------------
 <a name="options"></a>.options(key, [opt])
@@ -1210,23 +1227,6 @@ Valid `opt` keys include:
     - `'count'`: synonymous for `count: true`, see [`count()`](#count)
     - `'number'`: synonymous for `number: true`, see [`number()`](#number)
     - `'string'`: synonymous for `string: true`, see [`string()`](#string)
-
-.onFinishCommand([handler])
-------------
-
-Called after the completion of any command. `handler` is invoked with the
-result returned by the command:
-
-```js
-yargs(process.argv.slice(2))
-    .command('cmd', 'a command', () => {}, async () => {
-        await this.model.find()
-        return Promise.resolve('result value')
-    })
-    .onFinishCommand(async (resultValue) => {
-        await this.db.disconnect()
-    }).argv
-```
 
 .parse([args], [context], [parseCallback])
 ------------


### PR DESCRIPTION
onFinishCommand was not documented in api docs.

Fixes #1658, #1344 
