### PR TITLE
fix: always cache help message when running commands

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -338,8 +338,8 @@ export function command(
         }
       }
 
+      yargs.getUsageInstance().cacheHelpMessage();
       if (isPromise(innerArgv) && !yargs._hasParseCallback()) {
-        yargs.getUsageInstance().cacheHelpMessage();
         innerArgv.catch(error => {
           try {
             yargs.getUsageInstance().fail(null, error);
@@ -348,8 +348,6 @@ export function command(
             // registered, run usage's default fail method.
           }
         });
-      } else if (isPromise(innerArgv)) {
-        yargs.getUsageInstance().cacheHelpMessage();
       }
     }
 

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -3065,5 +3065,19 @@ describe('yargs dsl tests', () => {
       commandCalled.should.equal(false);
       middlewareCalled.should.equal(false);
     });
+    // Refs: #1853
+    it('should use cached help message for nested synchronous commands', async () => {
+      const y = yargs('object').command(
+        'object',
+        'object command',
+        (yargs) => {
+          yargs.command('get', 'get command');
+        }
+      );
+      const argv = y.argv;
+      const help = (await y.getHelp());
+      help.should.match(/node object get/);
+      argv._.should.eql(['object']);
+    });
   });
 });


### PR DESCRIPTION
Prior to this fix, we only cached the help message for commands
when using async commands. I believe we always want to cache the
help message for cases like #1853.

Fixes #1853