### PR TITLE
build: fix ts build errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+      - run: npm install -g npm@latest
       - run: node --version
       - run: npm install --engine-strict
       - run: npm test
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+      - run: npm install -g npm@latest
       - run: node --version
       - run: npm install --engine-strict
       - run: npm run test:esm
@@ -48,6 +50,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm run compile
       - uses: denoland/setup-deno@v1
@@ -63,6 +66,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 15
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm test
       - run: npm run coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm test
   esm:

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -102,10 +102,7 @@ export function applyMiddleware(
       if (isPromise(acc)) {
         return acc
           .then(initialObj =>
-            Promise.all<Arguments, Partial<Arguments>>([
-              initialObj,
-              middleware(initialObj, yargs),
-            ])
+            Promise.all([initialObj, middleware(initialObj, yargs)])
           )
           .then(([initialObj, middlewareObj]) =>
             Object.assign(initialObj, middlewareObj)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.4",
-    "@wessberg/rollup-plugin-ts": "^1.3.2",
     "c8": "^7.7.0",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
@@ -74,6 +73,7 @@
     "rollup": "^2.23.0",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-ts": "^2.0.4",
     "typescript": "^4.0.2",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -1,5 +1,5 @@
 const cleanup = require('rollup-plugin-cleanup');
-const ts = require('@wessberg/rollup-plugin-ts');
+const ts = require('rollup-plugin-ts');
 const {terser} = require('rollup-plugin-terser');
 
 const output = {


### PR DESCRIPTION
## Problem

I'm running into a few issues when running `build:cjs`:
- It looks like the ts logic for `Promise.all` has changed. I made a change to address this. (I used [this solution](https://github.com/microsoft/TypeScript/issues/46651#issuecomment-958599609))
- `@wessberg/rollup-plugin-ts` is throwing an error

### rollup-plugin-ts

#### error

```
TypeError: Cannot read properties of undefined (reading 'text')
    at getExportedSymbolFromExportSpecifier (/.../yargs/node_modules/@wessberg/rollup-plugin-ts/src/service/transformer/declaration-bundler/util/create-export-specifier-from-name-and-modifiers.ts:49:35)
```

#### reproduction

You can see a reproduction of the issue [here](https://github.com/yargs/yargs/runs/4316963468?check_suite_focus=true#step:5:34)


#### code

The issue is in [this line](https://github.com/wessberg/rollup-plugin-ts/blob/master/src/service/transformer/declaration-bundler/util/create-export-specifier-from-name-and-modifiers.ts#L50)

## Solution

- Use `rollup-plugin-ts` instead. 
- Install later version of npm for CI, because It wants npm >= 7.0.0, and the CI process was using npm 6.14.15.
