### PR TITLE
fix: cannot find package.json on ESM

### DIFF
--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -21,7 +21,7 @@ try {
 } catch (e) {
   __dirname = process.cwd();
 }
-const mainFilename = __dirname.split('node_modules')[0]
+const mainFilename = __dirname.substring(0, __dirname.lastIndexOf('node_modules'));
 
 export default {
   assert: {


### PR DESCRIPTION
Fixes #2122.

In the case of ava, `mainFilename` changes like below way.

```js
// existing code's value:
mainFilename: /usr/local/lib/

// this PR's value:
mainFilename: /usr/local/lib/node_modules/ava/
```

This enable yargs to find ava's package.json properly.