### PR TITLE
Add descriptions of parsing numbers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@ value should be a string or an array of strings.
 
 Get the arguments as a plain old object.
 
-Arguments without a corresponding flag show up in the `argv._` array. By default, elements of `argv._` that appear to be numeric will be parsed as numbers. To change this, see the `parse-positional-numbers` flag for [`parserConfiguration()`](#parserConfiguration).
+Arguments without a corresponding flag show up in the `argv._` array. Note that elements of `argv._` may be [converted to numbers](/docs/tricks.md#numbers) by default.
 
 The script name or node command is available at `argv.$0` similarly to how `$0`
 works in bash or perl.
@@ -1345,6 +1345,7 @@ yargs.parserConfiguration({
   "camel-case-expansion": true,
   "dot-notation": true,
   "parse-numbers": true,
+  "parse-positional-numbers": true,
   "boolean-negation": true,
   "deep-merge-config": false
 })

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@ value should be a string or an array of strings.
 
 Get the arguments as a plain old object.
 
-Arguments without a corresponding flag show up in the `argv._` array.
+Arguments without a corresponding flag show up in the `argv._` array. By default, elements of `argv._` that appear to be numeric will be parsed as numbers. To change this, see the `parse-positional-numbers` flag for [`parserConfiguration()`](#parserConfiguration).
 
 The script name or node command is available at `argv.$0` similarly to how `$0`
 works in bash or perl.
@@ -1335,13 +1335,20 @@ for details of this object
 ------------
 `parserConfiguration()` allows you to configure advanced yargs features.
 
-`obj` accepts the following configuration options:
+See [yargs-parser's configuration](https://github.com/yargs/yargs-parser#configuration) for valid configuration options. Yargs also supports the following options:
 
 * `sort-commands` when set to `true` (boolean) will sort the commands added, the default is `false`.
 
-For additional configuration options, see [yargs-parser's configuration](https://github.com/yargs/yargs-parser#configuration).
-
-_Note: configuration should be top level keys on the `obj` passed to `parserConfiguration`, not populated under the configuration key, as in `yargs-parser`._
+```js
+yargs.parserConfiguration({
+  "short-option-groups": true,
+  "camel-case-expansion": true,
+  "dot-notation": true,
+  "parse-numbers": true,
+  "boolean-negation": true,
+  "deep-merge-config": false
+})
+```
 
 <a name="pkg-conf"></a>
 .pkgConf(key, [cwd])

--- a/docs/tricks.md
+++ b/docs/tricks.md
@@ -31,6 +31,9 @@ one. This way you can just `net.createConnection(argv.port)` and you can add
 numbers out of `argv` with `+` without having that mean concatenation,
 which is super frustrating.
 
+You can change this behavior by calling [`parserConfiguration()`](/docs/api.md#parserConfiguration)
+or by explicitly specifying [`string`](/docs/api.md/#string) for your flags.
+
 <a name="arrays"></a>
 Arrays
 ----------


### PR DESCRIPTION
This updates the docs to help cover some of the issues discussed in #963.

I also copied the sample `parserConfiguration` usage from advanced.md#customizing-yargs-parser; it seems helpful to have an example in the API section, too.