### PR TITLE
fix: coerce middleware should be applied once

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -224,29 +224,27 @@ export class CommandInstance {
       helpOnly,
       helpOrVersionSet
     );
-    if (isPromise(builderResult)) {
-      return builderResult.then(result => {
-        return this.applyMiddlewareAndGetResult(
+    return isPromise(builderResult)
+      ? builderResult.then(result =>
+          this.applyMiddlewareAndGetResult(
+            isDefaultCommand,
+            commandHandler,
+            result.innerArgv,
+            currentContext,
+            helpOnly,
+            result.aliases,
+            yargs
+          )
+        )
+      : this.applyMiddlewareAndGetResult(
           isDefaultCommand,
           commandHandler,
-          result.innerArgv,
+          builderResult.innerArgv,
           currentContext,
           helpOnly,
-          result.aliases,
+          builderResult.aliases,
           yargs
         );
-      });
-    } else {
-      return this.applyMiddlewareAndGetResult(
-        isDefaultCommand,
-        commandHandler,
-        builderResult.innerArgv,
-        currentContext,
-        helpOnly,
-        builderResult.aliases,
-        yargs
-      );
-    }
   }
   private applyBuilderUpdateUsageAndParse(
     isDefaultCommand: boolean,

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1156,11 +1156,10 @@ export class YargsInstance {
       'alias',
     ];
     opts = objFilter(opts, (k, v) => {
-      let accept = supportedOpts.indexOf(k) !== -1;
       // type can be one of string|number|boolean.
-      if (k === 'type' && ['string', 'number', 'boolean'].indexOf(v) === -1)
-        accept = false;
-      return accept;
+      if (k === 'type' && !['string', 'number', 'boolean'].includes(v))
+        return false;
+      return supportedOpts.includes(k);
     });
 
     // copy over any settings that can be inferred from the command string.

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1549,7 +1549,7 @@ describe('Command', () => {
       });
 
       // addresses https://github.com/yargs/yargs/issues/1966
-      it('should not be applied multiple times for nested commands', done => {
+      it('should not be applied multiple times for nested commands', () => {
         let coerceExecutionCount = 0;
 
         const argv = yargs('cmd1 cmd2 foo bar baz')
@@ -1575,7 +1575,6 @@ describe('Command', () => {
 
         argv.rest.should.equal('bar baz');
         coerceExecutionCount.should.equal(1);
-        return done();
       });
     });
 

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1547,6 +1547,30 @@ describe('Command', () => {
             return done();
           });
       });
+
+      // addresses https://github.com/yargs/yargs/issues/1966
+      it('should not be applied multiple times', done => {
+        yargs('rule add foo bar baz')
+          .command('rule', 'rule desc', yargs =>
+            yargs.command(
+              'add <name> <abc...>',
+              'add desc',
+              yargs =>
+                yargs.positional('abc', {
+                  type: 'string',
+                  coerce: arg => arg.join(' '),
+                }),
+              argv => {
+                argv.abc.should.equal('bar baz');
+                return done();
+              }
+            )
+          )
+          .fail(() => {
+            expect.fail();
+          })
+          .parse();
+      });
     });
 
     describe('defaults', () => {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1550,6 +1550,8 @@ describe('Command', () => {
 
       // addresses https://github.com/yargs/yargs/issues/1966
       it('should not be applied multiple times', done => {
+        let coerceExecutionCount = 0;
+
         yargs('rule add foo bar baz')
           .command('rule', 'rule desc', yargs =>
             yargs.command(
@@ -1558,10 +1560,17 @@ describe('Command', () => {
               yargs =>
                 yargs.positional('abc', {
                   type: 'string',
-                  coerce: arg => arg.join(' '),
+                  coerce: arg => {
+                    if (coerceExecutionCount) {
+                      throw Error('coerce applied multiple times');
+                    }
+                    coerceExecutionCount++;
+                    return arg.join(' ');
+                  },
                 }),
               argv => {
                 argv.abc.should.equal('bar baz');
+                coerceExecutionCount.should.equal(1);
                 return done();
               }
             )

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1552,13 +1552,11 @@ describe('Command', () => {
       it('should not be applied multiple times for nested commands', done => {
         let coerceExecutionCount = 0;
 
-        yargs('cmd1 cmd2 foo bar baz')
+        const argv = yargs('cmd1 cmd2 foo bar baz')
           .command('cmd1', 'cmd1 desc', yargs =>
-            yargs.command(
-              'cmd2 <positional1> <rest...>',
-              'cmd2 desc',
-              yargs =>
-                yargs.positional('rest', {
+            yargs.command('cmd2 <positional1> <rest...>', 'cmd2 desc', yargs =>
+              yargs
+                .positional('rest', {
                   type: 'string',
                   coerce: arg => {
                     if (coerceExecutionCount) {
@@ -1567,18 +1565,17 @@ describe('Command', () => {
                     coerceExecutionCount++;
                     return arg.join(' ');
                   },
-                }),
-              argv => {
-                argv.rest.should.equal('bar baz');
-                coerceExecutionCount.should.equal(1);
-                return done();
-              }
+                })
+                .fail(() => {
+                  expect.fail();
+                })
             )
           )
-          .fail(() => {
-            expect.fail();
-          })
           .parse();
+
+        argv.rest.should.equal('bar baz');
+        coerceExecutionCount.should.equal(1);
+        return done();
       });
     });
 

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1553,30 +1553,27 @@ describe('Command', () => {
         let coerceExecutionCount = 0;
 
         yargs('cmd1 cmd2 foo bar baz')
-          .command(
-            'cmd1',
-            'cmd1 desc',
-            yargs =>
-              yargs.command(
-                'cmd2 <positional1> <rest...>',
-                'cmd2 desc',
-                yargs =>
-                  yargs.positional('rest', {
-                    type: 'string',
-                    coerce: arg => {
-                      if (coerceExecutionCount) {
-                        throw Error('coerce applied multiple times');
-                      }
-                      coerceExecutionCount++;
-                      return arg.join(' ');
-                    },
-                  })
-              ),
-            argv => {
-              argv.abc.should.equal('bar baz');
-              coerceExecutionCount.should.equal(1);
-              return done();
-            }
+          .command('cmd1', 'cmd1 desc', yargs =>
+            yargs.command(
+              'cmd2 <positional1> <rest...>',
+              'cmd2 desc',
+              yargs =>
+                yargs.positional('rest', {
+                  type: 'string',
+                  coerce: arg => {
+                    if (coerceExecutionCount) {
+                      throw Error('coerce applied multiple times');
+                    }
+                    coerceExecutionCount++;
+                    return arg.join(' ');
+                  },
+                }),
+              argv => {
+                argv.rest.should.equal('bar baz');
+                coerceExecutionCount.should.equal(1);
+                return done();
+              }
+            )
           )
           .fail(() => {
             expect.fail();

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1549,31 +1549,34 @@ describe('Command', () => {
       });
 
       // addresses https://github.com/yargs/yargs/issues/1966
-      it('should not be applied multiple times', done => {
+      it('should not be applied multiple times for nested commands', done => {
         let coerceExecutionCount = 0;
 
-        yargs('rule add foo bar baz')
-          .command('rule', 'rule desc', yargs =>
-            yargs.command(
-              'add <name> <abc...>',
-              'add desc',
-              yargs =>
-                yargs.positional('abc', {
-                  type: 'string',
-                  coerce: arg => {
-                    if (coerceExecutionCount) {
-                      throw Error('coerce applied multiple times');
-                    }
-                    coerceExecutionCount++;
-                    return arg.join(' ');
-                  },
-                }),
-              argv => {
-                argv.abc.should.equal('bar baz');
-                coerceExecutionCount.should.equal(1);
-                return done();
-              }
-            )
+        yargs('cmd1 cmd2 foo bar baz')
+          .command(
+            'cmd1',
+            'cmd1 desc',
+            yargs =>
+              yargs.command(
+                'cmd2 <positional1> <rest...>',
+                'cmd2 desc',
+                yargs =>
+                  yargs.positional('rest', {
+                    type: 'string',
+                    coerce: arg => {
+                      if (coerceExecutionCount) {
+                        throw Error('coerce applied multiple times');
+                      }
+                      coerceExecutionCount++;
+                      return arg.join(' ');
+                    },
+                  })
+              ),
+            argv => {
+              argv.abc.should.equal('bar baz');
+              coerceExecutionCount.should.equal(1);
+              return done();
+            }
           )
           .fail(() => {
             expect.fail();


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1966 and https://github.com/yargs/yargs/issues/1802

## Debugging

I know that the coerce middleware is being applied twice.
I ran the below example. I logged the execution of the functions that use `applyMiddleware`, and I logged the type/value of the arg during coercion.

```js
const argv = yargs("rule add foo bar baz")
  .command("rule", "rule desc", (yargs) =>
    yargs.command("add <name> <abc...>", "add desc", (yargs) =>
      yargs.positional("abc", {
        type: "string",
        coerce: (arg) => console.log({ argType: typeof arg, arg }) || arg.join(" "),
      })
    )
  ).argv;
```

Logs look like this:
```
parse called
kRunYargsParserAndExecuteCommands called
runCommand called
parseAndUpdateUsage called
kRunYargsParserAndExecuteCommands called
runCommand called
parseAndUpdateUsage called
kRunYargsParserAndExecuteCommands called
pre-validation applyMiddleware called
{ argType: 'object', arg: [ 'bar', 'baz' ] }
post-validation applyMiddleware called
pre-validation applyMiddleware called
{ argType: 'string', arg: 'bar baz' }
```

The coerce middleware is only supposed to run before validation, but the pre-validation `applyMiddleware` gets called twice.

## Fix

### stack trace

```
get > parse > kRunYargsParserAndExecuteCommands > runCommand > applyMiddlewareAndGetResult > applyMiddleware
```
### The problem

`runCommand` gets called recursively, which means that the middleware gets applied for each nested command.

Coerce middleware mutates argv, and repeating that mutation is undesired and can easily break.
ie: `coerce: (arg) => arg.join()`

### The solution

I added two properties to the Middleware interface:

- mutates (bool): if the middleware mutates argv and should only be applied once.
- applied (bool): if the mutating middleware has already been applied once.

`mutates` defaults to false, but is set to true in `addCoerceMiddleware`.

I then check each middleware during `applyMiddleware`:

- If it mutates argv:
  - If it hasn't been applied, apply it and set `applied` to true.
  - If it mutates and has been applied, skip it.
- If it doesn't mutate argv:
  - handle the middleware like it normally would
  
 ### Feedback
 
If you have recommendations for a better pattern, or better names for the interface properties I added, let me know. I feel like they could definitely be named better.