### PR TITLE
fix: positional array defaults should not be combined with provided values

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -593,15 +593,17 @@ export class CommandInstance {
         positionalKeys.push(...parsed.aliases[key]);
       });
 
+      const defaults = yargs.getOptions().default;
       Object.keys(parsed.argv).forEach(key => {
         if (positionalKeys.includes(key)) {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];
           // Addresses: https://github.com/yargs/yargs/issues/1637
-          // If both positionals/options provided,
+          // If both positionals/options provided, no default was set,
           // and if at least one is an array: don't overwrite, combine.
           if (
+            !Object.prototype.hasOwnProperty.call(defaults, key) &&
             Object.prototype.hasOwnProperty.call(argv, key) &&
             Object.prototype.hasOwnProperty.call(parsed.argv, key) &&
             (Array.isArray(argv[key]) || Array.isArray(parsed.argv[key]))

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -245,7 +245,26 @@ describe('Command', () => {
         .parse('--foods apples cherries grapes');
     });
 
-    it('does not overwrite options in argv if variadic and preserves falsey values', () => {
+    it('does not combine positional default and provided values', () => {
+      yargs()
+        .command({
+          command: 'cmd [foods..]',
+          desc: 'cmd desc',
+          builder: yargs =>
+            yargs.positional('foods', {
+              desc: 'foods desc',
+              type: 'string',
+              default: ['pizza', 'wings'],
+            }),
+          handler: argv => {
+            argv.foods.should.deep.equal(['apples', 'cherries', 'grapes']);
+            argv.foods.should.not.include('pizza');
+          },
+        })
+        .parse('cmd apples cherries grapes');
+    });
+
+    it('does not overwrite options in argv if variadic and preserves falsy values', () => {
       yargs
         .command({
           command: '$0 [numbers..]',


### PR DESCRIPTION
## Related to

- https://github.com/yargs/yargs/pull/1992
- https://github.com/mdn/browser-compat-data/pull/11990

## Problem

Positional array defaults were getting combined with, instead of overwritten by, the provided values.