### PR TITLE
feat: autocomplete choices for options

### DIFF
--- a/lib/argsert.ts
+++ b/lib/argsert.ts
@@ -73,7 +73,7 @@ export function argsert(
       position += 1;
     });
   } catch (err) {
-    console.warn(err.stack);
+    console.warn((err as Error).stack);
   }
 }
 

--- a/lib/utils/maybe-async-result.ts
+++ b/lib/utils/maybe-async-result.ts
@@ -19,7 +19,7 @@ export function maybeAsyncResult<T>(
       ? result.then((result: T) => resultHandler(result))
       : resultHandler(result);
   } catch (err) {
-    return errorHandler(err);
+    return errorHandler(err as Error);
   }
 }
 

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -296,6 +296,83 @@ describe('Completion', () => {
       r.logs.should.include('--foo');
       r.logs.should.not.include('bar');
     });
+
+    it('completes choices if previous option requires a choice', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '--fruit',
+        ])
+          .options({
+            fruit: {
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(3);
+      r.logs.should.include('apple');
+      r.logs.should.include('banana');
+      r.logs.should.include('pear');
+    });
+
+    it('completes choices if previous option requires a choice and space has been entered', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '--fruit',
+          '',
+        ])
+          .options({
+            fruit: {
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(3);
+      r.logs.should.include('apple');
+      r.logs.should.include('banana');
+      r.logs.should.include('pear');
+    });
+
+    it('completes choices if previous option requires a choice and a partial choice has been entered', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '--fruit',
+          'ap',
+        ])
+          .options({
+            fruit: {
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(1);
+      r.logs.should.include('apple');
+      r.logs.should.not.include('banana');
+      r.logs.should.not.include('pear');
+    });
   });
 
   describe('generateCompletionScript()', () => {


### PR DESCRIPTION
Hi!

This PR introduces support for auto completing choices if an option has been specified which has choices but no value has been selected yet. For example:
```
> cdktf convert --language <TAB>
csharp      java        python      typescript
```
when the option has been specified like this: ([source](https://github.com/hashicorp/terraform-cdk/blob/168349149773a969d64063a38d3a69a6d75680cb/packages/cdktf-cli/bin/cmds/convert.ts#L42-L45))
```typescript
.option("language", {
  choices: ["typescript", "python", "csharp", "java"],
  default: "typescript",
})
```

#### Background
We use `yargs` for the [CDK for Terraform](https://github.com/hashicorp/terraform-cdk) and wanted to [introduce support for shell completion](https://github.com/hashicorp/terraform-cdk/issues/676). As we wanted to offer support for auto completing choices for options, I figured I'd do a PR instead of building a custom completion handler in multiple places.

If there's anything I can do to get this merged, please tell me!

P.S. It also fixes #2016 because that caused the build to fail for me and there's no `package-lock.json` or alike.