### PR TITLE
fix(deno): get yargs working on deno@1.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ As of `v16`, `yargs` supports [Deno](https://github.com/denoland/deno):
 
 ```typescript
 import yargs from 'https://deno.land/x/yargs/deno.ts'
-import { Arguments, YargsType } from 'https://deno.land/x/yargs/types.ts'
+import { Arguments } from 'https://deno.land/x/yargs/types.ts'
 
 yargs(Deno.args)
-  .command('download <files...>', 'download a list of files', (yargs: YargsType) => {
+  .command('download <files...>', 'download a list of files', (yargs: any) => {
     return yargs.positional('files', {
       describe: 'a list of files to do something with'
     })

--- a/deno.ts
+++ b/deno.ts
@@ -1,11 +1,10 @@
 // Bootstrap yargs for Deno platform:
 import denoPlatformShim from './lib/platform-shims/deno.ts';
 import {YargsWithShim} from './build/lib/yargs-factory.js';
-import type {YargsInstance as YargsType} from './build/lib/yargs-factory.d.ts';
 
 const WrappedYargs = YargsWithShim(denoPlatformShim);
 
-function Yargs(args?: string[]): YargsType {
+function Yargs(args?: string[]) {
   return WrappedYargs(args);
 }
 

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -11,9 +11,9 @@ import {
   posix,
 } from 'https://deno.land/std/path/mod.ts';
 
-import cliui from 'https://deno.land/x/cliui@v7.0.0-deno/deno.ts';
+import cliui from 'https://deno.land/x/cliui@v7.0.4-deno/deno.ts';
 import escalade from 'https://deno.land/x/escalade@v3.0.3/sync.ts';
-import Parser from 'https://deno.land/x/yargs_parser@v20.2.0-deno/deno.ts';
+import Parser from 'https://deno.land/x/yargs_parser@v20.2.4-deno/deno.ts';
 import y18n from 'https://deno.land/x/y18n@v5.0.0-deno/deno.ts';
 import {YError} from '../../build/lib/yerror.js';
 

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -14,17 +14,19 @@ import {
   command as Command,
   CommandHandlerDefinition,
 } from './command.js';
-import {
+import type {
   Dictionary,
-  assertNotStrictEqual,
   KeyOf,
   DictionaryKeyof,
   ValueOf,
-  objectKeys,
-  assertSingleKey,
   RequireDirectoryOptions,
   PlatformShim,
   RequireType,
+} from './typings/common-types.js';
+import {
+  assertNotStrictEqual,
+  assertSingleKey,
+  objectKeys,
 } from './typings/common-types.js';
 import {
   ArgsOutput,

--- a/test/deno/yargs.test.ts
+++ b/test/deno/yargs.test.ts
@@ -5,7 +5,7 @@ import {
   assertMatch
 } from 'https://deno.land/std/testing/asserts.ts'
 import yargs from '../../deno.ts'
-import { Arguments, YargsType } from '../../types.ts'
+import { Arguments } from '../../types.ts'
 
 Deno.test('demandCommand(1) throw error if no command provided', () => {
   let err: Error|null = null
@@ -31,7 +31,7 @@ Deno.test('guesses version # based on package.json', () => {
 // https://github.com/yargs/yargs/issues/1758
 Deno.test('does not drop .0 if positional is configured as string', async () => {
   const argv = await yargs(['cmd', '33.0'])
-    .command('cmd [str]', 'a command', (yargs: YargsType) => {
+    .command('cmd [str]', 'a command', (yargs: any) => {
       return yargs.positional('str', {
         type: 'string'
       })

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,11 @@
-// expose types for the benefit of Deno.
-import type {
-  YargsInstance as YargsType,
-  Arguments,
-} from './build/lib/yargs-factory.d.ts';
+declare type ArgsOutput = (string | number)[];
 
-export type {Arguments, YargsType};
+// TODO(bcoe): attempt to get the types for YargsInstance working again.
+export interface Arguments {
+  /** Non-option arguments */
+  _: ArgsOutput;
+  /** Arguments after the end-of-options flag `--` */
+  '--'?: ArgsOutput;
+  /** All remaining options */
+  [argName: string]: any;
+}


### PR DESCRIPTION
This gets yargs working again on deno@1.5.x, by dropping the complex `YargsInstance`.

Unfortunately `deno@1.5.x` seems to break the already fragile path handling logic that was being used to target both Node.js and Deno simultaneously. I'm not sure what the best path forward is, we might want to simply maintain our own type definitions for deno?

Refs https://github.com/yargs/yargs/pull/1792
Fixes https://github.com/yargs/yargs/issues/1794

CC: @ffMathy @KhushrajRathod