### PR TITLE
deps(security): CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "escalade": "^3.1.1",
     "get-caller-file": "^2.0.5",
     "require-directory": "^2.1.1",
-    "string-width": "^4.2.0",
+    "string-width": "^4.2.3",
     "y18n": "^5.0.5",
     "yargs-parser": "^20.2.2"
   },


### PR DESCRIPTION
Update string-width to 4.2.3

In order to patch vulnerability [CVE-2021-3807](https://vuln.whitesourcesoftware.com/vulnerability/CVE-2021-3807), a downstream dependency has to be updated.
This dependency tree is:
yargs
  string-width
    strip-ansi
      ansi-regex
      
The vulnerability for this CVE related to ansi-regex has been fixed in strip-ansi 6.0.1 which is used by string-width 4.2.3.