### PR TITLE
Zsh completion is now installable system-wide

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -28,7 +28,8 @@ complete -o default -F _yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###
 `;
 
-export const completionZshTemplate = `###-begin-{{app_name}}-completions-###
+export const completionZshTemplate = `#compdef {{app_name}}
+###-begin-{{app_name}}-completions-###
 #
 # yargs command completion script
 #


### PR DESCRIPTION
I manage [an AUR package](https://aur.archlinux.org/packages/readability-cli/#news) for my own node CLI tool, so I want to be able to install Bash/Zsh completions system-wide.

Bash completion works fine when I put it in `/usr/share/bash-completion/completions/<app name>`. But when I try to put the Zsh completion into `/usr/share/zsh/site-functions/_<app name>` it does not work at all.

This is fixed by adding `#compdef _<app name>` at the top of the completion file.
