### PR TITLE
fix: strict should fail unknown arguments

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -182,17 +182,18 @@ export function validation(
     // https://github.com/yargs/yargs/issues/1861
     if (checkPositionals) {
       // Check for non-option args that are not in currentContext.commands
-      // If yargs.demand called, tolerate non-option args within min/max range
+      // Take into account expected args from commands and yargs.demand(number)
       const demandedCommands = yargs.getDemandedCommands();
       const maxNonOptDemanded = demandedCommands._?.max || 0;
-      if (maxNonOptDemanded < argv._.length) {
-        argv._.slice(maxNonOptDemanded).forEach(nonOptArg => {
-          nonOptArg = String(nonOptArg);
+      const expected = currentContext.commands.length + maxNonOptDemanded;
+      if (expected < argv._.length) {
+        argv._.slice(expected).forEach(key => {
+          key = String(key);
           if (
-            !currentContext.commands.includes(nonOptArg) &&
-            !unknown.includes(nonOptArg)
+            !currentContext.commands.includes(key) &&
+            !unknown.includes(key)
           ) {
-            unknown.push(nonOptArg);
+            unknown.push(key);
           }
         });
       }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -154,7 +154,7 @@ export function validation(
 
     Object.keys(argv).forEach(key => {
       if (
-        specialKeys.indexOf(key) === -1 &&
+        !specialKeys.includes(key) &&
         !Object.prototype.hasOwnProperty.call(positionalMap, key) &&
         !Object.prototype.hasOwnProperty.call(
           yargs.getInternalMethods().getParseContext(),
@@ -173,13 +173,32 @@ export function validation(
         isDefaultCommand)
     ) {
       argv._.slice(currentContext.commands.length).forEach(key => {
-        if (commandKeys.indexOf('' + key) === -1) {
+        if (!commandKeys.includes('' + key)) {
           unknown.push('' + key);
         }
       });
     }
 
-    if (unknown.length > 0) {
+    // https://github.com/yargs/yargs/issues/1861
+    if (checkPositionals) {
+      // Check for non-option args that are not in currentContext.commands
+      // If yargs.demand called, tolerate non-option args within min/max range
+      const demandedCommands = yargs.getDemandedCommands();
+      const maxNonOptDemanded = demandedCommands._?.max || 0;
+      if (maxNonOptDemanded < argv._.length) {
+        argv._.slice(maxNonOptDemanded).forEach(nonOptArg => {
+          nonOptArg = String(nonOptArg);
+          if (
+            !currentContext.commands.includes(nonOptArg) &&
+            !unknown.includes(nonOptArg)
+          ) {
+            unknown.push(nonOptArg);
+          }
+        });
+      }
+    }
+
+    if (unknown.length) {
       usage.fail(
         __n(
           'Unknown argument: %s',
@@ -201,7 +220,7 @@ export function validation(
 
     if (currentContext.commands.length > 0 || commandKeys.length > 0) {
       argv._.slice(currentContext.commands.length).forEach(key => {
-        if (commandKeys.indexOf('' + key) === -1) {
+        if (!commandKeys.includes('' + key)) {
           unknown.push('' + key);
         }
       });

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -330,6 +330,29 @@ describe('validation tests', () => {
       expect.fail('no parsing failure');
     });
 
+    // addresses: https://github.com/yargs/yargs/issues/1861
+    it('fails in strict mode when no commands defined but command is passed', done => {
+      yargs
+        .strict()
+        .fail(msg => {
+          msg.should.equal('Unknown argument: foo');
+          done();
+        })
+        .parse('foo');
+      expect.fail('no parsing failure');
+    });
+
+    it('fails because of undefined command and not because of argument after --', done => {
+      yargs
+        .strict()
+        .fail(msg => {
+          msg.should.equal('Unknown argument: foo');
+          done();
+        })
+        .parse('foo -- hello');
+      expect.fail('no parsing failure');
+    });
+
     it('fails in strict mode with invalid command', done => {
       yargs(['koala'])
         .command('wombat', 'wombat burrows')
@@ -916,7 +939,7 @@ describe('validation tests', () => {
     });
 
     it('does not fail for hidden options', () => {
-      const args = yargs('--foo hey')
+      const args = yargs('--foo')
         .strict()
         .option('foo', {boolean: true, describe: false})
         .fail(msg => {
@@ -926,8 +949,18 @@ describe('validation tests', () => {
       args.foo.should.equal(true);
     });
 
+    it('does not fail for hidden options but does for unknown arguments', () => {
+      const args = yargs('--foo hey')
+        .strict()
+        .option('foo', {boolean: true, describe: false})
+        .fail(msg => {
+          msg.should.equal('Unknown argument: hey');
+        })
+        .parse();
+    });
+
     it('does not fail if an alias is provided, rather than option itself', () => {
-      const args = yargs('--cat hey')
+      const args = yargs('--cat')
         .strict()
         .option('foo', {boolean: true, describe: false})
         .alias('foo', 'bar')


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1861

As always, let me know if I need to change/add/fix anything.

## Issue

This should fail:
```js
const argv = yargs.strict().parse('foo');
console.log(argv) // { _: [ 'foo' ], '$0': 'example.js' }
```

Neither `unknownArguments` nor `unknownCommands` catch extra args when `commandKeys.length` is 0.

## Fix

I added a block to check if there are any elements in `argv` that aren't in `currentContext.commands`. I made sure to tolerate args when `yargs.demand(number)`  is called, when the number of args falls within the min/max range.

This shouldn't fail:
```js
const argv = yargs.strict().demand(1).parse('foo');
console.log(argv) // { _: [ 'foo' ], '$0': 'example.js' }
```

## Note

I don't understand the `demand` logic well (as it's deprecated and not in the docs), so I'm not sure if the slice in [this line](https://github.com/yargs/yargs/pull/1977/files#diff-4dd83f100006aaa41a4fdf091876a4dd2eee068706221a21c9098ba7164b4e21R190) will always be correct:

I saw that a few other [places](https://github.com/yargs/yargs/blob/a87137143bb4ee33bbb76145d33c3322f8dce26f/lib/validation.ts#L175) do something similar.
