### PR TITLE
docs(usage): add return to fix TS inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const { hideBin } = require('yargs/helpers')
 
 yargs(hideBin(process.argv))
   .command('serve [port]', 'start the server', (yargs) => {
-    yargs
+    return yargs
       .positional('port', {
         describe: 'port to bind on',
         default: 5000


### PR DESCRIPTION
Should reflect solution of this issue: https://github.com/yargs/yargs/issues/1450  

This seems to be correct in [the deno example](https://github.com/yargs/yargs#deno):  
```ts
...

yargs(Deno.args)
  .command('download <files...>', 'download a list of files', (yargs: any) => {
    return yargs.positional('files', {
      describe: 'a list of files to do something with'
    })

...
```

/cc @garyking

Please Let me know if I can improve this PR somehow.