### PR TITLE
Use actual names for keys instead of inferring.

### DIFF
--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -66,7 +66,7 @@ export default {
     notStrictEqual: assertNotEquals,
     strictEqual: assertStrictEquals,
   },
-  cliui,
+  cliui: cliui,
   findUp: escalade,
   getEnv: (key: string) => {
     return env[key];
@@ -77,8 +77,8 @@ export default {
     return 'deno';
   },
   mainFilename: cwd,
-  Parser,
-  path,
+  Parser: Parser,
+  path: path,
   process: {
     argv: () => argv,
     cwd: () => cwd,


### PR DESCRIPTION
Fix: https://github.com/yargs/yargs/issues/1841#issuecomment-804770453

Not sure if this is a bug in deno itself, but for now this doesn't work when building distributable binaries. 

There is a distinction between the names of an exported value between  `deno run`  and `deno compile` when importing an object and using it as a key in a new object


In `'https://deno.land/x/yargs_parser@v20.2.4-deno/deno.ts'`
```ts
export default yargsParser
``` 

In `'https://deno.land/x/yargs/deno.ts'`
```ts
import Parser from 'https://deno.land/x/yargs_parser@v20.2.4-deno/deno.ts';

const newObject = {
 Parser
}
``` 
This will create `{yargParser: Parser}` in `deno compile` while work as intended with `deno run`  where you get `{Parser: Parser}`

The codebase relies on `shim.Parser` and that will be `undefined` when running `deno compile` to build binaries as it would be called `shim.yargParser`