### PR TITLE
feat: allow to access output of default completion in custom completion

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -279,7 +279,7 @@ interface FallbackCompletionFunction {
   (
     current: string,
     argv: Arguments,
-    defaultCompletion: (onCompleted?: CompletionCallback) => any,
+    completionFilter: (onCompleted?: CompletionCallback) => any,
     done: (completions: string[]) => any
   ): any;
 }

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -193,7 +193,8 @@ export class Completion implements CompletionInstance {
       return (this.customCompletionFunction as FallbackCompletionFunction)(
         current,
         argv,
-        () => this.defaultCompletion(args, argv, current, done),
+        (onCompleted = done) =>
+          this.defaultCompletion(args, argv, current, onCompleted),
         completions => {
           done(null, completions);
         }
@@ -278,7 +279,7 @@ interface FallbackCompletionFunction {
   (
     current: string,
     argv: Arguments,
-    defaultCompletion: () => any,
+    defaultCompletion: (onCompleted?: CompletionCallback) => any,
     done: (completions: string[]) => any
   ): any;
 }


### PR DESCRIPTION
## Allow to access output of default completion in custom completion

### Problem:

When using default completion both `positional` and `option` arguments are treated the same. This results in completion suggesting `positional` arguments in an `option` form, which is incorrect:

```ts
yargs
  .command(
    'exec <pos-a> <pos-b>',
    'Execute command.',
    (yargs) => {
      return yargs
        .positional('pos-a', { type: 'string', desc: 'Pos A' })
        .positional('pos-b', { type: 'string', desc: 'Pos B' })
        .option({
          'opt-a': { type: 'boolean', alias: 'oa', desc: 'Option A' },
          'opt-b': { type: 'string', requiresArg: true, desc: 'Option B' },
        });
    },
  )
  .completion('completion', 'Completion.').argv;
```

```
$ ./index.js exec --
--help     -- Show help
--opt-a    -- Option A
--opt-b    -- Option B
--pos-a    -- Pos A
--pos-b    -- Pos B
--version  -- Show version number
```

```
$ ./index.js exec --pos-a --
--help     -- Show help
--opt-a    -- Option A
--opt-b    -- Option B
--pos-b    -- Pos B
--version  -- Show version number
```

Currently, the solution is to write your on competion funtion from the ground up. There is no way to apply custom completion function that would be able to utilize default completion function output. But this would help significantly in the case above.

### Solution:

This PR adds ability to pass `onCompleted` callback to `defaultCompletion` function to replace the `done` callback, allowing us to do this:

```ts
yargs
  .command(
    'exec <pos-a> <pos-b>',
    'Execute command.',
    (yargs) => {
      return yargs
        .positional('pos-a', { type: 'string', desc: 'Pos A' })
        .positional('pos-b', { type: 'string', desc: 'Pos B' })
        .option({
          'opt-a': { type: 'boolean', alias: 'oa', desc: 'Option A' },
          'opt-b': { type: 'string', requiresArg: true, desc: 'Option B' },
        });
    },
  )
  .completion(
    'completion',
    'Completion.',
    (current, argv, defaultCompletion, done) => {
      // Execute `defaultCompletion` to get default `completions`
      defaultCompletion((_err, completions) => {
        const filteredCompletions = completions.filter(
          (c) => !c.includes('pos'),
        );
        // Execute `done` with `filteredCompletions`
        done(filteredCompletions);
      });
    },
  ).argv;
```
The example above is naive and just filtering based on the `pos` text, but illustrates the point.

```
$ ./index.js exec --
--help     -- Show help
--opt-a    -- Option A
--opt-b    -- Option B
--version  -- Show version number
```

Ideally, the default completion should ignore `positional` arguments out of the box, but this is a simple solution to fix completion right now.
