### PR TITLE
fix: boolean option should work with strict

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -912,7 +912,7 @@ export class YargsInstance {
       }
 
       this[kTrackManuallySetKeys](key);
-      
+
       // Warn about version name collision
       // Addresses: https://github.com/yargs/yargs/issues/1979
       if (this.#versionOpt && (key === 'version' || opt?.alias === 'version')) {

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -123,6 +123,7 @@ const kRunYargsParserAndExecuteCommands = Symbol(
 );
 const kRunValidation = Symbol('runValidation');
 const kSetHasOutput = Symbol('setHasOutput');
+const kTrackManuallySetKeys = Symbol('kTrackManuallySetKeys');
 export interface YargsInternalMethods {
   getCommandInstance(): CommandInstance;
   getContext(): Context;
@@ -281,11 +282,13 @@ export class YargsInstance {
   array(keys: string | string[]): YargsInstance {
     argsert('<array|string>', [keys], arguments.length);
     this[kPopulateParserHintArray]('array', keys);
+    this[kTrackManuallySetKeys](keys);
     return this;
   }
   boolean(keys: string | string[]): YargsInstance {
     argsert('<array|string>', [keys], arguments.length);
     this[kPopulateParserHintArray]('boolean', keys);
+    this[kTrackManuallySetKeys](keys);
     return this;
   }
   check(f: (argv: Arguments) => any, global?: boolean): YargsInstance {
@@ -528,6 +531,7 @@ export class YargsInstance {
   count(keys: string | string[]): YargsInstance {
     argsert('<array|string>', [keys], arguments.length);
     this[kPopulateParserHintArray]('count', keys);
+    this[kTrackManuallySetKeys](keys);
     return this;
   }
   default(
@@ -888,6 +892,7 @@ export class YargsInstance {
   number(keys: string | string[]): YargsInstance {
     argsert('<array|string>', [keys], arguments.length);
     this[kPopulateParserHintArray]('number', keys);
+    this[kTrackManuallySetKeys](keys);
     return this;
   }
   option(
@@ -904,8 +909,7 @@ export class YargsInstance {
         opt = {};
       }
 
-      this.#options.key[key] = true; // track manually set keys.
-
+      this[kTrackManuallySetKeys](key);
       if (opt.alias) this.alias(key, opt.alias);
 
       const deprecate = opt.deprecate || opt.deprecated;
@@ -1308,9 +1312,10 @@ export class YargsInstance {
     this.#strictOptions = enabled !== false;
     return this;
   }
-  string(key: string | string[]): YargsInstance {
-    argsert('<array|string>', [key], arguments.length);
-    this[kPopulateParserHintArray]('string', key);
+  string(keys: string | string[]): YargsInstance {
+    argsert('<array|string>', [keys], arguments.length);
+    this[kPopulateParserHintArray]('string', keys);
+    this[kTrackManuallySetKeys](keys);
     return this;
   }
   terminalWidth(): number | null {
@@ -2175,6 +2180,15 @@ export class YargsInstance {
   }
   [kSetHasOutput]() {
     this.#hasOutput = true;
+  }
+  [kTrackManuallySetKeys](keys: string | string[]) {
+    if (typeof keys === 'string') {
+      this.#options.key[keys] = true;
+    } else {
+      for (const k of keys) {
+        this.#options.key[k] = true;
+      }
+    }
   }
 }
 

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -986,6 +986,46 @@ describe('validation tests', () => {
       args.matey.should.equal('ben');
       args._.should.deep.equal(['ahoy', '--arrr']);
     });
+
+    it('does not fail when options are defined using array/boolean/count/number/string', () => {
+      yargs
+        .command({
+          command: 'cmd',
+          desc: 'cmd desc',
+          builder: yargs =>
+            yargs
+              .option('opt1', {
+                desc: 'opt1 desc',
+                type: 'boolean',
+              })
+              .option('opt2', {
+                desc: 'opt2 desc',
+                boolean: true,
+              })
+              .array('opt3')
+              .boolean('opt4')
+              .count('opt5')
+              .number('opt6')
+              .string('opt7')
+              .fail(() => {
+                expect.fail();
+              }),
+          handler: argv => {
+            argv.opt1.should.equal(true);
+            argv.opt2.should.equal(true);
+            argv.opt3.should.deep.equal(['foo', 'bar', 'baz']);
+            argv.opt4.should.equal(true);
+            argv.opt5.should.equal(1);
+            argv.opt6.should.equal(3);
+            argv.opt7.should.equal('cat');
+          },
+        })
+        .help()
+        .strict()
+        .parse(
+          'cmd --opt1 --opt2 --opt3 foo bar baz --opt4 --opt5 --opt6 3 --opt7 cat'
+        );
+    });
   });
 
   describe('demandOption', () => {


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1694

When defining an option with `yargs.option`, this line is called:

```js
this.#options.key[key] = true;
```

This affects the behavior in`validation > unknownArguments > isValidAndSomeAliasIsNotNew`. Without the tracking of set keys, `unknownArguments` will fail (as described in the issue).

I turned that line into a reusable function so that `yargs.option` and the array/boolean/count/number/string methods have consistent behavior when using `yargs.strict`