### PR TITLE
refactor: small simplifications 2

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -336,19 +336,16 @@ export class CommandInstance {
         commandIndex,
         helpOnly
       );
-    if (isPromise(innerArgv)) {
-      return innerArgv.then(argv => {
-        return {
+
+    return isPromise(innerArgv)
+      ? innerArgv.then(argv => ({
           aliases: (innerYargs.parsed as DetailedArguments).aliases,
           innerArgv: argv,
+        }))
+      : {
+          aliases: (innerYargs.parsed as DetailedArguments).aliases,
+          innerArgv: innerArgv,
         };
-      });
-    } else {
-      return {
-        aliases: (innerYargs.parsed as DetailedArguments).aliases,
-        innerArgv: innerArgv,
-      };
-    }
   }
   private shouldUpdateUsage(yargs: YargsInstance) {
     return (
@@ -428,11 +425,9 @@ export class CommandInstance {
       innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false);
       innerArgv = maybeAsyncResult<Arguments>(innerArgv, result => {
         const handlerResult = commandHandler.handler(result as Arguments);
-        if (isPromise(handlerResult)) {
-          return handlerResult.then(() => result);
-        } else {
-          return result;
-        }
+        return isPromise(handlerResult)
+          ? handlerResult.then(() => result)
+          : result;
       });
 
       if (!isDefaultCommand) {
@@ -602,7 +597,7 @@ export class CommandInstance {
       });
 
       Object.keys(parsed.argv).forEach(key => {
-        if (positionalKeys.indexOf(key) !== -1) {
+        if (~positionalKeys.indexOf(key)) {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -415,9 +415,8 @@ export class CommandInstance {
       yargs.getInternalMethods().setHasOutput();
       // to simplify the parsing of positionals in commands,
       // we temporarily populate '--' rather than _, with arguments
-      const populateDoubleDash = !!yargs.getOptions().configuration[
-        'populate--'
-      ];
+      const populateDoubleDash =
+        !!yargs.getOptions().configuration['populate--'];
       yargs
         .getInternalMethods()
         .postProcess(innerArgv, populateDoubleDash, false, false);

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -596,7 +596,7 @@ export class CommandInstance {
       });
 
       Object.keys(parsed.argv).forEach(key => {
-        if (~positionalKeys.indexOf(key)) {
+        if (positionalKeys.includes(key)) {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -8,7 +8,7 @@ import {YargsInstance} from './yargs-factory.js';
 import {Arguments, DetailedArguments} from './typings/yargs-parser-types.js';
 
 // add bash completions to your
-//  yargs-powered applications.
+// yargs-powered applications.
 
 type CompletionCallback = (
   err: Error | null,
@@ -240,7 +240,7 @@ export class Completion implements CompletionInstance {
       : templates.completionShTemplate;
     const name = this.shim.path.basename($0);
 
-    // add ./to applications not yet installed as bin.
+    // add ./ to applications not yet installed as bin.
     if ($0.match(/\.js$/)) $0 = `./${$0}`;
 
     script = script.replace(/{{app_name}}/g, name);
@@ -249,8 +249,8 @@ export class Completion implements CompletionInstance {
   }
 
   // register a function to perform your own custom
-  // completions., this function can be either
-  // synchrnous or asynchronous.
+  // completions. this function can be either
+  // synchronous or asynchronous.
   registerFunction(fn: CompletionFunction) {
     this.customCompletionFunction = fn;
   }

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -77,8 +77,9 @@ export class Completion implements CompletionInstance {
     args: string[],
     current: string
   ) {
-    const parentCommands = this.yargs.getInternalMethods().getContext()
-      .commands;
+    const parentCommands = this.yargs
+      .getInternalMethods()
+      .getContext().commands;
     if (
       !current.match(/^-/) &&
       parentCommands[parentCommands.length - 1] !== current

--- a/lib/typings/yargs-parser-types.ts
+++ b/lib/typings/yargs-parser-types.ts
@@ -80,9 +80,7 @@ export declare type ArrayOption =
       integer?: boolean;
     };
 export declare type CoerceCallback = (arg: any) => any;
-export declare type ConfigCallback = (
-  configPath: string
-) =>
+export declare type ConfigCallback = (configPath: string) =>
   | {
       [key: string]: any;
     }

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -317,13 +317,13 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         const normalizedKeys: string[] = groups[groupName]
           .filter(filterHiddenOptions)
           .map(key => {
-            if (~aliasKeys.indexOf(key)) return key;
+            if (aliasKeys.includes(key)) return key;
             for (
               let i = 0, aliasKey;
               (aliasKey = aliasKeys[i]) !== undefined;
               i++
             ) {
-              if (~(options.alias[aliasKey] || []).indexOf(key))
+              if ((options.alias[aliasKey] || []).includes(key))
                 return aliasKey;
             }
             return key;
@@ -347,7 +347,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
                     // matches yargs-parser logic in which single-digits
                     // aliases declared with a boolean type are now valid
                     (/^[0-9]$/.test(sw)
-                      ? ~options.boolean.indexOf(key)
+                      ? options.boolean.includes(key)
                         ? '-'
                         : '--'
                       : sw.length > 1
@@ -401,15 +401,15 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         let desc = descriptions[key] || '';
         let type = null;
 
-        if (~desc.lastIndexOf(deferY18nLookupPrefix))
+        if (desc.includes(deferY18nLookupPrefix))
           desc = __(desc.substring(deferY18nLookupPrefix.length));
 
-        if (~options.boolean.indexOf(key)) type = `[${__('boolean')}]`;
-        if (~options.count.indexOf(key)) type = `[${__('count')}]`;
-        if (~options.string.indexOf(key)) type = `[${__('string')}]`;
-        if (~options.normalize.indexOf(key)) type = `[${__('string')}]`;
-        if (~options.array.indexOf(key)) type = `[${__('array')}]`;
-        if (~options.number.indexOf(key)) type = `[${__('number')}]`;
+        if (options.boolean.includes(key)) type = `[${__('boolean')}]`;
+        if (options.count.includes(key)) type = `[${__('count')}]`;
+        if (options.string.includes(key)) type = `[${__('string')}]`;
+        if (options.normalize.includes(key)) type = `[${__('string')}]`;
+        if (options.array.includes(key)) type = `[${__('array')}]`;
+        if (options.number.includes(key)) type = `[${__('number')}]`;
 
         const deprecatedExtra = (deprecated?: string | boolean) =>
           typeof deprecated === 'string'
@@ -542,12 +542,12 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         if (alias in demandedOptions)
           yargs.demandOption(key, demandedOptions[alias]);
         // type messages.
-        if (~options.boolean.indexOf(alias)) yargs.boolean(key);
-        if (~options.count.indexOf(alias)) yargs.count(key);
-        if (~options.string.indexOf(alias)) yargs.string(key);
-        if (~options.normalize.indexOf(alias)) yargs.normalize(key);
-        if (~options.array.indexOf(alias)) yargs.array(key);
-        if (~options.number.indexOf(alias)) yargs.number(key);
+        if (options.boolean.includes(alias)) yargs.boolean(key);
+        if (options.count.includes(alias)) yargs.count(key);
+        if (options.string.includes(alias)) yargs.string(key);
+        if (options.normalize.includes(alias)) yargs.normalize(key);
+        if (options.array.includes(alias)) yargs.array(key);
+        if (options.number.includes(alias)) yargs.number(key);
       });
     });
   }

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -334,41 +334,40 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
       .filter(({normalizedKeys}) => normalizedKeys.length > 0)
       .map(({groupName, normalizedKeys}) => {
         // actually generate the switches string --foo, -f, --bar.
-        const switches: Dictionary<
-          string | IndentedText
-        > = normalizedKeys.reduce((acc, key) => {
-          acc[key] = [key]
-            .concat(options.alias[key] || [])
-            .map(sw => {
-              // for the special positional group don't
-              // add '--' or '-' prefix.
-              if (groupName === self.getPositionalGroupName()) return sw;
-              else {
-                return (
-                  // matches yargs-parser logic in which single-digits
-                  // aliases declared with a boolean type are now valid
-                  (/^[0-9]$/.test(sw)
-                    ? ~options.boolean.indexOf(key)
-                      ? '-'
-                      : '--'
-                    : sw.length > 1
-                    ? '--'
-                    : '-') + sw
-                );
-              }
-            })
-            // place short switches first (see #1403)
-            .sort((sw1, sw2) =>
-              isLongSwitch(sw1) === isLongSwitch(sw2)
-                ? 0
-                : isLongSwitch(sw1)
-                ? 1
-                : -1
-            )
-            .join(', ');
+        const switches: Dictionary<string | IndentedText> =
+          normalizedKeys.reduce((acc, key) => {
+            acc[key] = [key]
+              .concat(options.alias[key] || [])
+              .map(sw => {
+                // for the special positional group don't
+                // add '--' or '-' prefix.
+                if (groupName === self.getPositionalGroupName()) return sw;
+                else {
+                  return (
+                    // matches yargs-parser logic in which single-digits
+                    // aliases declared with a boolean type are now valid
+                    (/^[0-9]$/.test(sw)
+                      ? ~options.boolean.indexOf(key)
+                        ? '-'
+                        : '--'
+                      : sw.length > 1
+                      ? '--'
+                      : '-') + sw
+                  );
+                }
+              })
+              // place short switches first (see #1403)
+              .sort((sw1, sw2) =>
+                isLongSwitch(sw1) === isLongSwitch(sw2)
+                  ? 0
+                  : isLongSwitch(sw1)
+                  ? 1
+                  : -1
+              )
+              .join(', ');
 
-          return acc;
-        }, {} as Dictionary<string>);
+            return acc;
+          }, {} as Dictionary<string>);
 
         return {groupName, normalizedKeys, switches};
       });

--- a/lib/utils/set-blocking.ts
+++ b/lib/utils/set-blocking.ts
@@ -9,7 +9,7 @@ export default function setBlocking(blocking: boolean) {
   // Deno and browser have no process object:
   if (typeof process === 'undefined') return;
   [process.stdout, process.stderr].forEach(_stream => {
-    const stream = (_stream as any) as WriteStreamWithHandle;
+    const stream = _stream as any as WriteStreamWithHandle;
     if (
       stream._handle &&
       stream.isTTY &&

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1442,7 +1442,7 @@ export class YargsInstance {
         return;
       const hint = this.#options[hintKey];
       if (Array.isArray(hint)) {
-        if (~hint.indexOf(optionKey)) hint.splice(hint.indexOf(optionKey), 1);
+        if (hint.includes(optionKey)) hint.splice(hint.indexOf(optionKey), 1);
       } else if (typeof hint === 'object') {
         delete (hint as Dictionary)[optionKey];
       }
@@ -1966,7 +1966,7 @@ export class YargsInstance {
           .concat(aliases[this.#helpOpt] || [])
           .filter(k => k.length > 1);
         // check if help should trigger and strip it from _.
-        if (~helpCmds.indexOf('' + argv._[argv._.length - 1])) {
+        if (helpCmds.includes('' + argv._[argv._.length - 1])) {
           argv._.pop();
           helpOptSet = true;
         }
@@ -1980,7 +1980,7 @@ export class YargsInstance {
           let firstUnknownCommand;
           for (let i = commandIndex || 0, cmd; argv._[i] !== undefined; i++) {
             cmd = String(argv._[i]);
-            if (~handlerKeys.indexOf(cmd) && cmd !== this.#completionCommand) {
+            if (handlerKeys.includes(cmd) && cmd !== this.#completionCommand) {
               // commands are executed using a recursive algorithm that executes
               // the deepest command first; we keep track of the position in the
               // argv._ array that is currently being executed.
@@ -2026,7 +2026,7 @@ export class YargsInstance {
         // generate a completion script for adding to ~/.bashrc.
         if (
           this.#completionCommand &&
-          ~argv._.indexOf(this.#completionCommand) &&
+          argv._.includes(this.#completionCommand) &&
           !requestCompletions
         ) {
           if (this.#exitProcess) setBlocking(true);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -547,9 +547,8 @@ export class YargsInstance {
     if (typeof value === 'function') {
       assertSingleKey(key, this.#shim);
       if (!this.#options.defaultDescription[key])
-        this.#options.defaultDescription[key] = this.#usage.functionDescription(
-          value
-        );
+        this.#options.defaultDescription[key] =
+          this.#usage.functionDescription(value);
       value = value.call();
     }
     this[kPopulateParserHintSingleValueDictionary]<'default'>(
@@ -1165,9 +1164,8 @@ export class YargsInstance {
     });
 
     // copy over any settings that can be inferred from the command string.
-    const fullCommand = this.#context.fullCommands[
-      this.#context.fullCommands.length - 1
-    ];
+    const fullCommand =
+      this.#context.fullCommands[this.#context.fullCommands.length - 1];
     const parseOptions = fullCommand
       ? this.#command.cmdToParseOptions(fullCommand)
       : {
@@ -1725,9 +1723,8 @@ export class YargsInstance {
       postProcess: this[kPostProcess].bind(this),
       reset: this[kReset].bind(this),
       runValidation: this[kRunValidation].bind(this),
-      runYargsParserAndExecuteCommands: this[
-        kRunYargsParserAndExecuteCommands
-      ].bind(this),
+      runYargsParserAndExecuteCommands:
+        this[kRunYargsParserAndExecuteCommands].bind(this),
       setHasOutput: this[kSetHasOutput].bind(this),
     };
   }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1094,11 +1094,9 @@ export class YargsInstance {
     _parseFn?: ParseCallback
   ): Promise<Arguments> {
     const maybePromise = this.parse(args, shortCircuit, _parseFn);
-    if (!isPromise(maybePromise)) {
-      return Promise.resolve(maybePromise);
-    } else {
-      return maybePromise;
-    }
+    return !isPromise(maybePromise)
+      ? Promise.resolve(maybePromise)
+      : maybePromise;
   }
   parseSync(
     args?: string | string[],
@@ -1789,10 +1787,8 @@ export class YargsInstance {
   [kReset](aliases: Aliases = {}): YargsInstance {
     this.#options = this.#options || ({} as Options);
     const tmpOptions = {} as Options;
-    tmpOptions.local = this.#options.local ? this.#options.local : [];
-    tmpOptions.configObjects = this.#options.configObjects
-      ? this.#options.configObjects
-      : [];
+    tmpOptions.local = this.#options.local || [];
+    tmpOptions.configObjects = this.#options.configObjects || [];
 
     // if a key has been explicitly set as local,
     // we should reset it before passing options to command.
@@ -2109,7 +2105,7 @@ export class YargsInstance {
         );
       }
 
-      // If the help or version options where used and exitProcess is false,
+      // If the help or version options were used and exitProcess is false,
       // or if explicitly skipped, we won't run validations.
       if (!skipValidation) {
         if (parsed.error) throw new YError(parsed.error.message);
@@ -2157,8 +2153,6 @@ export class YargsInstance {
     parseErrors: Error | null,
     isDefaultCommand?: boolean
   ): (argv: Arguments) => void {
-    aliases = {...aliases};
-    positionalMap = {...positionalMap};
     const demandedOptions = {...this.getDemandedOptions()};
     return (argv: Arguments) => {
       if (parseErrors) throw new YError(parseErrors.message);

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1813,7 +1813,7 @@ describe('Command', () => {
   });
 
   // see: https://github.com/yargs/yargs/issues/853
-  it('should not execute command if it is proceeded by another positional argument', () => {
+  it('should not execute command if it is preceded by another positional argument', () => {
     let commandCalled = false;
     yargs()
       .command('foo', 'foo command', noop, () => {

--- a/test/helpers/utils.cjs
+++ b/test/helpers/utils.cjs
@@ -57,13 +57,15 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
     try {
       result = f();
       if (typeof result.then === 'function') {
-        return result.then((r) => {
-          reset();
-          return done();
-        }).catch(() => {
-          reset();
-          return done();
-        });
+        return result
+          .then(() => {
+            reset();
+            return done();
+          })
+          .catch(() => {
+            reset();
+            return done();
+          });
       } else {
         reset();
       }

--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -509,10 +509,7 @@ describe('middleware', () => {
               }, 100);
             });
           }, true)
-          .check(argv => {
-            if (argv.foo > 100) return true;
-            else return false;
-          })
+          .check(argv => argv.foo > 100)
           .parse();
         const argv = await argvEventual;
         argv.foo.should.equal(200);
@@ -534,10 +531,7 @@ describe('middleware', () => {
               }, 100);
             });
           }, true)
-          .check(argv => {
-            if (argv.foo > 100) return true;
-            else return false;
-          })
+          .check(argv => argv.foo > 100)
           .parse();
         const argv = await argvEventual;
         argv.foo.should.equal(200);
@@ -580,10 +574,7 @@ describe('middleware', () => {
           argv.foo = argv.foo * 2;
           argv.bar = 'hello';
         }, true)
-        .check(argv => {
-          if (argv.foo > 100) return true;
-          else return false;
-        })
+        .check(argv => argv.foo > 100)
         .parse();
       argv.foo.should.equal(200);
       argv.bar.should.equal('hello');
@@ -622,8 +613,7 @@ describe('middleware', () => {
           }, true)
           .check(async argv => {
             wait();
-            if (argv.foo < 200) return false;
-            else return true;
+            return argv.foo >= 200;
           })
           .parse();
         (!!argvPromise.then).should.equal(true);
@@ -638,8 +628,7 @@ describe('middleware', () => {
           }, true)
           .check(async argv => {
             wait();
-            if (argv.foo < 200) return false;
-            else return true;
+            return argv.foo >= 200;
           })
           .parse();
         (!!argvPromise.then).should.equal(true);
@@ -656,8 +645,7 @@ describe('middleware', () => {
               yargs.check(async argv => {
                 wait();
                 output += 'first';
-                if (argv.foo < 200) return false;
-                else return true;
+                return argv.foo >= 200;
               });
             },
             async argv => {
@@ -680,8 +668,7 @@ describe('middleware', () => {
               yargs.check(async argv => {
                 wait();
                 output += 'second';
-                if (argv.foo < 200) return false;
-                else return true;
+                return argv.foo >= 200;
               });
             },
             async argv => {
@@ -733,8 +720,7 @@ describe('middleware', () => {
                 yargs.check(async argv => {
                   wait();
                   output += 'first';
-                  if (argv.foo < 200) return false;
-                  else return true;
+                  return argv.foo >= 200;
                 });
               },
               async argv => {
@@ -759,8 +745,7 @@ describe('middleware', () => {
                 yargs.check(async argv => {
                   wait();
                   output += 'second';
-                  if (argv.foo < 200) return false;
-                  else return true;
+                  return argv.foo >= 200;
                 });
               },
               async argv => {
@@ -786,7 +771,7 @@ describe('middleware', () => {
         output.should.equal('firstsecond');
       });
     });
-    it('applies alliases prior to calling check', async () => {
+    it('applies aliases prior to calling check', async () => {
       const argv = await yargs('--f 99')
         .alias('foo', 'f')
         .check(async argv => {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -2524,7 +2524,7 @@ describe('usage tests', () => {
         ]);
     });
 
-    it('allows a builder to add more than one usage with mutiple usage calls', () => {
+    it('allows a builder to add more than one usage with multiple usage calls', () => {
       const r = checkUsage(() =>
         yargs('upload --help')
           .command(

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2381,9 +2381,7 @@ describe('yargs dsl tests', () => {
       const argv = yargs('cmd batman')
         .command('cmd <hero>', 'a command', yargs => {
           yargs.positional('hero', {
-            coerce: function (arg) {
-              return arg.toUpperCase();
-            },
+            coerce: arg => arg.toUpperCase(),
             alias: 'do-gooder',
           });
         })

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -96,7 +96,7 @@ describe('yargs dsl tests', () => {
     argv.cat.should.eql(33);
   });
 
-  it('do not populates argv with placeholder keys for unset options', () => {
+  it('does not populate argv with placeholder keys for unset options', () => {
     const argv = yargs([]).option('cool', {}).parse();
 
     Object.keys(argv).should.not.include('cool');
@@ -1389,7 +1389,7 @@ describe('yargs dsl tests', () => {
         }).to.throw(YError);
       });
 
-      it('handles aboslute paths', () => {
+      it('handles absolute paths', () => {
         const absolutePath = path.join(
           process.cwd(),
           'test',

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2610,8 +2610,12 @@ describe('yargs dsl tests', () => {
 
   describe('parsing --value as a value in -f=--value and --bar=--value', () => {
     it('should work in the general case', () => {
-      const argv = yargs(['-f=--item1', 'item2', '--bar=--item3', 'item4'])
-        .argv;
+      const argv = yargs([
+        '-f=--item1',
+        'item2',
+        '--bar=--item3',
+        'item4',
+      ]).argv;
       argv.f.should.eql('--item1');
       argv.bar.should.eql('--item3');
       argv._.should.eql(['item2', 'item4']);


### PR DESCRIPTION
## Changes

- Remove shallow copy logic in `lib/yargs-factory.js`.
- Use ternary and || operator where practical.
- Update comments.
- Lint.

I'm still new at this, so let me know if there is anything I can do better.