### PR TITLE
docs: add example of using middleware with choices

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1087,8 +1087,8 @@ require('yargs/yargs')(process.argv.slice(2))
   .parse()
 ```
 
-_Example: Using middleware to apply a transformation on argv after `choices` have
-been enforced ([see #756](https://github.com/yargs/yargs/issues/756)):_
+Example, Using middleware to apply a transformation on argv after `choices` have
+been enforced ([see #756](https://github.com/yargs/yargs/issues/756)):
 
 ```js
 require('yargs')

--- a/docs/api.md
+++ b/docs/api.md
@@ -1087,6 +1087,39 @@ require('yargs/yargs')(process.argv.slice(2))
   .parse()
 ```
 
+_Example: Using middleware to apply a transformation on argv after `choices` have
+been enforced ([see #756](https://github.com/yargs/yargs/issues/756)):_
+
+```js
+require('yargs')
+  .command('$0', 'accept username', () => {}, (argv) => {
+    // The middleware will have been applied before the default
+    // command is called:
+    console.info(argv);
+  })
+  .choices('user', ['Goofy', 'Miky'])
+  .middleware(argv => {
+    console.info('gots here');
+    const user = argv.user;
+    switch (user) {
+      case 'Goofy':
+        argv.user = {
+          firstName: 'Mark',
+          lastName: 'Pipe',
+        };
+        break;
+      case 'Miky':
+        argv.user = {
+          firstName: 'Elon',
+          lastName: 'Stone',
+        };
+        break;
+    }
+    return argv;
+  })
+  .parse('--user Miky');
+```
+
 <a name="nargs"></a>.nargs(key, count)
 -----------
 


### PR DESCRIPTION
Middleware can be applied either before or after validation. When combined with a default command this allows you to perform a transformation after choices has already been enforced (as requested in #756)

Fixes #756