### PR TITLE
feat(usage): output the environment variable name

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -338,7 +338,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         // actually generate the switches string --foo, -f, --bar.
         const switches: Dictionary<string | IndentedText> =
           normalizedKeys.reduce((acc, key) => {
-            acc[key] = [key]
+            const my = [key]
               .concat(options.alias[key] || [])
               .map(sw => {
                 // for the special positional group don't
@@ -366,8 +366,10 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
                   ? 1
                   : -1
               )
-              .join(', ');
-
+            my.push(...my.filter(i => i.startsWith("--")).map(i => {
+                 return "[$" + i.slice(2).replace(/([A-Z])/g, '_$1').toUpperCase() + ']';
+            }));
+            acc[key] = my.join(', ');
             return acc;
           }, {} as Dictionary<string>);
 


### PR DESCRIPTION
This is not tested and  or complete-:) 

I had the idea to display the environment name for an option.
To help the "dockerized" people to understand/help that they could pass environment variables.

So I did this spike. 
Missing is that, it should only printed if envPrefix is set, I didn't find if envPrefix is passed to usage.ts.
And some commands like --help should currently not work if HELP=xx is set.
And my replace should make use of the real converting function:
UnknownFunction("outputSchema")  -> OUTPUT_SCHEMA
which  i didn't found.

currently help looks like this:

Options:
  --help, [$HELP]                                                Show help                                                  [boolean]
  --version, [$VERSION]                                     Show version number                              [boolean]
  --outputSchema, [$OUTPUT_SCHEMA]        output Schema                  [string] [default: "tbd"]
