### PR TITLE
fix(builder): apply default builder for showHelp/getHelp

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -779,6 +779,13 @@ export class YargsInstance {
           });
         }
       }
+      // Ensure top level options/positionals have been configured:
+      const builderResponse = this.#command.runDefaultBuilderOn(this);
+      if (isPromise(builderResponse)) {
+        return builderResponse.then(() => {
+          return this.#usage.help();
+        });
+      }
     }
     return Promise.resolve(this.#usage.help());
   }
@@ -1257,6 +1264,14 @@ export class YargsInstance {
           });
           return this;
         }
+      }
+      // Ensure top level options/positionals have been configured:
+      const builderResponse = this.#command.runDefaultBuilderOn(this);
+      if (isPromise(builderResponse)) {
+        builderResponse.then(() => {
+          this.#usage.showHelp(level);
+        });
+        return this;
       }
     }
     this.#usage.showHelp(level);
@@ -2044,11 +2059,6 @@ export class YargsInstance {
           !!calledFromCommand,
           false
         );
-      } else if (!calledFromCommand && helpOnly) {
-        // TODO(bcoe): what if the default builder is async?
-        // TODO(bcoe): add better comments for runDefaultBuilderOn, why
-        // are we doing this?
-        this.#command.runDefaultBuilderOn(this);
       }
 
       // we must run completions first, a user might
@@ -2083,8 +2093,6 @@ export class YargsInstance {
         if (helpOptSet) {
           if (this.#exitProcess) setBlocking(true);
           skipValidation = true;
-          // TODO: add appropriate comment.
-          if (!calledFromCommand) this.#command.runDefaultBuilderOn(this);
           this.showHelp('log');
           this.exit(0);
         } else if (versionOptSet) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yargs",
-  "version": "17.0.0-candidate.10",
+  "version": "17.0.0-candidate.12",
   "description": "yargs the modern, pirate-themed, successor to optimist.",
   "main": "./index.cjs",
   "exports": {

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2192,7 +2192,6 @@ describe('yargs dsl tests', () => {
         })
         .coerce('option2', () => undefined)
         .getHelp();
-      console.info(help);
       help.should.match(/option2 description/);
     });
   });


### PR DESCRIPTION
The builder for default commands was not being properly applied when `.showHelp()` and `.getHelp()` were used.

Fixes #1912