### PR TITLE
feat: fallback to default bash completion

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -24,7 +24,7 @@ _{{app_name}}_yargs_completions()
 
     return 0
 }
-complete -o default -F _{{app_name}}_yargs_completions {{app_name}}
+complete -o bashdefault -o default -F _{{app_name}}_yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###
 `;
 


### PR DESCRIPTION
If you do not generate a completion entry, use the default bash completion. If that also does not return a completion, fall back to "readline" default filename completion.

This allows you to complete on for example environment variables. `mycommand --option $OPT<tab>` would complete to `mycommand --option $OPTION` if there was an environment variable called `OPTION` set.