### PR TITLE
fix(builder): nested builder is now awaited

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -307,7 +307,9 @@ export class CommandInstance {
     parentCommands: string[],
     commandIndex: number,
     helpOnly: boolean
-  ): {aliases: Dictionary<string[]>; innerArgv: Arguments} {
+  ):
+    | {aliases: Dictionary<string[]>; innerArgv: Arguments}
+    | Promise<{aliases: Dictionary<string[]>; innerArgv: Arguments}> {
     // A null command indicates we are running the default command,
     // if this is the case, we should show the root usage instructions
     // rather than the usage instructions for the nested default command:
@@ -334,10 +336,19 @@ export class CommandInstance {
         commandIndex,
         helpOnly
       );
-    return {
-      aliases: (innerYargs.parsed as DetailedArguments).aliases,
-      innerArgv: innerArgv as Arguments,
-    };
+    if (isPromise(innerArgv)) {
+      return innerArgv.then(argv => {
+        return {
+          aliases: (innerYargs.parsed as DetailedArguments).aliases,
+          innerArgv: argv,
+        };
+      });
+    } else {
+      return {
+        aliases: (innerYargs.parsed as DetailedArguments).aliases,
+        innerArgv: innerArgv,
+      };
+    }
   }
   private shouldUpdateUsage(yargs: YargsInstance) {
     return (

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1032,11 +1032,7 @@ export class YargsInstance {
     );
     this[kFreeze](); // Push current state of parser onto stack.
     if (typeof args === 'undefined') {
-      const argv = this[kRunYargsParserAndExecuteCommands](this.#processArgs);
-      const tmpParsed = this.parsed;
-      this[kUnfreeze](); // Pop the stack.
-      this.parsed = tmpParsed;
-      return argv;
+      args = this.#processArgs;
     }
 
     // a context object can optionally be provided, this allows
@@ -1063,6 +1059,7 @@ export class YargsInstance {
       args,
       !!shortCircuit
     );
+    const tmpParsed = this.parsed;
     this.#completion!.setParsed(this.parsed as DetailedArguments);
     if (isPromise(parsed)) {
       return parsed
@@ -1082,10 +1079,12 @@ export class YargsInstance {
         })
         .finally(() => {
           this[kUnfreeze](); // Pop the stack.
+          this.parsed = tmpParsed;
         });
     } else {
       if (this.#parseFn) this.#parseFn(this.#exitError, parsed, this.#output);
       this[kUnfreeze](); // Pop the stack.
+      this.parsed = tmpParsed;
     }
     return parsed;
   }
@@ -1983,7 +1982,6 @@ export class YargsInstance {
       const handlerKeys = this.#command.getCommands();
       const requestCompletions = this.#completion!.completionKey in argv;
       const skipRecommendation = helpOptSet || requestCompletions || helpOnly;
-
       if (argv._.length) {
         if (handlerKeys.length) {
           let firstUnknownCommand;

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -596,7 +596,6 @@ describe('usage tests', () => {
             // ignore the error, we only test the output here
           }
         });
-        console.info(r);
         r.errors
           .join('\n')
           .split(/\n+/)


### PR DESCRIPTION
Addresses two bugs with async builders:

1. if no arguments were provided to `.parse()`, results were not being awaited before unfreezing yargs instance.
2. `runCommand` was not awaiting async builders before returning results.

Fixes #1917 