### PR TITLE
fix: completion script name clashing on bash

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -5,7 +5,7 @@ export const completionShTemplate = `###-begin-{{app_name}}-completions-###
 # Installation: {{app_path}} {{completion_command}} >> ~/.bashrc
 #    or {{app_path}} {{completion_command}} >> ~/.bash_profile on OSX.
 #
-_yargs_completions()
+_{{app_name}}_yargs_completions()
 {
     local cur_word args type_list
 
@@ -24,7 +24,7 @@ _yargs_completions()
 
     return 0
 }
-complete -o default -F _yargs_completions {{app_name}}
+complete -o default -F _{{app_name}}_yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###
 `;
 


### PR DESCRIPTION
fix https://github.com/yargs/yargs/issues/874