### PR TITLE
fix: update deno CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: 14
       - run: npm install
       - run: npm run compile
-      - uses: denolib/setup-deno@v2
+      - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
       - run: |


### PR DESCRIPTION
denolib/setup-deno is deprecated. CI passed in my fork.