### PR TITLE
fix: don't fail if "fileURLToPath(import.meta.url)" throws

### DIFF
--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -15,8 +15,13 @@ import y18n from 'y18n'
 const REQUIRE_ERROR = 'require is not supported by ESM'
 const REQUIRE_DIRECTORY_ERROR = 'loading a directory of commands is not supported yet for ESM'
 
-const mainFilename = fileURLToPath(import.meta.url).split('node_modules')[0]
-const __dirname = fileURLToPath(import.meta.url)
+let __dirname;
+try {
+  __dirname = fileURLToPath(import.meta.url);
+} catch (e) {
+  __dirname = process.cwd();
+}
+const mainFilename = __dirname.split('node_modules')[0]
 
 export default {
   assert: {


### PR DESCRIPTION
For usage like:

 - built final project used in a javascript vm
 - project built on unix via webpack and used on windows (path format are incompatible with drive letters on windows)

https://github.com/webpack/webpack/issues/14445