### PR TITLE
fix: implies should not fail when implied key's value is 0, false or empty string

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -339,10 +339,10 @@ export function validation(
     } else if (val.match(/^--no-.+/)) {
       // check if key/value doesn't exist
       val = val.match(/^--no-(.+)/)[1];
-      val = !argv[val];
+      val = !Object.prototype.hasOwnProperty.call(argv, val);
     } else {
       // check if key/value exists
-      val = argv[val];
+      val = Object.prototype.hasOwnProperty.call(argv, val);
     }
     return val;
   }

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -102,39 +102,33 @@ describe('validation tests', () => {
     });
 
     it("doesn't fail if implied key exists with value 0", () => {
-      let failCalled = false;
       yargs('--foo --bar 0')
         .implies('foo', 'bar')
-        .fail(msg => {
-          failCalled = true;
+        .fail(() => {
+          expect.fail();
         })
         .parse();
-      failCalled.should.equal(false);
     });
 
     it("doesn't fail if implied key exists with value false", () => {
-      let failCalled = false;
       yargs('--foo --bar false')
         .implies('foo', 'bar')
-        .fail(msg => {
-          failCalled = true;
+        .fail(() => {
+          expect.fail();
         })
         .parse();
-      failCalled.should.equal(false);
     });
 
     it('doesn\'t fail if implied key (with "no" in the name) is set', () => {
-      let failCalled = false;
       const argv = yargs('--bar --noFoo')
         .implies({
           bar: 'noFoo', // --bar means --noFoo (or --no-foo with boolean-negation disabled) is required
           // note that this has nothing to do with --foo
         })
-        .fail(msg => {
-          failCalled = true;
+        .fail(() => {
+          expect.fail();
         })
         .parse();
-      failCalled.should.equal(false);
       expect(argv.bar).to.equal(true);
       expect(argv.noFoo).to.equal(true);
       expect(argv.foo).to.equal(undefined);
@@ -156,17 +150,15 @@ describe('validation tests', () => {
     });
 
     it('doesn\'t fail if implied key (with "no" in the name) that should not be given is not set', () => {
-      let failCalled = false;
       const argv = yargs('--bar')
         .implies({
           bar: '--no-noFoo', // --bar means --noFoo (or --no-foo with boolean-negation disabled) cannot be given
           // note that this has nothing to do with --foo
         })
-        .fail(msg => {
-          failCalled = true;
+        .fail(() => {
+          expect.fail();
         })
         .parse();
-      failCalled.should.equal(false);
       expect(argv.bar).to.equal(true);
       expect(argv.noFoo).to.equal(undefined);
       expect(argv.foo).to.equal(undefined);

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -101,6 +101,28 @@ describe('validation tests', () => {
       failCalled.should.equal(true);
     });
 
+    it("doesn't fail if implied key exists with value 0", () => {
+      let failCalled = false;
+      yargs('--foo --bar 0')
+        .implies('foo', 'bar')
+        .fail(msg => {
+          failCalled = true;
+        })
+        .parse();
+      failCalled.should.equal(false);
+    });
+
+    it("doesn't fail if implied key exists with value false", () => {
+      let failCalled = false;
+      yargs('--foo --bar false')
+        .implies('foo', 'bar')
+        .fail(msg => {
+          failCalled = true;
+        })
+        .parse();
+      failCalled.should.equal(false);
+    });
+
     it('doesn\'t fail if implied key (with "no" in the name) is set', () => {
       let failCalled = false;
       const argv = yargs('--bar --noFoo')


### PR DESCRIPTION
This is an attemps at fixing #1091 and #1203.

## The issue

The documentation for `implies` is:

> Given the key x is set, it is required that the key y is set.

But this check fails when the value of the key `y` is `0`, `false`, or empty string.

When `y` value is `false`, we might want `implies` to continue failing though. I'd like to have your input on that, and I will adjust that PR accordingly.

The issue came from `keyExists` which, instead of always returning a boolean, could returned the value of the key. That value is later on used like so:
```
if (key && !value) {
  implyFail.push(` ${origKey} -> ${origValue}`);
}
```
Thus, that `if` resolved to `true` when `value` was `0`, `false` or `""`.

## The fix

Having `keyExists` always returning a boolean seems more robust. I used `Object.hasOwnProperty` to check for presence of the key instead.

Let me know if you think that `keyExists` should still return `false` when the value of the key is `false`.

Thanks :)