### PR TITLE
feat: command() now accepts an array of modules

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -233,6 +233,8 @@ This example uses [jest](https://github.com/facebook/jest) as a test runner, but
 .commandDir(directory, [opts])
 ------------------------------
 
+_Note: `commandDir()` does not work with ESM or Deno, see [hierarchy using index.mjs](/docs/advanced.md#esm-hierarchy) for an example of building a complex nested CLI using ESM._
+
 Apply command modules from a directory relative to the module calling this method.
 
 This allows you to organize multiple commands into their own modules under a
@@ -358,6 +360,38 @@ exports.builder = {}
 exports.handler = function (argv) {
   console.log('pruning remotes %s', [].concat(argv.name).concat(argv.names).join(', '))
 }
+```
+
+<a name="esm-hierarchy"></a>
+### Example command hierarchy using index.mjs
+
+To support creating a complex nested CLI when using ESM, the method
+`.command()` was extended to accept an array of command modules.
+Rather than using `.commandDir()`, create an `index.mjs` in each command
+directory with a list of the commands:
+
+cmds/index.mjs:
+
+```js
+import * as a from './init.mjs';
+import * as b from './remote.mjs';
+export const commands = [a, b];
+```
+
+This index will then be imported and registered with your CLI:
+
+cli.js:
+
+```js
+#!/usr/bin/env node
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { commands } from './cmds/index.mjs';
+
+yargs(hideBin(process.argv))
+  .command(commands)
+  .argv;
 ```
 
 <a name="configuration"></a>

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -57,17 +57,15 @@ export function command(
 
     // If an array is provided that is all CommandHandlerDefinitions, add
     // each handler individually:
-    if (Array.isArray(cmd) && !cmd.find(c => typeof c === 'string')) {
-      for (const command of cmd) {
-        self.addHandler(command);
+    if (Array.isArray(cmd)) {
+      if (cmd.every(c => typeof c === 'string')) {
+        ([cmd, aliases] = cmd);
+      } else {
+        for (const command of cmd) {
+          self.addHandler(command);
+        }
       }
-    } else if (Array.isArray(cmd)) {
-      // Assume the array is a cmd, followed by aliases, if the array contains
-      // any strings [cmd, 'alias1', 'alias2']:
-      aliases = cmd.slice(1) as string[];
-      cmd = cmd[0];
     } else if (isCommandHandlerDefinition(cmd)) {
-      // An object was provided rather than individual parameters:
       let command =
         Array.isArray(cmd.command) || typeof cmd.command === 'string'
           ? cmd.command

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -81,10 +81,8 @@ export function command(
         cmd.deprecated
       );
       return;
-    }
-
-    // Allow a module to be provided as builder, rather than function:
-    if (isCommandBuilderDefinition(builder) && isDefinitionOrCommandName(cmd)) {
+    } else if (isCommandBuilderDefinition(builder)) {
+      // Allow a module to be provided as builder, rather than function:
       self.addHandler(
         [cmd].concat(aliases),
         description,
@@ -671,16 +669,6 @@ export function isCommandHandlerDefinition(
   cmd: DefinitionOrCommandName | [DefinitionOrCommandName, ...string[]]
 ): cmd is CommandHandlerDefinition {
   return typeof cmd === 'object' && !Array.isArray(cmd);
-}
-
-function isDefinitionOrCommandName(
-  cmd: DefinitionOrCommandName | [DefinitionOrCommandName, ...string[]]
-): cmd is DefinitionOrCommandName {
-  if (typeof cmd === 'string' || isCommandHandlerDefinition(cmd)) {
-    return true;
-  } else {
-    return false;
-  }
 }
 
 interface Positionals extends Pick<Options, 'alias' | 'array' | 'default'> {

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -5,14 +5,15 @@
 // Works by accepting a shim which shims methods that contain platform
 // specific logic.
 import {
+  command as Command,
   CommandInstance,
   CommandHandler,
   CommandBuilderDefinition,
   CommandBuilder,
   CommandHandlerCallback,
-  FinishCommandHandler,
-  command as Command,
   CommandHandlerDefinition,
+  FinishCommandHandler,
+  HandlerArrayItem,
 } from './command.js';
 import type {
   Dictionary,
@@ -655,7 +656,7 @@ function Yargs(
   };
 
   self.command = function (
-    cmd: string | string[] | CommandHandlerDefinition,
+    cmd: string | CommandHandlerDefinition | HandlerArrayItem[],
     description?: CommandHandler['description'],
     builder?: CommandBuilderDefinition | CommandBuilder,
     handler?: CommandHandlerCallback,

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -13,7 +13,7 @@ import {
   CommandHandlerCallback,
   CommandHandlerDefinition,
   FinishCommandHandler,
-  HandlerArrayItem,
+  DefinitionOrCommandName,
 } from './command.js';
 import type {
   Dictionary,
@@ -656,7 +656,7 @@ function Yargs(
   };
 
   self.command = function (
-    cmd: string | CommandHandlerDefinition | HandlerArrayItem[],
+    cmd: string | CommandHandlerDefinition | DefinitionOrCommandName[],
     description?: CommandHandler['description'],
     builder?: CommandBuilderDefinition | CommandBuilder,
     handler?: CommandHandlerCallback,

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1832,4 +1832,32 @@ describe('Command', () => {
     const argv = yargs.command('$0 <phone>', '', yargs => {}).parse('+5550100');
     argv.phone.should.equal('+5550100');
   });
+
+  it('allows an array of commands to be provided', () => {
+    const innerCommands = [
+      {
+        command: 'c <x> <y>',
+        describe: 'add x to y',
+        builder: () => {},
+        handler: argv => {
+          argv.output.value = argv.x + argv.y;
+        },
+      },
+    ];
+    const cmds = [
+      {
+        command: 'a',
+        describe: 'numeric comamand',
+        builder: yargs => {
+          yargs.command(innerCommands);
+        },
+        handler: () => {},
+      },
+    ];
+    const context = {
+      output: {},
+    };
+    yargs().command(cmds).parse('a c 10 5', context);
+    context.output.value.should.equal(15);
+  });
 });

--- a/test/deno/yargs.test.ts
+++ b/test/deno/yargs.test.ts
@@ -6,6 +6,7 @@ import {
 } from 'https://deno.land/std/testing/asserts.ts'
 import yargs from '../../deno.ts'
 import { Arguments } from '../../deno-types.ts'
+import { commands } from '../esm/fixtures/commands/index.mjs'
 
 Deno.test('demandCommand(1) throw error if no command provided', () => {
   let err: Error|null = null
@@ -37,4 +38,12 @@ Deno.test('does not drop .0 if positional is configured as string', async () => 
       })
     }).parse() as Arguments
   assertEquals(argv.str, '33.0')
+})
+
+Deno.test('hierarchy of commands', async () => {
+  const context = {
+    output: {value: 0},
+  };
+  yargs().command(commands).parse('a c 10 5', context);
+  assertEquals(context.output.value, 15);
 })

--- a/test/esm/fixtures/commands/a.mjs
+++ b/test/esm/fixtures/commands/a.mjs
@@ -1,0 +1,8 @@
+import {commands} from './subcommands/index.mjs';
+
+export const command = 'a';
+export const describe = 'numeric commands';
+export const builder = yargs => {
+  yargs.command(commands);
+};
+export const handler = function (argv) {};

--- a/test/esm/fixtures/commands/b.mjs
+++ b/test/esm/fixtures/commands/b.mjs
@@ -1,0 +1,8 @@
+export const command = 'b <str1> <str2>';
+export const describe = 'string commands';
+export const builder = yargs => {
+  yargs.string(['str1', 'str2']);
+};
+export const handler = function (argv) {
+  argv.output.text = `${argv.str1} ${argv.str2}`;
+};

--- a/test/esm/fixtures/commands/index.mjs
+++ b/test/esm/fixtures/commands/index.mjs
@@ -1,0 +1,3 @@
+import * as a from './a.mjs';
+import * as b from './b.mjs';
+export const commands = [a, b];

--- a/test/esm/fixtures/commands/subcommands/c.mjs
+++ b/test/esm/fixtures/commands/subcommands/c.mjs
@@ -1,0 +1,6 @@
+export const command = 'c <x> <y>';
+export const describe = 'add x to y';
+export const builder = yargs => {};
+export const handler = function (argv) {
+  argv.output.value = argv.x + argv.y;
+};

--- a/test/esm/fixtures/commands/subcommands/d.mjs
+++ b/test/esm/fixtures/commands/subcommands/d.mjs
@@ -1,0 +1,6 @@
+export const command = 'd <x> <y>';
+export const describe = 'multiply x by y';
+export const builder = yargs => {};
+export const handler = function (argv) {
+  argv.output.value = argv.x * argv.y;
+};

--- a/test/esm/fixtures/commands/subcommands/index.mjs
+++ b/test/esm/fixtures/commands/subcommands/index.mjs
@@ -1,0 +1,3 @@
+import * as c from './c.mjs';
+import * as d from './d.mjs';
+export const commands = [c, d];

--- a/test/esm/yargs-test.mjs
+++ b/test/esm/yargs-test.mjs
@@ -3,6 +3,9 @@
 import * as assert from 'assert';
 import yargs from '../../index.mjs';
 
+// Example of composing hierarchical commands when using ESM:
+import {commands} from './fixtures/commands/index.mjs';
+
 describe('ESM', () => {
   describe('parser', () => {
     it('parses process.argv by default', () => {
@@ -33,6 +36,22 @@ describe('ESM', () => {
         })
         .parse();
       assert.strictEqual(argv.str, '33.0');
+    });
+  });
+  describe('hierarchy of commands', () => {
+    it('allows array of commands to be registered', () => {
+      const context = {
+        output: {},
+      };
+      yargs().command(commands).parse('b hello world!', context);
+      assert.strictEqual(context.output.text, 'hello world!');
+    });
+    it('allows array of subcommands to be registered', () => {
+      const context = {
+        output: {},
+      };
+      yargs().command(commands).parse('a d 10 5', context);
+      assert.strictEqual(context.output.value, 50);
     });
   });
 });


### PR DESCRIPTION
.command() now accepts an array of modules, the intention being that this
makes it easier for people to build a complex hierarchical CLI in
environments that can not use requireDirectory().