### PR TITLE
feat!: improve support for async/await

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 15
       - run: npm install
       - run: npm test
       - run: npm run coverage

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -558,8 +558,8 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
 ## Using Yargs with Async/await
 
 If you use async middleware or async handlers for commands, `yargs.parse` and
-`yargs.argv` will return a Promise. When you `await` this promise the final
-parsed result will be returned:
+`yargs.argv` will return a `Promise`. When you `await` this promise the
+parsed arguments object will be returned after the handler completes.
 
 ```js
 import yargs from 'yargs'
@@ -585,8 +585,8 @@ console.info('finish')
 
 ### Handling async errors
 
-By default, when an error occurs in an during an async parse, yargs will
-exit with code `1` and print the help message. If you would rather
+By default, when an async error occurs within a command yargs will
+exit with code `1` and print a help message. If you would rather
 Use `try`/`catch` to perform error handling, you can do so with the setting
 `.fail(false)`:
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -559,7 +559,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
 
 If you use async middleware or async handlers for commands, `yargs.parse` and
 `yargs.argv` will return a `Promise`. When you `await` this promise the
-parsed arguments object will be returned after the handler completes.
+parsed arguments object will be returned after the handler completes:
 
 ```js
 import yargs from 'yargs'
@@ -587,7 +587,7 @@ console.info('finish')
 
 By default, when an async error occurs within a command yargs will
 exit with code `1` and print a help message. If you would rather
-Use `try`/`catch` to perform error handling, you can do so with the setting
+Use `try`/`catch` to perform error handling, you can do so by setting
 `.fail(false)`:
 
 ```js

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -484,19 +484,6 @@ yargs.parserConfiguration({
 See the [yargs-parser](https://github.com/yargs/yargs-parser#configuration) module
 for detailed documentation of this feature.
 
-## Command finish hook
-### Example
-```js
-yargs(process.argv.slice(2))
-    .command('cmd', 'a command', () => {}, async () => {
-        await this.model.find()
-        return Promise.resolve('result value')
-    })
-    .onFinishCommand(async (resultValue) => {
-        await this.db.disconnect()
-    }).argv
-```
-
 ## Middleware
 
 Sometimes you might want to transform arguments before they reach the command handler.

--- a/docs/api.md
+++ b/docs/api.md
@@ -837,7 +837,10 @@ Allows to programmatically get completion choices for any line.
 
 `args`: An array of the words in the command line to complete.
 
-`done`: The callback to be called with the resulting completions.
+`done`: Optional callback which will be invoked with `err`, or the resulting completions.
+
+If no `done` callback is provided, `getCompletion` returns a promise that
+resolves with the completions.
 
 For example:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -814,9 +814,9 @@ wanted to exit. Follows the behavior set by `.exitProcess()`.
 
 Method to execute when a failure occurs, rather than printing the failure message.
 
-Providing `false` as a value for `fn` can be used to prevent failure
-messages from being output. _This is useful if you wish to handle failures
-yourself, using `try`/`catch` and [`.getHelp()`](#get-help).
+Providing `false` as a value for `fn` can be used to prevent yargs from
+exiting and printing a failure message. _This is useful if you wish to
+handle failures yourself using `try`/`catch` and [`.getHelp()`](#get-help).
 
 `fn` is called with the failure message that would have been printed, the
 `Error` instance originally thrown and yargs state when the failure

--- a/docs/api.md
+++ b/docs/api.md
@@ -815,7 +815,7 @@ wanted to exit. Follows the behavior set by `.exitProcess()`.
 Method to execute when a failure occurs, rather than printing the failure message.
 
 Providing `false` as a value for `fn` can be used to prevent yargs from
-exiting and printing a failure message. _This is useful if you wish to
+exiting and printing a failure message. This is useful if you wish to
 handle failures yourself using `try`/`catch` and [`.getHelp()`](#get-help).
 
 `fn` is called with the failure message that would have been printed, the

--- a/docs/api.md
+++ b/docs/api.md
@@ -1165,23 +1165,6 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   .argv
 ```
 
-.onFinishCommand([handler])
-------------
-
-Called after the completion of any command. `handler` is invoked with the
-result returned by the command:
-
-```js
-yargs(process.argv.slice(2))
-    .command('cmd', 'a command', () => {}, async () => {
-        await this.model.find()
-        return Promise.resolve('result value')
-    })
-    .onFinishCommand(async (resultValue) => {
-        await this.db.disconnect()
-    }).argv
-```
-
 <a name="option"></a>.option(key, [opt])
 -----------------
 <a name="options"></a>.options(key, [opt])

