### PR TITLE
fix: failed command usage string is missing arg descriptions and optional args

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -312,7 +312,7 @@ export class CommandInstance {
     // if this is the case, we should show the root usage instructions
     // rather than the usage instructions for the nested default command:
     if (isDefaultCommand)
-      innerYargs.getInternalMethods().getUsageInstance().unfreeze();
+      innerYargs.getInternalMethods().getUsageInstance().unfreeze(true);
     if (this.shouldUpdateUsage(innerYargs)) {
       innerYargs
         .getInternalMethods()

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -707,22 +707,31 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
       descriptions,
     });
   };
-  self.unfreeze = function unfreeze() {
+  self.unfreeze = function unfreeze(defaultCommand = false) {
     const frozen = frozens.pop();
     // In the case of running a defaultCommand, we reset
     // usage early to ensure we receive the top level instructions.
     // unfreezing again should just be a noop:
     if (!frozen) return;
-    ({
-      failMessage,
-      failureOutput,
-      usages,
-      usageDisabled,
-      epilogs,
-      examples,
-      commands,
-      descriptions,
-    } = frozen);
+    // Addresses: https://github.com/yargs/yargs/issues/2030
+    if (defaultCommand) {
+      descriptions = {...frozen.descriptions, ...descriptions};
+      commands = [...frozen.commands, ...commands];
+      usages = [...frozen.usages, ...usages];
+      examples = [...frozen.examples, ...examples];
+      epilogs = [...frozen.epilogs, ...epilogs];
+    } else {
+      ({
+        failMessage,
+        failureOutput,
+        usages,
+        usageDisabled,
+        epilogs,
+        examples,
+        commands,
+        descriptions,
+      } = frozen);
+    }
   };
 
   return self;
@@ -759,7 +768,7 @@ export interface UsageInstance {
   showHelpOnFail(enabled?: boolean | string, message?: string): UsageInstance;
   showVersion(level?: 'error' | 'log' | ((message: string) => void)): void;
   stringifiedValues(values?: any[], separator?: string): string;
-  unfreeze(): void;
+  unfreeze(defaultCommand?: boolean): void;
   usage(msg: string | null, description?: string | false): UsageInstance;
   version(ver: any): void;
   wrap(cols: number | null | undefined): void;

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -3840,6 +3840,45 @@ describe('usage tests', () => {
           '  --uuid                                                              [required]',
         ]);
     });
+
+    // Addresses: https://github.com/yargs/yargs/issues/2030
+    it('should display options (with descriptions) on failed default command', () => {
+      const r = checkUsage(() =>
+        yargs('')
+          .command({
+            command: '$0 <arg1>',
+            desc: 'default desc',
+            builder: yargs =>
+              yargs
+                .option('arg1', {
+                  type: 'string',
+                  desc: 'arg1 desc',
+                  demandOption: true,
+                })
+                .option('arg2', {
+                  type: 'string',
+                  desc: 'arg2 desc',
+                }),
+            handler: noop,
+          })
+          .strict()
+          .parse()
+      );
+      console.log(r);
+      r.errors[0]
+        .split('\n')
+        .should.deep.equal([
+          'usage <arg1>',
+          '',
+          'default desc',
+          '',
+          'Options:',
+          '  --help     Show help                                                 [boolean]',
+          '  --version  Show version number                                       [boolean]',
+          '  --arg1     arg1 desc (default command)                     [string] [required]',
+          '  --arg2     arg2 desc (default command)                                [string]',
+        ]);
+    });
   });
 
   describe('positional', () => {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -3875,8 +3875,8 @@ describe('usage tests', () => {
           'Options:',
           '  --help     Show help                                                 [boolean]',
           '  --version  Show version number                                       [boolean]',
-          '  --arg1     arg1 desc (default command)                     [string] [required]',
-          '  --arg2     arg2 desc (default command)                                [string]',
+          '  --arg1     arg1 desc                                       [string] [required]',
+          '  --arg2     arg2 desc                                                  [string]',
         ]);
     });
   });


### PR DESCRIPTION
Addresses: 
https://github.com/yargs/yargs/issues/2030
https://github.com/yargs/yargs/issues/2102

## Problem

The usage from a failed default command is missing the following:
- argument descriptions
- optional arguments
- possibly more (?)

### Example

In the code and output below, you will see that the failed default command is missing descriptions and optional arguments. (I omitted the command usage output, as it's not part of the issue.)

```js

yargs('')
  .command({
    command: '$0 <arg1>',
    desc: 'default desc',
    builder: yargs => yargs
      .option('arg1', {
        type: 'string',
        desc: 'arg1 desc (default command)',
        demandOption: true
      })
      .option('arg2', {
        type: 'string',
        desc: 'arg2 desc (default command)'
      }),
    handler: argv => {
      console.log(argv)
    }
  })
  .command({
    command: 'cmd1 <arg1>',
    desc: 'cmd1 desc',
    builder: yargs => yargs
      .option('arg1', {
        type: 'string',
        desc: 'arg1 desc',
        demandOption: true
      }),
    handler: argv => {
      console.log(argv)
    }
  })
  .strict()
  .parse()


/*

# cmd1
# yargs('cmd1')

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --arg1     arg1 desc                                       [string] [required]

# default (failed command)
# yargs('')

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --arg1                                                     [string] [required]

# default (help)
# yargs('--help')

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --arg1     arg1 desc (default command)                     [string] [required]
  --arg2     arg2 desc (default command)                                [string]

*/
```

## Solution

I'm still trying to figure out the fix for this. I wrote a unit test that should demonstrate the incongruity between expected/actual behavior. 

## Notes

This is what I've found so far, concerning failed default commands and the parts that are missing from the usage output:

- validation functions call `usage.fail` if validation fails
- usage.fail calls `yargs.showHelp('error')`
- yargs.showHelp calls `this.#usage.showHelp`
- usage.showHelp calls `emit(self.help())`

I logged `descriptions` at multiple points in the yargs process, and it's strange because arg1/arg2 show up in descriptions, but later get removed. I don't know if that's a result of resetting or using cached values, but something is wonky there. I'll keep trying to figure out why they get removed.

```
usage.describe { descriptions: { help: '__yargsString__:Show help' } }
usage.describe {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number'
  }
}
usage.describe { descriptions: { help: '__yargsString__:Show help' } }
usage.describe {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number'
  }
}
yargs.option { key: 'arg1', desc: 'arg1 desc (default command)' }
usage.describe {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number',
    arg1: 'arg1 desc (default command)'
  }
}
yargs.option { key: 'arg2', desc: 'arg2 desc (default command)' }
usage.describe {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number',
    arg1: 'arg1 desc (default command)',
    arg2: 'arg2 desc (default command)'
  }
}
usage.showHelp {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number'
  }
}
usage.help {
  descriptions: {
    help: '__yargsString__:Show help',
    version: '__yargsString__:Show version number'
  }
}
```