### PR TITLE
chore: add package.json to module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "yargs the modern, pirate-themed, successor to optimist.",
   "main": "./index.cjs",
   "exports": {
+    "./package.json": "./package.json",
     ".": [
       {
         "import": "./index.mjs",


### PR DESCRIPTION
The reason for this change is explained in #1817.

TL;DR: yargs uses the `package.json`::`exports` field to define importable paths from the outside. Any files that are not explicitly listed in it cannot be required anymore. However, some tools may attempt to `require(node_modules/yargs/package.json)` to read package info and fail. This PR exposes the package.json file to the public.