### PR TITLE
event.keyCode is deprecated, use new `.code` API

### DIFF
--- a/example/yargs.html
+++ b/example/yargs.html
@@ -35,7 +35,7 @@
       const input = document.getElementById('input');
       const output = document.getElementById('output');
       input.addEventListener('keydown', event => {
-        if (event.keyCode === 13) { // Enter.
+        if (event.key === "Enter" || event.code === "Enter" || event.keyCode === 13) { // Enter.
           const argv = yargs.parse(input.value, (err, argv, _output) => {
             if (output) {
               output.value += `\n${_output}`;


### PR DESCRIPTION
Some browser don't support `code` so I added a fallback for `keyCode`