### PR TITLE
fix: conflicts and strip-dashed

### DIFF
--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -190,9 +190,9 @@ describe('validation tests', () => {
         .parse();
     });
 
-    // strip-dash breaks conflicting
+    // strip-dashed breaks conflicting
     // https://github.com/yargs/yargs/issues/1952
-    it('fails if conflicting arguments are provided, and strip-dash is enabled', () => {
+    it('fails if conflicting arguments are provided, and strip-dashed is enabled', () => {
       yargs()
         .option('foo-foo', {
           description: 'a foo-foo',

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -190,6 +190,28 @@ describe('validation tests', () => {
         .parse();
     });
 
+    // strip-dash breaks conflicting
+    // https://github.com/yargs/yargs/issues/1952
+    it('fails if conflicting arguments are provided, and strip-dash is enabled', () => {
+      yargs()
+        .option('foo-foo', {
+          description: 'a foo-foo',
+          type: 'string',
+        })
+        .option('bar-bar', {
+          description: 'a bar-bar',
+          type: 'string',
+        })
+        .conflicts({'foo-foo': 'bar-bar'})
+        .parserConfiguration({'strip-dashed': true})
+        .parse('--foo-foo a --bar-bar b', (error, argv, output) => {
+          expect(error).to.not.equal(null);
+          error.message.should.match(
+            /Arguments foo-foo and bar-bar are mutually exclusive/
+          );
+        });
+    });
+
     it('should not fail if no conflicting arguments are provided', () => {
       yargs(['-b', '-c'])
         .conflicts('f', ['b', 'c'])


### PR DESCRIPTION
# strip-dashed and conflicting (#1952)

When `strip-dashed` is true, the kebab case arguments are removed from argv.
When looking for conflicts, the result is a false negative. The conflicts are in kebab case while the argv arguments are in camel case, so the conflicts logic will never match the conflicting arguments.

This false negative doesn't happen when `strip-dashed` is false, because argv has both kebab/camel cases.

This problem doesn't happen when camel-case-expansion is false. (In that scenario, both argv/conflicts use kebab case.)

## Solution

I'm not sure where changes should take place.

One solution might be to convert the `conflicting` dictionary's keys/values to camel case, if strip-dashed is true. The problem is, I don't think the parserConfig is accessible in validation. (I believe that `yargs.getInternalMethods().getParserConfiguration()` will always return `{}` in validation, because `#parserConfig` won't be set in yargs-factory yet.)

I will keep thinking/working on this, but if you have any ideas/solutions I would definitely appreciate the help.

## Example code

```js
const yargs = require("./yargs/index.cjs");

// normal

const normal = () => yargs()
.option('foo-foo', {
  description: 'foo-foo',
  type: 'string',
  conflicts: 'bar-bar',
})
.option('bar-bar', {
  description: 'bar-bar',
  type: 'string',
});

// buggy (false negative)

const stripDashed = () => normal()
  .parserConfiguration({ 'strip-dashed': true, });

// test

const argv = '--foo-foo a --bar-bar b';

const buggyParser = stripDashed();
buggyParser.parse(argv, (error, argv, output) => {
  // error is null
});

const normalParser = normal();
normalParser.parse(argv, (error, argv, output) => {
  // error
});
```

## validation.ts > conflicts

### With strip-dashed enabled

_Conflicting is in kebab case, argv is in camel. Conflicts func can't match keys._

conflicting
```js
{ 'foo-foo': [ 'bar-bar' ] }
```

argv
```js
{ _: [], fooFoo: 'a', barBar: 'b', '$0': 'yargs-test.js' }
```

### With strip-dashed disabled

_Conflicting is in kebab case, argv is in both kebab / camel. Conflicts func can match keys_

conflicting
```js
{ 'foo-foo': [ 'bar-bar' ] }
```

argv
```js
{
  _: [],
  'foo-foo': 'a',
  fooFoo: 'a',
  'bar-bar': 'b',
  barBar: 'b',
  '$0': 'yargs-test.js'
}
```