### PR TITLE
fix: re-add options to check callback

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -293,7 +293,10 @@ export class YargsInstance {
     this[kTrackManuallySetKeys](keys);
     return this;
   }
-  check(f: (argv: Arguments) => any, global?: boolean): YargsInstance {
+  check(
+    f: (argv: Arguments, options: Options) => any,
+    global?: boolean
+  ): YargsInstance {
     argsert('<function> [boolean]', [f, global], arguments.length);
     this.middleware(
       (
@@ -304,7 +307,7 @@ export class YargsInstance {
           Partial<Arguments> | Promise<Partial<Arguments>> | any
         >(
           () => {
-            return f(argv);
+            return f(argv, _yargs.getOptions());
           },
           (result: any): Partial<Arguments> | Promise<Partial<Arguments>> => {
             if (!result) {

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -15,7 +15,7 @@ describe('validation tests', () => {
   });
 
   describe('check', () => {
-    it('fails if error is thrown in check callback', () => {
+    it('fails if error is thrown in check callback', done => {
       yargs
         .command(
           '$0',
@@ -38,6 +38,9 @@ describe('validation tests', () => {
             expect.fail();
           }
         )
+        .fail(() => {
+          return done();
+        })
         .parse('--name');
     });
 
@@ -81,8 +84,14 @@ describe('validation tests', () => {
                 alias: 'n',
               })
               .check((_, options) => {
-                if (!Object.isObject(options)) {
-                  expect.fail();
+                if (
+                  typeof options !== 'object' ||
+                  !Object.prototype.hasOwnProperty.call(options, 'string') ||
+                  !options.string.includes('name')
+                ) {
+                  throw new Error(
+                    'Check callback should have access to options'
+                  );
                 }
                 return true;
               }),

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -14,6 +14,87 @@ describe('validation tests', () => {
     yargs.getInternalMethods().reset();
   });
 
+  describe('check', () => {
+    it('fails if error is thrown in check callback', () => {
+      yargs
+        .command(
+          '$0',
+          'default command desc',
+          yargs =>
+            yargs
+              .option('name', {
+                describe: 'name desc',
+                type: 'string',
+                alias: 'n',
+              })
+              .check(argv => {
+                const {name} = argv;
+                if (typeof name !== 'string' || !name.length) {
+                  throw new Error('Option "name" must be a non-empty string');
+                }
+                return true;
+              }),
+          () => {
+            expect.fail();
+          }
+        )
+        .parse('--name');
+    });
+
+    it('does not fail if error is not thrown in check callback, and true is returned', () => {
+      yargs
+        .command(
+          '$0',
+          'default command desc',
+          yargs =>
+            yargs
+              .option('name', {
+                describe: 'version desc',
+                type: 'string',
+                alias: 'n',
+              })
+              .check(argv => {
+                const {name} = argv;
+                if (typeof name !== 'string' || !name.length) {
+                  throw new Error('Option "name" must be a non-empty string');
+                }
+                return true;
+              }),
+          argv => argv
+        )
+        .fail(() => {
+          expect.fail();
+        })
+        .parse('--name Itachi');
+    });
+
+    it('callback has access to options', () => {
+      yargs
+        .command(
+          '$0',
+          'default command desc',
+          yargs =>
+            yargs
+              .option('name', {
+                describe: 'name desc',
+                type: 'string',
+                alias: 'n',
+              })
+              .check((_, options) => {
+                if (!Object.isObject(options)) {
+                  expect.fail();
+                }
+                return true;
+              }),
+          argv => argv
+        )
+        .fail(() => {
+          expect.fail();
+        })
+        .parse('--name Itachi');
+    });
+  });
+
   describe('implies', () => {
     const implicationsFailedPattern = new RegExp(
       english['Implications failed:']


### PR DESCRIPTION
Addresses: 

https://github.com/yargs/yargs/issues/2069

## Problem

Check callback `options` is undefined. It should be an object.

The [docs](http://yargs.js.org/docs/#api-reference-checkfn-globaltrue) show `options` in the call signature for the callback in`check`. In [yargs 17](https://github.com/yargs/yargs/blob/main/lib/yargs-factory.ts#L296), options is missing from that call signature.

## Questions

- Not sure if the options object I used is the correct one (or if it's in the correct state). 
- Not sure if mutable access to options should be exposed. Should it be read-only or a copy?

Let me know if there are any changes that need to happen, or if I should add more tests.