### PR TITLE
build(publishing): use terser to minify CJS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.23.0",
     "rollup-plugin-cleanup": "^3.1.1",
+    "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.0.2",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -1,5 +1,6 @@
 const cleanup = require('rollup-plugin-cleanup');
 const ts = require('@wessberg/rollup-plugin-ts');
+const {terser} = require('rollup-plugin-terser');
 
 const output = {
   format: 'cjs',
@@ -14,7 +15,15 @@ const plugins = [
     extensions: ['*'],
   }),
 ];
-if (process.env.NODE_ENV === 'test') output.sourcemap = true;
+if (process.env.NODE_ENV === 'test') {
+  // During development include a source map. We don't ship this to npm,
+  // because it significantly increases the module size:
+  output.sourcemap = true;
+} else {
+  // Minify code when publishing, this significantly decreases the module
+  // size increased introduced by shipping both ESM and CJS:
+  plugins.push(terser());
+}
 
 module.exports = {
   input: './lib/cjs.ts',


### PR DESCRIPTION
By minifying the CJS bundle we reduce the published size of yargs from 345 kB down to 264.9 kB. I'm comfortable making this trade off, given that (if it introduces any issues) we can push users towards ESM (which is not minified).