### PR TITLE
Expose CommandHandlerDefinition in Deno

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -3,5 +3,7 @@ import type {
   YargsInstance as YargsType,
   Arguments,
 } from './build/lib/yargs-factory.d.ts';
+  
+import type { CommandHandlerDefinition } from './build/lib/command.js';
 
-export type {Arguments, YargsType};
+export type {Arguments, YargsType, CommandHandlerDefinition};


### PR DESCRIPTION
Today, it's hard to have command handlers in separate files that are strong typed, if this is not exposed.