### PR TITLE
fix: Generate sourcemap for the minified file build/index.cjs

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -3,6 +3,7 @@ const ts = require('@wessberg/rollup-plugin-ts');
 const {terser} = require('rollup-plugin-terser');
 
 const output = {
+  sourcemap: true,
   format: 'cjs',
   file: './build/index.cjs',
   exports: 'default',


### PR DESCRIPTION
This PR includes a single line change to the rollup configuration, to enable the sourcemap file generation.
The file generated is going to the placed by rollup into the `build/` subdirectory and so it should be already become part of the assets released on npm.

Including it helps to make sure that dependents of the yargs package will get more readable errors stacktraces when the error triggered is coming from one of the minified node modules. 

<details>
<summary>Error stacktrace without sourcemap</summary>

```
Error:
    at someInternalFunctionFromMyOwnProject (...)
    at coerce (...)
    at n.<computed> (.../yargs/build/index.cjs:1:28508)
    at j (.../yargs/build/index.cjs:1:4816)
    at .../yargs/build/index.cjs:1:28483
    at .../yargs/build/index.cjs:1:4674
    at Array.reduce (<anonymous>)
    at C (.../yargs/build/index.cjs:1:4521)
    at _.applyMiddlewareAndGetResult (.../yargs/build/index.cjs:1:8609)
    at _.runCommand (.../yargs/build/index.cjs:1:7127)
```
</details>

<details>
<summary>Error stacktrace with sourcemap</summary>

```
Error:
    at someInternalFunctionFromMyOwnProject (...)
    at coerce (...)
    at getResult (.../yargs/lib/yargs-factory.ts:383:20)
    at maybeAsyncResult (.../yargs/lib/utils/maybe-async-result.ts:17:44)
    at middleware (.../yargs/lib/yargs-factory.ts:378:16)
    at reduce (.../yargs/lib/middleware.ts:107:24)
    at Array.reduce (<anonymous>)
    at applyMiddleware (.../yargs/lib/middleware.ts:89:22)
    at _.applyMiddlewareAndGetResult (.../yargs/lib/command.ts:398:17)
    at _.runCommand (.../yargs/lib/command.ts:240:19)
```
</details>