### PR TITLE
fix(async): don't call parse callback until async ops complete

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1052,10 +1052,13 @@ export class YargsInstance {
 
     if (this.#parseFn) this.#exitProcess = false;
 
-    let parsed = this[kRunYargsParserAndExecuteCommands](args, !!shortCircuit);
+    const parsed = this[kRunYargsParserAndExecuteCommands](
+      args,
+      !!shortCircuit
+    );
     this.#completion!.setParsed(this.parsed as DetailedArguments);
     if (isPromise(parsed)) {
-      parsed = parsed
+      return parsed
         .then(argv => {
           if (this.#parseFn) this.#parseFn(this.#exitError, argv, this.#output);
           return argv;

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -2054,9 +2054,17 @@ describe('Command', () => {
         assert.strictEqual(set, true);
       });
     });
-    // TODO: investigate why .parse('cmd --help', () => {}); does not
-    // work properly with an async builder. We should test the same
-    // with handler.
+    // Refs: https://github.com/yargs/yargs/issues/1894
+    it('does not print to stdout when parse callback is provided', async () => {
+      await yargs()
+        .command('cmd <foo>', 'a test command', async () => {
+          await wait();
+        })
+        .parse('cmd --help', (_err, argv, output) => {
+          output.should.include('a test command');
+          argv.help.should.equal(true);
+        });
+    });
   });
 
   describe('builder', () => {

--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -857,7 +857,7 @@ describe('middleware', () => {
             choices: [10, 20, 30],
           })
           .coerce('foo', async arg => {
-            wait();
+            await wait();
             return (arg *= 2);
           })
           .parse('--foo 2'),

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2687,7 +2687,7 @@ describe('yargs dsl tests', () => {
   // See: https://github.com/yargs/yargs/issues/1420
   describe('async', () => {
     describe('parse', () => {
-      it('returns promise that resolves argv on success', done => {
+      it('calls parse callback once async handler has resolved', done => {
         let executionCount = 0;
         yargs()
           .command(
@@ -2705,15 +2705,13 @@ describe('yargs dsl tests', () => {
             }
           )
           .parse('cmd foo', async (_err, argv) => {
-            (typeof argv.then).should.equal('function');
-            argv = await argv;
             argv.addedAsync.should.equal(99);
             argv.str.should.equal('foo');
             executionCount.should.equal(1);
             return done();
           });
       });
-      it('returns deeply nested promise that resolves argv on success', done => {
+      it('calls parse callback once deeply nested promise has resolved', done => {
         let executionCount = 0;
         yargs()
           .command(
@@ -2738,15 +2736,13 @@ describe('yargs dsl tests', () => {
             () => {}
           )
           .parse('cmd foo orange', async (_err, argv) => {
-            (typeof argv.then).should.equal('function');
-            argv = await argv;
             argv.addedAsync.should.equal(99);
             argv.apple.should.equal('orange');
             executionCount.should.equal(1);
             return done();
           });
       });
-      it('returns promise that can be caught if rejected', done => {
+      it('populates err with async rejection', done => {
         let executionCount = 0;
         yargs()
           .command(
@@ -2762,15 +2758,10 @@ describe('yargs dsl tests', () => {
               });
             }
           )
-          .parse('cmd foo', async (_err, argv) => {
-            (typeof argv.then).should.equal('function');
-            try {
-              await argv;
-            } catch (err) {
-              err.message.should.equal('async error');
-              executionCount.should.equal(1);
-              return done();
-            }
+          .parse('cmd foo', async err => {
+            err.message.should.equal('async error');
+            executionCount.should.equal(1);
+            return done();
           });
       });
       it('caches nested help output, so that it can be output by showHelp()', done => {
@@ -2789,16 +2780,11 @@ describe('yargs dsl tests', () => {
             });
           }
         ).parse('cmd foo', async (_err, argv) => {
-          (typeof argv.then).should.equal('function');
-          try {
-            await argv;
-          } catch (err) {
-            y.showHelp(output => {
-              output.should.match(/a command/);
-              executionCount.should.equal(1);
-              return done();
-            });
-          }
+          y.showHelp(output => {
+            output.should.match(/a command/);
+            executionCount.should.equal(1);
+            return done();
+          });
         });
       });
       it('caches deeply nested help output, so that it can be output by showHelp()', done => {
@@ -2824,16 +2810,11 @@ describe('yargs dsl tests', () => {
           },
           () => {}
         ).parse('cmd inner bar', async (_err, argv) => {
-          (typeof argv.then).should.equal('function');
-          try {
-            await argv;
-          } catch (err) {
-            y.showHelp(output => {
-              output.should.match(/inner command/);
-              executionCount.should.equal(1);
-              return done();
-            });
-          }
+          y.showHelp(output => {
+            output.should.match(/inner command/);
+            executionCount.should.equal(1);
+            return done();
+          });
         });
       });
     });


### PR DESCRIPTION
If a callback is provided to `parse()` it will now be executed after all promises have resolved.

The cause of #1888, was that `this[kUnfreeze]();` was being called too soon, which set `this.#parseFn` to `null`.

Fixes #1888 