### PR TITLE
fix(cve): Update y18n to 5.0.5 to fix  CVE-2020-7774

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "set-blocking": "^2.0.0",
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
-    "y18n": "^4.0.0",
+    "y18n": "^5.0.5",
     "yargs-parser": "^18.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Could you please make an exception and release it in 15.x Version due to many packages that are depending on old 15th version?