### PR TITLE
multiple: improved completion for choices

### DIFF
--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -373,6 +373,86 @@ describe('Completion', () => {
       r.logs.should.not.include('banana');
       r.logs.should.not.include('pear');
     });
+
+    it('completes choices if previous option or one of its aliases requires a choice', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '-f',
+        ])
+          .options({
+            fruit: {
+              alias: ['f', 'not-a-vegetable'],
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(3);
+      r.logs.should.include('apple');
+      r.logs.should.include('banana');
+      r.logs.should.include('pear');
+    });
+
+    it('completes choices if previous option or one of its aliases requires a choice and space has been entered', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '--not-a-vegetable',
+          '',
+        ])
+          .options({
+            fruit: {
+              alias: ['f', 'not-a-vegetable'],
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(3);
+      r.logs.should.include('apple');
+      r.logs.should.include('banana');
+      r.logs.should.include('pear');
+    });
+
+    it('completes choices if previous option or one of its aliases requires a choice and a partial choice has been entered', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkUsage(() => {
+        return yargs([
+          './completion',
+          '--get-yargs-completions',
+          './completion',
+          '-f',
+          'ap',
+        ])
+          .options({
+            fruit: {
+              alias: 'f',
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion('completion', false).argv;
+      });
+
+      r.logs.should.have.length(1);
+      r.logs.should.include('apple');
+      r.logs.should.not.include('banana');
+      r.logs.should.not.include('pear');
+    });
   });
 
   describe('generateCompletionScript()', () => {


### PR DESCRIPTION
This is an improvement on #2018. Changes:

- Improvement: Completion for choices will now work for all possible aliases of an option and not just the default long option. This is accomplished by iterating over all known aliases of the provided option, and checking for `choices` on each.
- Fix: changed the RegExp used to remove hypens (`-`), because it removed ALL hyphens from the argument, which broke options like `--long-option-with-dashes`. It now only removes dashes at the beginning of the option.
- Fix: changed the check for option arguments to match options that begin with `'-'`, instead of `'--'`, to include short options
