### PR TITLE
fix(coerce): options using coerce now displayed in help

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -368,7 +368,7 @@ export class YargsInstance {
     // This noop tells yargs-parser about the existence of the option
     // represented by "keys", so that it can apply camel case expansion
     // if needed:
-    this.alias(keys, keys);
+    this.#options.key[keys] = true;
     this.#globalMiddleware.addCoerceMiddleware(
       (
         argv: Arguments,

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2176,6 +2176,25 @@ describe('yargs dsl tests', () => {
         yargs().coerce('c');
       }, /coerce callback must be provided/);
     });
+
+    // Refs: https://github.com/yargs/yargs/issues/1909
+    it('shows coerced option in help', async () => {
+      const help = await yargs()
+        .option('option1', {
+          describe: 'option1 description',
+          type: 'string',
+          demandOption: true,
+        })
+        .option('option2', {
+          describe: 'option2 description',
+          type: 'string',
+          demandOption: true,
+        })
+        .coerce('option2', () => undefined)
+        .getHelp();
+      console.info(help);
+      help.should.match(/option2 description/);
+    });
   });
 
   describe('stop parsing', () => {


### PR DESCRIPTION
The trick we were using of .alias("foo", "foo") to "tell" yargs-parser about a key
using coerce has a bug such that help output is broken. We can instead use
.key (https://github.com/yargs/yargs-parser/blob/master/lib/yargs-parser.ts#L191) which
is designed for exactly our purposes (telling yargs-parser a key exists, without
setting attributes such as description).

Fixes #1909