### PR TITLE
fix: array options should not eat positionals

### DIFF
--- a/test/command.cjs
+++ b/test/command.cjs
@@ -209,6 +209,42 @@ describe('Command', () => {
       argv['--'].should.eql(['apple', 'banana']);
       called.should.equal(true);
     });
+
+    // Addresses: https://github.com/yargs/yargs/issues/1848
+    it('is not stolen by array options', () => {
+      yargs
+        .command({
+          command: 'cmd <entree>',
+          desc: 'cmd desc',
+          builder: yargs =>
+            yargs
+              .positional('entree', {
+                desc: 'entree desc',
+                type: 'string',
+              })
+              .option('drink', {
+                desc: 'drink desc',
+                type: 'string',
+              })
+              .option('desserts', {
+                desc: 'desserts desc',
+                type: 'string',
+                array: 'true',
+              })
+              .fail(() => {
+                expect.fail();
+              }),
+          handler: argv => {
+            argv.should.have.property('entree');
+            argv.entree.should.equall('barbacoa');
+            argv.drink.should.equall('horchata');
+            argv.desserts.should.deep.equall(['churro', 'sopapilla']);
+          },
+        })
+        .help()
+        .strict()
+        .parse('cmd --drink horchata --desserts churro sopapilla barbacoa');
+    });
   });
 
   describe('variadic', () => {


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1848 https://github.com/yargs/yargs/issues/2017

## Problem

I'm looking at the options that get passed with argv into the parser, and it looks like the parser is unaware of positionals.

## Questions

Possible solution:

- Send the number of expected (required) positional arguments to the parser, 
- Have the parser grab the expected args, before array options are handled.

This solution would have the following problems:

- This wouldn't resolve the ambiguity between array args and optional positional arguments.
- This wouldn't work if the positional args are variadic.

Alternative solutions:

- Output a warning when array options and positionals are used.
- Suggest setting 'greedy-arrays' setting to false.

Any ideas? @bcoe