### PR TITLE
Update ko.json

### DIFF
--- a/locales/ko.json
+++ b/locales/ko.json
@@ -22,22 +22,22 @@
     "other": "옵션이 아닌 인수가 너무 많습니다: %s개 입력받음, 최대 %s개 입력 가능"
   },
   "Missing argument value: %s": {
-    "one": "알 수 없는 인수 값: %s",
-    "other": "알 수 없는 인수 값: %s"
+    "one": "인수가 주어지지 않았습니다: %s",
+    "other": "인수가 주어지지 않았습니다: %s"
   },
   "Missing required argument: %s": {
-    "one": "알 수 없는 필수 인수: %s",
-    "other": "알 수 없는 필수 인수: %s"
+    "one": "필수 인수가 주어지지 않았습니다: %s",
+    "other": "필수 인수가 주어지지 않았습니다: %s"
   },
   "Unknown argument: %s": {
-    "one": "알 수 없는 인수: %s",
-    "other": "알 수 없는 인수: %s"
+    "one": "알 수 없는 인수입니다: %s",
+    "other": "알 수 없는 인수입니다: %s"
   },
   "Invalid values:": "유효하지 않은 값:",
   "Argument: %s, Given: %s, Choices: %s": "인수: %s, 주어진 값: %s, 선택지: %s",
   "Argument check failed: %s": "인수 체크에 실패했습니다: %s",
-  "Implications failed:": "주어진 인수에 필요한 추가 인수가 제공되지 않았습니다:",
-  "Not enough arguments following: %s": "다음 인수가 부족합니다: %s",
+  "Implications failed:": "주어진 인수에 필요한 추가 인수가 주어지지 않았습니다:",
+  "Not enough arguments following: %s": "다음 인수가 주어지지 않았습니다: %s",
   "Invalid JSON config file: %s": "유효하지 않은 JSON 설정 파일: %s",
   "Path to JSON config file": "JSON 설정 파일 경로",
   "Show help": "도움말 표시",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -2,48 +2,48 @@
   "Commands:": "명령:",
   "Options:": "옵션:",
   "Examples:": "예시:",
-  "boolean": "여부",
+  "boolean": "불리언"
   "count": "개수",
   "string": "문자열",
   "number": "숫자",
   "array": "배열",
   "required": "필수",
-  "default": "기본",
-  "default:": "기본:",
-  "choices:": "선택:",
+  "default": "기본값",
+  "default:": "기본값:",
+  "choices:": "선택지:",
   "aliases:": "별칭:",
   "generated-value": "생성된 값",
   "Not enough non-option arguments: got %s, need at least %s": {
-    "one": "옵션이 아닌 인자가 충분치 않습니다: %s개를 받았지만, 적어도 %s개는 필요합니다",
-    "other": "옵션이 아닌 인자가 충분치 않습니다: %s개를 받았지만, 적어도 %s개는 필요합니다"
+    "one": "옵션이 아닌 인수가 충분하지 않습니다: %s개 입력받음, 최소 %s개 입력 필요",
+    "other": "옵션이 아닌 인수가 충분하지 않습니다: %s개 입력받음, 최소 %s개 입력 필요"
   },
   "Too many non-option arguments: got %s, maximum of %s": {
-    "one": "옵션이 아닌 인자가 너무 많습니다: %s개를 받았지만, %s개 이하여야 합니다",
-    "other": "옵션이 아닌 인자가 너무 많습니다: %s개를 받았지만, %s개 이하여야 합니다"
+    "one": "옵션이 아닌 인수가 너무 많습니다: %s개 입력받음, 최대 %s개 입력 가능",
+    "other": "옵션이 아닌 인수가 너무 많습니다: %s개 입력받음, 최대 %s개 입력 가능"
   },
   "Missing argument value: %s": {
-    "one": "인자값을 받지 못했습니다: %s",
-    "other": "인자값들을 받지 못했습니다: %s"
+    "one": "알 수 없는 인수 값: %s",
+    "other": "알 수 없는 인수 값: %s"
   },
   "Missing required argument: %s": {
-    "one": "필수 인자를 받지 못했습니다: %s",
-    "other": "필수 인자들을 받지 못했습니다: %s"
+    "one": "알 수 없는 필수 인수: %s",
+    "other": "알 수 없는 필수 인수: %s"
   },
   "Unknown argument: %s": {
-    "one": "알 수 없는 인자입니다: %s",
-    "other": "알 수 없는 인자들입니다: %s"
+    "one": "알 수 없는 인수: %s",
+    "other": "알 수 없는 인수: %s"
   },
-  "Invalid values:": "잘못된 값입니다:",
-  "Argument: %s, Given: %s, Choices: %s": "인자: %s, 입력받은 값: %s, 선택지: %s",
-  "Argument check failed: %s": "유효하지 않은 인자입니다: %s",
-  "Implications failed:": "옵션의 조합이 잘못되었습니다:",
-  "Not enough arguments following: %s": "인자가 충분하게 주어지지 않았습니다: %s",
-  "Invalid JSON config file: %s": "유효하지 않은 JSON 설정파일입니다: %s",
-  "Path to JSON config file": "JSON 설정파일 경로",
-  "Show help": "도움말을 보여줍니다",
-  "Show version number": "버전 넘버를 보여줍니다",
-  "Did you mean %s?": "찾고계신게 %s입니까?",
-  "Arguments %s and %s are mutually exclusive" : "%s와 %s 인자는 같이 사용될 수 없습니다",
+  "Invalid values:": "유효하지 않은 값:",
+  "Argument: %s, Given: %s, Choices: %s": "인수: %s, 주어진 값: %s, 선택지: %s",
+  "Argument check failed: %s": "인수 체크에 실패했습니다: %s",
+  "Implications failed:": "주어진 인수에 필요한 추가 인수가 제공되지 않았습니다:",
+  "Not enough arguments following: %s": "다음 인수가 부족합니다: %s",
+  "Invalid JSON config file: %s": "유효하지 않은 JSON 설정 파일: %s",
+  "Path to JSON config file": "JSON 설정 파일 경로",
+  "Show help": "도움말 표시",
+  "Show version number": "버전 표시",
+  "Did you mean %s?": "%s를 찾으시나요?",
+  "Arguments %s and %s are mutually exclusive" : "인수 %s와 %s는 동시에 지정할 수 없습니다",
   "Positionals:": "위치:",
   "command": "명령"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -2,7 +2,7 @@
   "Commands:": "명령:",
   "Options:": "옵션:",
   "Examples:": "예시:",
-  "boolean": "불리언"
+  "boolean": "불리언",
   "count": "개수",
   "string": "문자열",
   "number": "숫자",


### PR DESCRIPTION
Translating "deprecated" and "deprecated: %s" is out of my consideration as I couldn't describe them as no short sentences.
"불리언" is itself a pronouncation of "boolean" also is a registered word in wikipedia. Still better than past one.
Besides, fixed several words into commonly used intuitive translations.