### PR TITLE
fix: prevent version name collision

### DIFF
--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -41,7 +41,6 @@ export default {
   process: {
     argv: () => [],
     cwd: () => '',
-    // eslint-disable-next-line no-unused-vars
     emitWarning: (warning, name) => {},
     execPath: () => '',
     // exit is noop browser:

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -42,7 +42,7 @@ export default {
     argv: () => [],
     cwd: () => '',
     // eslint-disable-next-line no-unused-vars
-    emitWarning: (warning, name, code, ctor) => {},
+    emitWarning: (warning, name) => {},
     execPath: () => '',
     // exit is noop browser:
     exit: () => {},

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -41,6 +41,8 @@ export default {
   process: {
     argv: () => [],
     cwd: () => '',
+    // eslint-disable-next-line no-unused-vars
+    emitWarning: (warning, name, code, ctor) => {},
     execPath: () => '',
     // exit is noop browser:
     exit: () => {},

--- a/lib/platform-shims/cjs.ts
+++ b/lib/platform-shims/cjs.ts
@@ -26,7 +26,8 @@ export default {
   process: {
     argv: () => process.argv,
     cwd: process.cwd,
-    emitWarning: process.emitWarning,
+    emitWarning: (warning: string | Error, type?: string) =>
+      process.emitWarning(warning, type),
     execPath: () => process.execPath,
     exit: (code: number) => {
       // eslint-disable-next-line no-process-exit

--- a/lib/platform-shims/cjs.ts
+++ b/lib/platform-shims/cjs.ts
@@ -26,6 +26,7 @@ export default {
   process: {
     argv: () => process.argv,
     cwd: process.cwd,
+    emitWarning: process.emitWarning,
     execPath: () => process.execPath,
     exit: (code: number) => {
       // eslint-disable-next-line no-process-exit

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -82,12 +82,7 @@ export default {
   process: {
     argv: () => argv,
     cwd: () => cwd,
-    emitWarning: (
-      warning: string | Error,
-      name?: string,
-      cod?: string,
-      ctor?: Function
-    ) => {},
+    emitWarning: (warning: string | Error, type?: string) => {},
     execPath: () => {
       try {
         return Deno.execPath();

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -82,6 +82,12 @@ export default {
   process: {
     argv: () => argv,
     cwd: () => cwd,
+    emitWarning: (
+      warning: string | Error,
+      name?: string,
+      cod?: string,
+      ctor?: Function
+    ) => {},
     execPath: () => {
       try {
         return Deno.execPath();

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -45,6 +45,7 @@ export default {
   process: {
     argv: () => process.argv,
     cwd: process.cwd,
+    emitWarning: process.emitWarning,
     execPath: () => process.execPath,
     exit: process.exit,
     nextTick: process.nextTick,

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -3,7 +3,7 @@
 import { notStrictEqual, strictEqual } from 'assert'
 import cliui from 'cliui'
 import escalade from 'escalade/sync'
-import { format, inspect } from 'util'
+import { inspect } from 'util'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url';
 import Parser from 'yargs-parser'
@@ -45,7 +45,7 @@ export default {
   process: {
     argv: () => process.argv,
     cwd: process.cwd,
-    emitWarning: process.emitWarning,
+    emitWarning: (warning, type) => process.emitWarning(warning, type),
     execPath: () => process.execPath,
     exit: process.exit,
     nextTick: process.nextTick,

--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -103,6 +103,7 @@ export interface PlatformShim {
   process: {
     argv: () => string[];
     cwd: () => string;
+    emitWarning: typeof process.emitWarning;
     execPath: () => string;
     exit: (code: number) => void;
     nextTick: (cb: Function) => void;

--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -103,7 +103,7 @@ export interface PlatformShim {
   process: {
     argv: () => string[];
     cwd: () => string;
-    emitWarning: typeof process.emitWarning;
+    emitWarning: (warning: string | Error, type?: string) => void;
     execPath: () => string;
     exit: (code: number) => void;
     nextTick: (cb: Function) => void;

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1470,12 +1470,12 @@ export class YargsInstance {
   }
   [kEmitWarning](
     warning: string,
-    name: string | undefined,
+    type: string | undefined,
     deduplicationID: string
   ) {
     // prevent duplicate warning emissions
     if (!this.#emittedWarnings[deduplicationID]) {
-      this.#shim.process.emitWarning(warning, name);
+      this.#shim.process.emitWarning(warning, type);
       this.#emittedWarnings[deduplicationID] = true;
     }
   }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -904,10 +904,10 @@ export class YargsInstance {
         opt = {};
       }
 
-      // Prevent version name collision
+      // Warn about version name collision
       // Addresses: https://github.com/yargs/yargs/issues/1979
       if (this.#versionOpt && (key === 'version' || opt?.alias === 'version')) {
-        throw new YError(
+        this.#shim.process.emitWarning(
           [
             '"version" is a reserved word.',
             'Please do one of the following:',

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -904,6 +904,13 @@ export class YargsInstance {
         opt = {};
       }
 
+      // Prevent version name collision
+      if (key === 'version' || opt?.alias === 'version') {
+        throw new YError(
+          '"version" is a reserved word.\nPlease use a different option key or use the built-in version method (if applicable).\nhttps://yargs.js.org/docs/#api-reference-version'
+        );
+      }
+
       this.#options.key[key] = true; // track manually set keys.
 
       if (opt.alias) this.alias(key, opt.alias);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -905,9 +905,17 @@ export class YargsInstance {
       }
 
       // Prevent version name collision
-      if (key === 'version' || opt?.alias === 'version') {
+      // Addresses: https://github.com/yargs/yargs/issues/1979
+      if (this.#versionOpt && (key === 'version' || opt?.alias === 'version')) {
         throw new YError(
-          '"version" is a reserved word.\nPlease use a different option key or use the built-in version method (if applicable).\nhttps://yargs.js.org/docs/#api-reference-version'
+          [
+            '"version" is a reserved word.',
+            'Please do one of the following:',
+            '- Disable version with `yargs.version(false)` if using "version" as an option',
+            '- Use the built-in `yargs.version` method instead (if applicable)',
+            '- Use a different option key',
+            'https://yargs.js.org/docs/#api-reference-version',
+          ].join('\n')
         );
       }
 

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1471,12 +1471,12 @@ export class YargsInstance {
   [kEmitWarning](
     warning: string,
     type: string | undefined,
-    deduplicationID: string
+    deduplicationId: string
   ) {
     // prevent duplicate warning emissions
-    if (!this.#emittedWarnings[deduplicationID]) {
+    if (!this.#emittedWarnings[deduplicationId]) {
       this.#shim.process.emitWarning(warning, type);
-      this.#emittedWarnings[deduplicationID] = true;
+      this.#emittedWarnings[deduplicationId] = true;
     }
   }
   [kFreeze]() {

--- a/test/helpers/utils.cjs
+++ b/test/helpers/utils.cjs
@@ -9,6 +9,7 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
   let exitCode = 0;
   const _exit = process.exit;
   const _emit = process.emit;
+  const _emitWarning = process.emitWarning;
   const _env = process.env;
   const _argv = process.argv;
   const _error = console.error;
@@ -25,6 +26,7 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
   const errors = [];
   const logs = [];
   const warnings = [];
+  const emittedWarnings = [];
 
   console.error = (...msg) => {
     errors.push(format(...msg));
@@ -34,6 +36,9 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
   };
   console.warn = (...msg) => {
     warnings.push(format(...msg));
+  };
+  process.emitWarning = warning => {
+    emittedWarnings.push(warning);
   };
 
   let result;
@@ -80,6 +85,7 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
     process.emit = _emit;
     process.env = _env;
     process.argv = _argv;
+    process.emitWarning = _emitWarning;
 
     console.error = _error;
     console.log = _log;
@@ -93,6 +99,7 @@ exports.checkOutput = function checkOutput(f, argv, cb) {
       errors,
       logs,
       warnings,
+      emittedWarnings,
       exit,
       exitCode,
       result,

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1571,6 +1571,7 @@ describe('usage tests', () => {
       r.logs[0].should.eql('1.0.2');
     });
 
+    // Addresses: https://github.com/yargs/yargs/issues/1979
     describe('when an option or alias "version" is set', () => {
       it('fails unless version is disabled', done => {
         yargs

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -5,6 +5,7 @@
 const checkUsage = require('./helpers/utils.cjs').checkOutput;
 const chalk = require('chalk');
 const yargs = require('../index.cjs');
+const expect = require('chai').expect;
 const {YError} = require('../build/index.cjs');
 
 const should = require('chai').should();
@@ -1568,6 +1569,46 @@ describe('usage tests', () => {
         yargs(['--version']).version('1.0.2').wrap(null).parse()
       );
       r.logs[0].should.eql('1.0.2');
+    });
+
+    describe('when an option or alias "version" is set', () => {
+      it('fails unless false is first argument', done => {
+        yargs
+          .command('cmd1', 'cmd desc', yargs =>
+            yargs.option('v', {
+              alias: 'version',
+              describe: 'version desc',
+              type: 'string',
+            })
+          )
+          .fail(msg => {
+            msg.should.match(/reserved word/);
+            return done();
+          })
+          .wrap(null)
+          .parse('cmd1 --version 0.25.10');
+      });
+
+      it('allows if false is first argument', () => {
+        yargs
+          .command(
+            'cmd1',
+            'cmd1 desc',
+            yargs =>
+              yargs.version(false).option('version', {
+                alias: 'v',
+                describe: 'version desc',
+                type: 'string',
+              }),
+            argv => {
+              argv.version.should.equal('0.25.10');
+            }
+          )
+          .fail(() => {
+            expect.fail();
+          })
+          .parse('cmd1 --version 0.25.10');
+      });
     });
 
     describe('when exitProcess is false', () => {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1573,41 +1573,49 @@ describe('usage tests', () => {
 
     // Addresses: https://github.com/yargs/yargs/issues/1979
     describe('when an option or alias "version" is set', () => {
-      it('emits warning unless version is disabled', () => {
-        yargs
-          .command('cmd1', 'cmd desc', yargs =>
-            yargs.option('v', {
-              alias: 'version',
-              describe: 'version desc',
-              type: 'string',
+      it('emits warning if version is not disabled', () => {
+        const r = checkUsage(() =>
+          yargs
+            .command('cmd1', 'cmd1 desc', yargs =>
+              yargs.option('v', {
+                alias: 'version',
+                describe: 'version desc',
+                type: 'string',
+              })
+            )
+            .fail(() => {
+              expect.fail();
             })
-          )
-          .fail(() => {
-            expect.fail();
-          })
-          .wrap(null)
-          .parse('cmd1 --version 0.25.10');
+            .wrap(null)
+            .parse('cmd1 --version 0.25.10')
+        );
+        r.should.have.property('emittedWarnings').with.length(1);
+        r.emittedWarnings[0].should.match(/reserved word/);
       });
 
       it('does not emit warning if version is disabled', () => {
-        yargs
-          .command(
-            'cmd1',
-            'cmd1 desc',
-            yargs =>
-              yargs.version(false).option('version', {
-                alias: 'v',
-                describe: 'version desc',
-                type: 'string',
-              }),
-            argv => {
-              argv.version.should.equal('0.25.10');
-            }
-          )
-          .fail(() => {
-            expect.fail();
-          })
-          .parse('cmd1 --version 0.25.10');
+        const r = checkUsage(() =>
+          yargs
+            .command(
+              'cmd1',
+              'cmd1 desc',
+              yargs =>
+                yargs.version(false).option('version', {
+                  alias: 'v',
+                  describe: 'version desc',
+                  type: 'string',
+                }),
+              argv => {
+                argv.version.should.equal('0.25.10');
+              }
+            )
+            .fail(() => {
+              expect.fail();
+            })
+            .parse('cmd1 --version 0.25.10')
+        );
+
+        r.should.have.property('emittedWarnings').with.length(0);
       });
     });
 

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1573,7 +1573,7 @@ describe('usage tests', () => {
 
     // Addresses: https://github.com/yargs/yargs/issues/1979
     describe('when an option or alias "version" is set', () => {
-      it('fails unless version is disabled', done => {
+      it('emits warning unless version is disabled', () => {
         yargs
           .command('cmd1', 'cmd desc', yargs =>
             yargs.option('v', {
@@ -1582,15 +1582,14 @@ describe('usage tests', () => {
               type: 'string',
             })
           )
-          .fail(msg => {
-            msg.should.match(/reserved word/);
-            return done();
+          .fail(() => {
+            expect.fail();
           })
           .wrap(null)
           .parse('cmd1 --version 0.25.10');
       });
 
-      it('works if version is disabled', () => {
+      it('does not emit warning if version is disabled', () => {
         yargs
           .command(
             'cmd1',

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1572,7 +1572,7 @@ describe('usage tests', () => {
     });
 
     describe('when an option or alias "version" is set', () => {
-      it('fails unless false is first argument', done => {
+      it('fails unless version is disabled', done => {
         yargs
           .command('cmd1', 'cmd desc', yargs =>
             yargs.option('v', {
@@ -1589,7 +1589,7 @@ describe('usage tests', () => {
           .parse('cmd1 --version 0.25.10');
       });
 
-      it('allows if false is first argument', () => {
+      it('works if version is disabled', () => {
         yargs
           .command(
             'cmd1',


### PR DESCRIPTION
Addresses: #1979 and #1864

## Problem

"version" can be passed as a key to `yargs.option()`, but this messes up parsing. 
The `yargs.version()` method already occupies that namespace.

This code

```js
yargs.command(
  "cmd1",
  "cmd1 desc",
  (yargs) =>
    yargs.option("version", {
      alias: "v",
      describe: "version desc",
      type: "string",
    }),
  (argv) => {
    console.log({ argv });
  }
).parse('cmd1 --version 0.25.10')
```

produces this result:

```js
{
  argv: {
    _: [ 'cmd1', '0.25.10' ],
    version: false,
    v: false,
    '$0': 'my-script.js'
  }
}
```

## Solution

I added a check in `yargs.option` that will ~throw an error~ emit a warning if an option (or its alias) is "version", unless they disabled version with `yargs.version(false)`.


