### PR TITLE
fix(deno): update types for deno ^1.4.0

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -1,7 +1,7 @@
 // Bootstrap yargs for Deno platform:
 import denoPlatformShim from './lib/platform-shims/deno.ts'
 import { YargsWithShim } from './build/lib/yargs-factory.js'
-import { YargsInstance as YargsType } from './build/lib/yargs-factory.d.ts'
+import type { YargsInstance as YargsType } from './build/lib/yargs-factory.d.ts'
 
 const WrappedYargs = YargsWithShim(denoPlatformShim)
 

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,7 @@
 // expose types for the benefit of Deno.
-import { YargsInstance as YargsType, Arguments } from './build/lib/yargs-factory.d.ts'
+import type { YargsInstance as YargsType, Arguments } from './build/lib/yargs-factory.d.ts'
 
-export {
+export type {
   Arguments,
   YargsType
 }


### PR DESCRIPTION
In version 1.4 Deno adopted;

- the tsconfig setting [importsNotUsedAsValues](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) - https://github.com/denoland/deno/pull/7413
- the tsconfig setting [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules) when using the deno `--unstable` flag - https://github.com/denoland/deno/issues/7326 ([intended to be enabled by default in 1.5](https://github.com/denoland/deno/issues/7326))

These require the use of;
- type only imports for values which are only used as types (`importsNotUsedAsValues`)
- type only exports for types which are re-exported (`isolatedModules`)

I've added more details at https://github.com/yargs/yargs/issues/1771.

related prs:
- yargs-parser https://github.com/yargs/yargs-parser/pull/329
- y18n https://github.com/yargs/y18n/pull/100