### PR TITLE
test(deno): add example of parseAsync behavior

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -2,10 +2,6 @@
 import denoPlatformShim from './lib/platform-shims/deno.ts';
 import {YargsFactory} from './build/lib/yargs-factory.js';
 
-const WrappedYargs = YargsFactory(denoPlatformShim);
-
-function Yargs(args?: string[]) {
-  return WrappedYargs(args);
-}
+const Yargs = YargsFactory(denoPlatformShim);
 
 export default Yargs;

--- a/test/deno/yargs.test.ts
+++ b/test/deno/yargs.test.ts
@@ -53,3 +53,20 @@ Deno.test('hierarchy of commands', async () => {
   yargs().command(commands).parse('a c 10 5', context);
   assertEquals(context.output.value, 15);
 });
+
+Deno.test('parseAsync()', async () => {
+  const err: Error | null = null;
+  const argvPromise = yargs()
+    .middleware([
+      async (argv: Arguments) => {
+        await new Promise(resolve => {
+          setTimeout(resolve, 10);
+        });
+        argv.foo *= 2;
+      },
+    ])
+    .parseAsync('--foo 33');
+  assertEquals(typeof argvPromise.then, 'function');
+  const argv = (await argvPromise) as Arguments;
+  assertEquals(argv.foo, 66);
+});


### PR DESCRIPTION
Update deno entrypoint, and add test demonstrating `parseAsync()`.