### PR TITLE
fix(exports): node 13.0-13.6 require a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,22 @@
   "description": "yargs the modern, pirate-themed, successor to optimist.",
   "main": "./index.cjs",
   "exports": {
-    ".": {
-      "import": "./index.mjs",
-      "require": "./index.cjs"
-    },
+    ".": [
+      {
+        "import": "./index.mjs",
+        "require": "./index.cjs"
+      },
+      "./index.cjs"
+    ],
     "./helpers": {
       "import": "./helpers.mjs"
     },
-    "./yargs": {
-      "require": "./yargs"
-    }
+    "./yargs": [
+      {
+        "require": "./yargs"
+      },
+      "./yargs"
+    ]
   },
   "type": "module",
   "module": "./index.mjs",


### PR DESCRIPTION
package.json’s "engines" field claims yargs supports node >= 10; node v13.0-v13.6 are included in this semver range. This change is required to be able to require() from yargs successfully in these versions.

I'm running into this because I'm trying to build tests for `list-exports`/`ls-exports`, and `resolve`, to cover resolution behavior in these node versions.

I've manually tested this; combined with a similar change in `y18n`, `yargs-parser`, `cliui`, and `escalade`, it fixes the bug. Since the behavior can only be observed by installing yargs into a node_modules folder and then trying to `require` it, it's exceedingly difficult to test in CI.

I'll be happy to make those PRs as well, if you'll accept them, and will then update this PR to bump the dep versions once published.