### PR TITLE
fix: positionals should not overwrite options

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -598,13 +598,7 @@ export class CommandInstance {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];
-          // addresses: https://github.com/yargs/yargs/issues/1637
-          // don't overwrite if key already exists in argv
-          if (argv[key]) {
-            argv[key] = ([] as string[]).concat(argv[key], positionalMap[key]);
-          } else {
-            argv[key] = parsed.argv[key];
-          }
+          argv[key] = parsed.argv[key];
         }
       });
     }

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -598,7 +598,18 @@ export class CommandInstance {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];
-          argv[key] = parsed.argv[key];
+          // Addresses: https://github.com/yargs/yargs/issues/1637
+          // If both positionals/options provided,
+          // and if at least one is an array: don't overwrite, combine.
+          if (
+            argv[key] &&
+            parsed.argv[key] &&
+            (Array.isArray(argv[key]) || Array.isArray(parsed.argv[key]))
+          ) {
+            argv[key] = ([] as string[]).concat(argv[key], parsed.argv[key]);
+          } else {
+            argv[key] = parsed.argv[key];
+          }
         }
       });
     }

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -602,8 +602,8 @@ export class CommandInstance {
           // If both positionals/options provided,
           // and if at least one is an array: don't overwrite, combine.
           if (
-            argv[key] &&
-            parsed.argv[key] &&
+            Object.prototype.hasOwnProperty.call(argv, key) &&
+            Object.prototype.hasOwnProperty.call(parsed.argv, key) &&
             (Array.isArray(argv[key]) || Array.isArray(parsed.argv[key]))
           ) {
             argv[key] = ([] as string[]).concat(argv[key], parsed.argv[key]);

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -598,7 +598,13 @@ export class CommandInstance {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];
-          argv[key] = parsed.argv[key];
+          // addresses: https://github.com/yargs/yargs/issues/1637
+          // don't overwrite if key already exists in argv
+          if (argv[key]) {
+            argv[key] = ([] as string[]).concat(argv[key], positionalMap[key]);
+          } else {
+            argv[key] = parsed.argv[key];
+          }
         }
       });
     }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -809,7 +809,7 @@ export class YargsInstance {
       );
     } else {
       globals.forEach(g => {
-        if (this.#options.local.indexOf(g) === -1) this.#options.local.push(g);
+        if (!this.#options.local.includes(g)) this.#options.local.push(g);
       });
     }
     return this;

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -209,6 +209,41 @@ describe('Command', () => {
       argv['--'].should.eql(['apple', 'banana']);
       called.should.equal(true);
     });
+
+    // Addresses: https://github.com/yargs/yargs/issues/1637
+    it('does not overwrite options in argv', () => {
+      yargs
+        .command({
+          command: 'cmd [foods..]',
+          desc: 'cmd desc',
+          builder: yargs =>
+            yargs.positional('foods', {
+              desc: 'foods desc',
+              type: 'string',
+            }),
+          handler: argv => {
+            argv.foods.should.deep.equal(['apples', 'cherries', 'grapes']);
+          },
+        })
+        .parse('cmd --foods apples cherries grapes');
+    });
+
+    it('does not overwrite options in argv when using default command', () => {
+      yargs
+        .command({
+          command: '$0 [foods..]',
+          desc: 'default desc',
+          builder: yargs =>
+            yargs.positional('foods', {
+              desc: 'foods desc',
+              type: 'string',
+            }),
+          handler: argv => {
+            argv.foods.should.deep.equal(['apples', 'cherries', 'grapes']);
+          },
+        })
+        .parse('--foods apples cherries grapes');
+    });
   });
 
   describe('variadic', () => {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -211,7 +211,7 @@ describe('Command', () => {
     });
 
     // Addresses: https://github.com/yargs/yargs/issues/1637
-    it('does not overwrite options in argv', () => {
+    it('does not overwrite options in argv if variadic', () => {
       yargs
         .command({
           command: 'cmd [foods..]',
@@ -228,7 +228,7 @@ describe('Command', () => {
         .parse('cmd --foods apples cherries grapes');
     });
 
-    it('does not overwrite options in argv when using default command', () => {
+    it('does not overwrite options in argv if variadic and when using default command', () => {
       yargs
         .command({
           command: '$0 [foods..]',
@@ -243,6 +243,23 @@ describe('Command', () => {
           },
         })
         .parse('--foods apples cherries grapes');
+    });
+
+    it('does not overwrite options in argv if variadic and preserves falsey values', () => {
+      yargs
+        .command({
+          command: '$0 [numbers..]',
+          desc: 'default desc',
+          builder: yargs =>
+            yargs.positional('numbers', {
+              desc: 'numbers desc',
+              type: 'number',
+            }),
+          handler: argv => {
+            argv.numbers.should.deep.equal([0, 1, 2]);
+          },
+        })
+        .parse('--numbers 0 1 2');
     });
   });
 


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1637

## Problem

When executing the default command, if both positionals and options are provided under the same namespace, positionals will overwrite the options in argv. This doesn't happen if a command is provided.

### yargs

#### Command provided

This will behave correctly. `argv.foods` will have both `apples` and `carrots`

```js
yargs
  .command({
    command: "cmd [foods..]",
    desc: "cmd desc",
    builder: (yargs) =>
      yargs.positional("foods", {
        desc: "foods desc",
        type: "string",
      }),
    handler: (argv) => {
      console.log(argv);
    },
  })
  .help()
  .parse("cmd --foods apples carrots");
```

logs

```
// first time through parser (kRunYargsParserAndExecuteCommands)
{ args: 'cmd --foods apples carrots', config: { 'populate--': true } }
{ 'parsed.argv': { _: [ 'cmd', 'carrots' ], foods: 'apples' } }

// second time through parser
{ args: 'cmd --foods apples carrots', config: { 'populate--': true } }
{ 'parsed.argv': { _: [ 'cmd' ], foods: [ 'apples', 'carrots' ] } }

// argv in handler
{
  _: [ 'cmd' ],
  foods: [ 'apples', 'carrots' ],
  '$0': 'test-issue.js'
}
```

#### Default command

This will behave incorrectly. `argv.foods` will only have `carrots`.

```js
yargs
  .command({
    command: "$0 [foods..]",
    desc: "default desc",
    builder: (yargs) =>
      yargs.positional("foods", {
        desc: "foods desc",
        type: "string",
      }),
    handler: (argv) => {
      console.log(argv);
    },
  })
  .help();
  .parse('--foods apples carrots')
```

logs

```
// first time through parser (kRunYargsParserAndExecuteCommands)
{ args: '--foods apples carrots', config: { 'populate--': true } }
{ 'parsed.argv': { _: [ 'carrots' ], foods: 'apples' } }

// second time through parser
{ args: '--foods apples carrots', config: { 'populate--': true } }
{ 'parsed.argv': { _: [ 'carrots' ], foods: 'apples' } }

// argv in handler
{
  _: [],
  foods: [ 'carrots' ],
  '$0': 'test-issue.js'
}
```

The logic in `postProcessPositionals` will cause the positionals (`['carrots']`) to override the option (`'apples'`) in argv.

## Solution

Check during `postProcessPositionals` if a particular key is already set on argv. If both positionals/options are provided and at least one is an array, combine rather than overwrite.

## Questions

When both positional and option are provided, what should be the behavior?
- if variadic, combine?
- if single value, overwrite?

(This is the assumption I made with this fix.)