--- a/docs/api.md
+++ b/docs/api.md
@@ -809,10 +809,14 @@ error message when this promise rejects
 Manually indicate that the program should exit, and provide context about why we
 wanted to exit. Follows the behavior set by `.exitProcess()`.
 
-<a name="fail"></a>.fail(fn)
+<a name="fail"></a>.fail(fn | boolean)
 ---------
 
 Method to execute when a failure occurs, rather than printing the failure message.
+
+Providing `false` as a value for `fn` can be used to prevent failure
+messages from being output. _This is useful if you wish to handle failures
+yourself, using `try`/`catch` and [`.getHelp()`](#get-help).
 
 `fn` is called with the failure message that would have been printed, the
 `Error` instance originally thrown and yargs state when the failure
@@ -855,6 +859,12 @@ require('yargs/yargs')(process.argv.slice(2))
 ```
 
 Outputs the same completion choices as `./test.js --foo`<kbd>TAB</kbd>: `--foobar` and `--foobaz`
+
+<a name="get-help"></a>.getHelp()
+---------------------------
+
+Returns a promise that resolves with a `string` equivalent to what would
+be output by [`.showHelp()`](#show-help), or by running yargs with `--help`.
 
 <a name="global"></a>.global(globals, [global=true])
 ------------
@@ -1467,7 +1477,7 @@ Generate a bash completion script. Users of your application can install this
 script in their `.bashrc`, and yargs will provide completion shortcuts for
 commands and options.
 
-.showHelp([consoleLevel | printCallback])
+<a name="show-help">.showHelp([consoleLevel | printCallback])
 ---------------------------
 
 Print the usage data.

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -320,8 +320,9 @@ export function command(
         innerArgv.catch(error => {
           try {
             yargs.getUsageInstance().fail(null, error);
-          } catch (err) {
-            // fail's throwing would cause an unhandled rejection.
+          } catch (_err) {
+            // If .fail(false) is not set, and no parse cb() has been
+            // registered, run usage's default fail method.
           }
         });
       } else if (isPromise(innerArgv)) {

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -600,8 +600,8 @@ export interface CommandInstance {
     command: string | null,
     yargs: YargsInstance,
     parsed: DetailedArguments,
-    commandIndex?: number,
-    helpOnly?: boolean
+    commandIndex: number,
+    helpOnly: boolean
   ): Arguments | Promise<Arguments>;
   runDefaultBuilderOn(yargs: YargsInstance): void;
   unfreeze(): void;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -311,25 +311,21 @@ export function command(
         const handlerResult = commandHandler.handler(innerArgv);
         if (isPromise(handlerResult)) {
           const innerArgvRef = innerArgv;
-          innerArgv = commandHandler
-            .handler(innerArgv)
-            .then(() => innerArgvRef);
+          innerArgv = handlerResult.then(() => innerArgvRef);
         }
       }
 
-      if (isPromise(innerArgv)) {
+      if (isPromise(innerArgv) && !yargs._hasParseCallback()) {
         yargs.getUsageInstance().cacheHelpMessage();
-        innerArgv
-          .catch(error => {
-            try {
-              yargs.getUsageInstance().fail(null, error);
-            } catch (err) {
-              // fail's throwing would cause an unhandled rejection.
-            }
-          })
-          .then(() => {
-            yargs.getUsageInstance().clearCachedHelpMessage();
-          });
+        innerArgv.catch(error => {
+          try {
+            yargs.getUsageInstance().fail(null, error);
+          } catch (err) {
+            // fail's throwing would cause an unhandled rejection.
+          }
+        });
+      } else if (isPromise(innerArgv)) {
+        yargs.getUsageInstance().cacheHelpMessage();
       }
     }
 

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -48,7 +48,7 @@ export function usage(yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {
       for (let i = fails.length - 1; i >= 0; --i) {
         const fail = fails[i];
         if (isBoolean(fail)) {
-          continue;
+          throw err;
         } else {
           fail(msg, err, self);
         }

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -12,16 +12,19 @@ import {YError} from './yerror.js';
 import {DetailedArguments} from './typings/yargs-parser-types.js';
 import setBlocking from './utils/set-blocking.js';
 
+function isBoolean(fail: FailureFunction | boolean): fail is boolean {
+  return typeof fail === 'boolean';
+}
+
 export function usage(yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {
   const __ = y18n.__;
   const self = {} as UsageInstance;
 
   // methods for ouputting/building failure message.
-  const fails: FailureFunction[] = [];
+  const fails: (FailureFunction | boolean)[] = [];
   self.failFn = function failFn(f) {
     fails.push(f);
   };
-
   let failMessage: string | undefined | null = null;
   let showHelpOnFail = true;
   self.showHelpOnFail = function showHelpOnFailFn(
@@ -43,7 +46,12 @@ export function usage(yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {
 
     if (fails.length) {
       for (let i = fails.length - 1; i >= 0; --i) {
-        fails[i](msg, err, self);
+        const fail = fails[i];
+        if (isBoolean(fail)) {
+          continue;
+        } else {
+          fail(msg, err, self);
+        }
       }
     } else {
       if (yargs.getExitProcess()) setBlocking(true);
@@ -554,6 +562,10 @@ export function usage(yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {
     cachedHelpMessage = undefined;
   };
 
+  self.hasCachedHelpMessage = function () {
+    return !!cachedHelpMessage;
+  };
+
   // given a set of keys, place any keys that are
   // ungrouped under the 'Options:' grouping.
   function addUngroupedKeys(
@@ -710,6 +722,7 @@ export function usage(yargs: YargsInstance, y18n: Y18N, shim: PlatformShim) {
 export interface UsageInstance {
   cacheHelpMessage(): void;
   clearCachedHelpMessage(): void;
+  hasCachedHelpMessage(): boolean;
   command(
     cmd: string,
     description: string | undefined,
@@ -722,7 +735,7 @@ export interface UsageInstance {
   epilog(msg: string): void;
   example(cmd: string, description?: string): void;
   fail(msg?: string | null, err?: YError | string): void;
-  failFn(f: FailureFunction): void;
+  failFn(f: FailureFunction | boolean): void;
   freeze(): void;
   functionDescription(fn: {name?: string}): string;
   getCommands(): [string, string, boolean, string[], boolean][];

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1223,7 +1223,10 @@ function Yargs(
 
   self.getHelp = async function () {
     if (!usage.hasCachedHelpMessage()) {
+      // TODO(@bcoe): do we need this logic for getHelp()? what should the
+      // behavior be if you use `getHelp()` without having run the parser.
       if (!self.parsed) await self._parseArgs(processArgs); // run parser, if it has not already been executed.
+      // TODO(@bcoe): why is `hasDefaultCommand` separate from the _parseArgs step.
       if (command.hasDefaultCommand()) {
         context.resets++; // override the restriction on top-level positoinals.
         command.runDefaultBuilderOn(self);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -12,7 +12,6 @@ import {
   CommandBuilder,
   CommandHandlerCallback,
   CommandHandlerDefinition,
-  FinishCommandHandler,
   DefinitionOrCommandName,
 } from './command.js';
 import type {
@@ -80,7 +79,6 @@ function Yargs(
   const preservedGroups: Dictionary<string[]> = {};
   let usage: UsageInstance;
   let validation: ValidationInstance;
-  let handlerFinishCommand: FinishCommandHandler | null = null;
 
   const y18n = shim.y18n;
 
@@ -278,7 +276,6 @@ function Yargs(
       parsed: self.parsed,
       parseFn,
       parseContext,
-      handlerFinishCommand,
     });
     usage.freeze();
     validation.freeze();
@@ -303,7 +300,6 @@ function Yargs(
       completionCommand,
       parseFn,
       parseContext,
-      handlerFinishCommand,
     } = frozen);
     options.configObjects = configObjects;
     usage.unfreeze();
@@ -844,14 +840,6 @@ function Yargs(
     usage.failFn(f);
     return self;
   };
-
-  self.onFinishCommand = function (f) {
-    argsert('<function>', [f], arguments.length);
-    handlerFinishCommand = f;
-    return self;
-  };
-
-  self.getHandlerFinishCommand = () => handlerFinishCommand;
 
   self.check = function (f, _global) {
     argsert('<function> [boolean]', [f, _global], arguments.length);
@@ -1894,7 +1882,6 @@ export interface YargsInstance {
   getDetectLocale(): boolean;
   getExitProcess(): boolean;
   getGroups(): Dictionary<string[]>;
-  getHandlerFinishCommand(): FinishCommandHandler | null;
   getOptions(): Options;
   getParserConfiguration(): Configuration;
   getStrict(): boolean;
@@ -1924,7 +1911,6 @@ export interface YargsInstance {
   };
   normalize(keys: string | string[]): YargsInstance;
   number(keys: string | string[]): YargsInstance;
-  onFinishCommand(f: FinishCommandHandler): YargsInstance;
   option: {
     (key: string, optionDefinition: OptionDefinition): YargsInstance;
     (keyOptionDefinitions: Dictionary<OptionDefinition>): YargsInstance;
@@ -2110,7 +2096,6 @@ interface FrozenYargsInstance {
   parsed: DetailedArguments | false;
   parseFn: ParseCallback | null;
   parseContext: object | null;
-  handlerFinishCommand: FinishCommandHandler | null;
 }
 
 interface ParseCallback {

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1572,7 +1572,13 @@ function Yargs(
 
           // run the default command, if defined
           if (command.hasDefaultCommand() && !skipDefaultCommand) {
-            const innerArgv = command.runCommand(null, self, parsed);
+            const innerArgv = command.runCommand(
+              null,
+              self,
+              parsed,
+              0,
+              helpOnly
+            );
             return self._postProcess(innerArgv, populateDoubleDash);
           }
 
@@ -1594,7 +1600,7 @@ function Yargs(
           self.exit(0);
         }
       } else if (command.hasDefaultCommand() && !skipDefaultCommand) {
-        const innerArgv = command.runCommand(null, self, parsed);
+        const innerArgv = command.runCommand(null, self, parsed, 0, helpOnly);
         return self._postProcess(innerArgv, populateDoubleDash);
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yargs",
-  "version": "16.2.0",
+  "version": "17.0.0-candidate.0",
   "description": "yargs the modern, pirate-themed, successor to optimist.",
   "main": "./index.cjs",
   "exports": {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1787,7 +1787,32 @@ describe('Command', () => {
       parsed.pos.should.equal('hello');
     });
 
-    // TODO(bcoe): add test for handler rejecting, when using parsedPromise.
+    it('returns promise that can be caught, when fail(false)', async () => {
+      let complete = false;
+      const handler = new Promise((resolve, reject) => {
+        setTimeout(() => {
+          complete = true;
+          return reject(Error('error from handler'));
+        }, 10);
+      });
+      const parsedPromise = yargs('foo hello')
+        .command(
+          'foo <pos>',
+          'foo command',
+          () => {},
+          () => handler
+        )
+        .fail(false)
+        .parse();
+      try {
+        complete.should.equal(false);
+        await parsedPromise;
+        throw Error('unreachable');
+      } catch (err) {
+        err.message.should.match(/error from handler/);
+        complete.should.equal(true);
+      }
+    });
 
     // see: https://github.com/yargs/yargs/issues/1144
     it('displays error and appropriate help message when handler fails', done => {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1765,30 +1765,29 @@ describe('Command', () => {
         .parse();
     });
 
-    it('succeeds when the promise returned by the command handler resolves', done => {
+    it('returns promise that resolves arguments once handler succeeds', async () => {
+      let complete = false;
       const handler = new Promise((resolve, reject) => {
         setTimeout(() => {
-          return resolve(true);
-        }, 5);
+          complete = true;
+          return resolve();
+        }, 10);
       });
-      const parsed = yargs('foo hello')
+      const parsedPromise = yargs('foo hello')
         .command(
           'foo <pos>',
           'foo command',
           () => {},
-          yargs => handler
+          () => handler
         )
-        .fail((msg, err) => {
-          return done(Error('should not have been called'));
-        })
         .parse();
-
-      handler.then(called => {
-        called.should.equal(true);
-        parsed.pos.should.equal('hello');
-        return done();
-      });
+      complete.should.equal(false);
+      const parsed = await parsedPromise;
+      complete.should.equal(true);
+      parsed.pos.should.equal('hello');
     });
+
+    // TODO(bcoe): add test for handler rejecting, when using parsedPromise.
 
     // see: https://github.com/yargs/yargs/issues/1144
     it('displays error and appropriate help message when handler fails', done => {

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -688,4 +688,7 @@ describe('Completion', () => {
       r.logs.should.include('of-memory:Dream about a specific memory');
     });
   });
+
+  // TODO: add async tests for getCompletion.
+  // See: https://github.com/yargs/yargs/issues/1420
 });

--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -138,6 +138,8 @@ describe('middleware', () => {
         .parse();
     });
 
+    // TODO(bcoe): add test for middleware rejecting, when using promise form.
+
     it('calls the command handler when all middleware promises resolve', done => {
       const middleware = (key, value) => () =>
         new Promise((resolve, reject) => {

--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -139,6 +139,7 @@ describe('middleware', () => {
     });
 
     // TODO(bcoe): add test for middleware rejecting, when using promise form.
+    // TODO(bcoe): add test that ensures handler awaited after middleware.
 
     it('calls the command handler when all middleware promises resolve', done => {
       const middleware = (key, value) => () =>

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -3178,6 +3178,23 @@ describe('usage tests', () => {
         return done();
       }
     });
+    // See: https://github.com/yargs/yargs/issues/1791
+    it('should not run default command', done => {
+      let executed = false;
+      yargs.command(
+        '$0',
+        'a default command',
+        yargs => yargs,
+        () => {
+          executed = true;
+        }
+      );
+      yargs.showHelp(output => {
+        executed.should.equal(false);
+        output.should.match(/a default command/);
+        return done();
+      });
+    });
   });
 
   describe('$0', () => {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -612,7 +612,6 @@ describe('usage tests', () => {
             .fail(message => {
               console.log(message);
             })
-            .exitProcess(false)
             .wrap(null)
             .check(argv => {
               throw new Error('foo');
@@ -641,7 +640,6 @@ describe('usage tests', () => {
             .fail((message, error, yargs) => {
               yargs.showHelp();
             })
-            .exitProcess(false)
             .wrap(null)
             .parse()
         );
@@ -656,7 +654,6 @@ describe('usage tests', () => {
               .fail((message, error) => {
                 console.log(error.message);
               })
-              .exitProcess(false)
               .wrap(null)
               .check(() => {
                 throw new Error('foo');
@@ -674,7 +671,6 @@ describe('usage tests', () => {
               .fail(() => {
                 console.log('is triggered last');
               })
-              .exitProcess(false)
               .wrap(null)
               .command(
                 'test',
@@ -698,6 +694,36 @@ describe('usage tests', () => {
           ]);
           r.should.have.property('exit').and.equal(false);
         });
+      });
+
+      it('allows "false" to be provided to prevent exit/output', () => {
+        try {
+          yargs()
+            .fail(false)
+            .wrap(null)
+            .check(argv => {
+              throw new Error('sync error');
+            })
+            .parse();
+          throw Error('unreachable');
+        } catch (err) {
+          err.message.should.equal('sync error');
+        }
+      });
+
+      it('does not allow "true" as argument', () => {
+        try {
+          yargs()
+            .fail(true)
+            .wrap(null)
+            .check(argv => {
+              throw new Error('sync error');
+            })
+            .parse();
+          throw Error('unreachable');
+        } catch (err) {
+          err.message.should.match(/Invalid first argument/);
+        }
       });
     });
   });
@@ -3126,6 +3152,29 @@ describe('usage tests', () => {
             '      --version  Show version number  [boolean]',
             '  -f, --foo      foo option',
           ]);
+        return done();
+      }
+    });
+    it('should not run handler or middleware', done => {
+      let commandRun = false;
+      let middlewareRun = false;
+      const y = yargs(['foo'])
+        .command(
+          'foo',
+          'foo command',
+          () => {},
+          () => {
+            commandRun = true;
+          }
+        )
+        .middleware(() => {
+          middlewareRun = true;
+        });
+      y.showHelp(printCallback);
+      function printCallback(msg) {
+        commandRun.should.equal(false);
+        middlewareRun.should.equal(false);
+        msg.should.match(/foo command/);
         return done();
       }
     });

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -21,6 +21,10 @@ describe('yargs dsl tests', () => {
   const oldProcess = {versions: {}};
 
   beforeEach(() => {
+    process.execPath = 'node';
+    process._ = 'node';
+    process.argv[1] = 'node';
+
     oldProcess.argv = process.argv;
     oldProcess.defaultApp = process.defaultApp;
     oldProcess.versions.electron = process.versions.electron;
@@ -35,17 +39,12 @@ describe('yargs dsl tests', () => {
   });
 
   it('should use bin name for $0, eliminating path', () => {
-    const originalExec = process.execPath;
     process.argv[1] = '/usr/local/bin/ndm';
     process.env._ = '/usr/local/bin/ndm';
     process.execPath = '/usr/local/bin/ndm';
     const argv = yargs([]).parse();
     argv.$0.should.equal('ndm');
     yargs.$0.should.equal('ndm');
-    // Restore env:
-    process.execPath = originalExec;
-    process._ = originalExec;
-    process.argv[1] = originalExec;
   });
 
   it('should not remove the 1st argument of bundled electron apps', () => {

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2441,46 +2441,6 @@ describe('yargs dsl tests', () => {
     argv['--'].should.eql(['foo']);
   });
 
-  describe('onFinishCommand', () => {
-    it('use with promise', done => {
-      const result = 'noop-result';
-      let calledTimes = 0;
-      yargs(['noop'])
-        .command('noop', 'a noop command', noop, async () => {
-          return result;
-        })
-        .onFinishCommand(async commandResult => {
-          commandResult.should.eql(result);
-          calledTimes++;
-        })
-        .parse('noop');
-
-      setTimeout(() => {
-        calledTimes.should.eql(1);
-        done();
-      }, 5);
-    });
-
-    it('use without promise', done => {
-      const result = 'noop-result';
-      let calledTimes = 0;
-      yargs(['noop'])
-        .command('noop', 'a noop command', noop, () => {
-          return result;
-        })
-        .onFinishCommand(commandResult => {
-          commandResult.should.eql(result);
-          calledTimes++;
-        })
-        .parse('noop');
-
-      setTimeout(() => {
-        calledTimes.should.eql(1);
-        done();
-      }, 5);
-    });
-  });
-
   // See: https://github.com/yargs/yargs/issues/1098
   it('should allow array and requires arg to be used in conjunction', () => {
     const argv = yargs(['-i', 'item1', 'item2', 'item3']).option('i', {
@@ -2695,3 +2655,45 @@ describe('yargs dsl tests', () => {
     });
   });
 });
+
+/*
+  describe('asyncParse', () => {
+    it('use with promise', done => {
+      const result = 'noop-result';
+      let calledTimes = 0;
+      yargs(['noop'])
+        .command('noop', 'a noop command', noop, async () => {
+          return result;
+        })
+        .onFinishCommand(async commandResult => {
+          commandResult.should.eql(result);
+          calledTimes++;
+        })
+        .parse('noop');
+
+      setTimeout(() => {
+        calledTimes.should.eql(1);
+        done();
+      }, 5);
+    });
+
+    it('use without promise', done => {
+      const result = 'noop-result';
+      let calledTimes = 0;
+      yargs(['noop'])
+        .command('noop', 'a noop command', noop, () => {
+          return result;
+        })
+        .onFinishCommand(commandResult => {
+          commandResult.should.eql(result);
+          calledTimes++;
+        })
+        .parse('noop');
+
+      setTimeout(() => {
+        calledTimes.should.eql(1);
+        done();
+      }, 5);
+    });
+  });
+*/


### PR DESCRIPTION
In `node@15` [top level await](https://v8.dev/features/top-level-await) is now supported 🎉. 

This means that we can have yargs return a promise in more situations, with users writing code that looks like this:

```js
import yargs from './index.mjs';
import { setTimeout } from 'timers/promises';

const argv = await yargs(process.argv.slice(2))
  .command(
    'foo',
    'foo commnd',
    () => {},
    async (argv) => {
      console.info('second')
      await setTimeout(1000)
    }
  )
  .middleware(async (argv) => {
    console.info('first')
    await setTimeout(1000)
    argv.value = 99
  }).argv;
console.info('third', argv)
```

This PR begins work to add better first class support of promises to yargs.

---

TODO:

- [x] ~write unit tests for scenarios outlined in #1420~ broke into several steps.
- [x] add tests for async behavior of `.parse()` (Refs: #1420). 
- [x] add tests for async behavior of top level `.argv` (Refs: #1420).
- [x] add tests for, and document `async getHelp() (Refs: #1420).
- [x] add tests for async getCompletion()/completion (Refs: #1420, #1235).
- [x] write unit tests for any TODO comments added during this work.
- [x] ~should command builders accept a promise?~ see #1042 -- we will land this work separately before the next major.
- [x] ~add async support to coerce/check~, see #859 -- we will land this work separately before the next major.
- [x] ~make global middleware work without defining command (_this work should be in separate breaking PR_).~ broken into ticket https://github.com/yargs/yargs/issues/1849
- [x] add documentation for new async behavior.

BREAKING CHANGES:

* now returns a promise if handler is `async`.
* onFinishCommand removed, in favor of being able to await promise.
* getCompletion now invokes callback with `err` and `completions, returns promise of completions.

Fixes #1791, #1420, #1235