### PR TITLE
docs: improve typing of `Difficulty` in TypeScript example

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -126,8 +126,8 @@ interface Arguments {
 To improve the `choices` option typing you can also specify its types:
 
 ```typescript
-type Difficulty = 'normal' | 'nightmare' | 'hell';
-const difficulties: ReadonlyArray<Difficulty> = ['normal', 'nightmare', 'hell'];
+const difficulties = ["normal", "nightmare", "hell"] as const;
+type Difficulty = typeof difficulties[number];
 
 const argv = yargs.option('difficulty', {
   choices: difficulties,


### PR DESCRIPTION
Hi all and thanks for making Yargs :-)

I believe that this:

```ts
const difficulties = ["normal", "nightmare", "hell"] as const;
type Difficulty = typeof difficulties[number];
```

gives the same result than:

```ts
type Difficulty = 'normal' | 'nightmare' | 'hell';
const difficulties: ReadonlyArray<Difficulty> = ['normal', 'nightmare', 'hell'];
```

but is better as it doesn't include twice the content of the list, and prevents missing elements (indeed, the following is valid despite the fact that one element is missing: `const difficulties: ReadonlyArray<Difficulty> = ['normal', 'hell'];`).