### PR TITLE
fix: Show message when showHelpOnFail is chained globally

### DIFF
--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -1,6 +1,11 @@
 import {Parser} from './yargs-parser-types.js';
 
 /**
+ * A type that represents undefined or null
+ */
+export type nil = undefined | null;
+
+/**
  * An object whose all properties have the same type.
  */
 export type Dictionary<T = any> = {[key: string]: T};

--- a/lib/typings/yargs-parser-types.ts
+++ b/lib/typings/yargs-parser-types.ts
@@ -1,6 +1,6 @@
 // Taken from yargs-parser@19.0.1
 // TODO: update this file periodically.
-import type {Dictionary, ValueOf} from './common-types.js';
+import type {Dictionary, ValueOf, nil} from './common-types.js';
 
 type KeyOf<T> = {
   [K in keyof T]: string extends K ? never : number extends K ? never : K;
@@ -142,7 +142,7 @@ export interface Parser {
   detailed(args: ArgsInput, opts?: Partial<Options>): DetailedArguments;
   camelCase(str: string): string;
   decamelize(str: string, joinString?: string): string;
-  looksLikeNumber(x: null | undefined | number | string): boolean;
+  looksLikeNumber(x: nil | number | string): boolean;
 }
 export declare type StringFlag = Dictionary<string[]>;
 export declare type BooleanFlag = Dictionary<boolean>;

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -1,8 +1,8 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-import {Dictionary, PlatformShim} from './typings/common-types.js';
+import {Dictionary, PlatformShim, nil} from './typings/common-types.js';
 import {objFilter} from './utils/obj-filter.js';
-import {YargsInstance, nil} from './yargs-factory.js';
+import {YargsInstance} from './yargs-factory.js';
 import {YError} from './yerror.js';
 import {DetailedArguments} from './typings/yargs-parser-types.js';
 import setBlocking from './utils/set-blocking.js';
@@ -157,7 +157,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   };
 
   let wrapSet = false;
-  let wrap: number | null | undefined;
+  let wrap: number | nil;
   self.wrap = cols => {
     wrapSet = true;
     wrap = cols;
@@ -778,7 +778,7 @@ export interface UsageInstance {
   unfreeze(defaultCommand?: boolean): void;
   usage(msg: string | null, description?: string | false): UsageInstance;
   version(ver: any): void;
-  wrap(cols: number | null | undefined): void;
+  wrap(cols: number | nil): void;
 }
 
 export interface FailureFunction {

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -32,7 +32,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
 
     // If global context, set globalFailMessage
     // Addresses: https://github.com/yargs/yargs/issues/2085
-    if (yargs.getInternalMethods().getContext().commands.length === 0) {
+    if (yargs.getInternalMethods().isGlobalContext()) {
       globalFailMessage = message;
     }
 

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -117,6 +117,7 @@ const kGetParseContext = Symbol('getParseContext');
 const kGetUsageInstance = Symbol('getUsageInstance');
 const kGetValidationInstance = Symbol('getValidationInstance');
 const kHasParseCallback = Symbol('hasParseCallback');
+const kIsGlobalContext = Symbol('isGlobalContext');
 const kPostProcess = Symbol('postProcess');
 const kRebase = Symbol('rebase');
 const kReset = Symbol('reset');
@@ -136,6 +137,7 @@ export interface YargsInternalMethods {
   getUsageInstance(): UsageInstance;
   getValidationInstance(): ValidationInstance;
   hasParseCallback(): boolean;
+  isGlobalContext(): boolean;
   postProcess<T extends Arguments | Promise<Arguments>>(
     argv: Arguments | Promise<Arguments>,
     populateDoubleDash: boolean,
@@ -182,6 +184,7 @@ export class YargsInstance {
   #groups: Dictionary<string[]> = {};
   #hasOutput = false;
   #helpOpt: string | null = null;
+  #isGlobalContext = true;
   #logger: LoggerInstance;
   #output = '';
   #options: Options;
@@ -1761,6 +1764,7 @@ export class YargsInstance {
       getUsageInstance: this[kGetUsageInstance].bind(this),
       getValidationInstance: this[kGetValidationInstance].bind(this),
       hasParseCallback: this[kHasParseCallback].bind(this),
+      isGlobalContext: this[kIsGlobalContext].bind(this),
       postProcess: this[kPostProcess].bind(this),
       reset: this[kReset].bind(this),
       runValidation: this[kRunValidation].bind(this),
@@ -1792,6 +1796,9 @@ export class YargsInstance {
   }
   [kHasParseCallback](): boolean {
     return !!this.#parseFn;
+  }
+  [kIsGlobalContext](): boolean {
+    return this.#isGlobalContext;
   }
   [kPostProcess]<T extends Arguments | Promise<Arguments>>(
     argv: Arguments | Promise<Arguments>,
@@ -2012,6 +2019,8 @@ export class YargsInstance {
           helpOptSet = true;
         }
       }
+
+      this.#isGlobalContext = false;
 
       const handlerKeys = this.#command.getCommands();
       const requestCompletions = this.#completion!.completionKey in argv;

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -22,6 +22,7 @@ import type {
   RequireDirectoryOptions,
   PlatformShim,
   RequireType,
+  nil,
 } from './typings/common-types.js';
 import {
   assertNotStrictEqual,
@@ -1423,7 +1424,7 @@ export class YargsInstance {
     this.describe(this.#versionOpt, msg);
     return this;
   }
-  wrap(cols: number | null | undefined): YargsInstance {
+  wrap(cols: number | nil): YargsInstance {
     argsert('<number|null|undefined>', [cols], arguments.length);
     this.#usage.wrap(cols);
     return this;
@@ -2227,8 +2228,6 @@ export class YargsInstance {
     }
   }
 }
-
-export type nil = undefined | null;
 
 export function isYargsInstance(y: YargsInstance | void): y is YargsInstance {
   return !!y && typeof y.getInternalMethods === 'function';

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -172,7 +172,7 @@ export class YargsInstance {
   #completion: CompletionInstance | null = null;
   #completionCommand: string | null = null;
   #defaultShowHiddenOpt = 'show-hidden';
-  #exitError: YError | string | undefined | null = null;
+  #exitError: YError | string | nil = null;
   #detectLocale = true;
   #emittedWarnings: Dictionary<boolean> = {};
   #exitProcess = true;
@@ -2228,6 +2228,8 @@ export class YargsInstance {
   }
 }
 
+export type nil = undefined | null;
+
 export function isYargsInstance(y: YargsInstance | void): y is YargsInstance {
   return !!y && typeof y.getInternalMethods === 'function';
 }
@@ -2344,7 +2346,7 @@ interface FrozenYargsInstance {
   strictOptions: boolean;
   completionCommand: string | null;
   output: string;
-  exitError: YError | string | undefined | null;
+  exitError: YError | string | nil;
   hasOutput: boolean;
   parsed: DetailedArguments | false;
   parseFn: ParseCallback | null;
@@ -2352,11 +2354,7 @@ interface FrozenYargsInstance {
 }
 
 interface ParseCallback {
-  (
-    err: YError | string | undefined | null,
-    argv: Arguments,
-    output: string
-  ): void;
+  (err: YError | string | nil, argv: Arguments, output: string): void;
 }
 
 interface Aliases {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1682,7 +1682,7 @@ describe('usage tests', () => {
   });
 
   describe('showHelpOnFail', () => {
-    it('should display user supplied message (command usage)', () => {
+    it('should display user supplied message', () => {
       const opts = {
         foo: {desc: 'foo option', alias: 'f'},
         bar: {desc: 'bar option', alias: 'b'},

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1682,7 +1682,7 @@ describe('usage tests', () => {
   });
 
   describe('showHelpOnFail', () => {
-    it('should display user supplied message', () => {
+    it('should display user supplied message (command usage)', () => {
       const opts = {
         foo: {desc: 'foo option', alias: 'f'},
         bar: {desc: 'bar option', alias: 'b'},
@@ -1710,6 +1710,89 @@ describe('usage tests', () => {
           '',
           'Specify --help for available options',
         ]);
+    });
+
+    describe('should handle being chained both globally and on a command ', () => {
+      const options = {
+        opt1: {
+          alias: 'o',
+          demandOption: true,
+        },
+      };
+      const cmdMessage = 'What have you done (command)????';
+      const globalMessage = 'What have you done (global)????';
+      const errorMessage = 'Unknown argument: extraOpt';
+
+      it('chained on to command', () => {
+        const r = checkUsage(() =>
+          yargs('cmd1 --opt1 hello --extraOpt oops')
+            .command(
+              'cmd1',
+              'cmd1 desc',
+              yargs => yargs.options(options).showHelpOnFail(false, cmdMessage),
+              argv => console.log(argv)
+            )
+            .strict()
+            .parse()
+        );
+        r.should.have.property('result');
+        r.result.should.have.property('_').with.length(1);
+        r.should.have.property('errors');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(true);
+        r.errors
+          .join('\n')
+          .split(/\n/)
+          .should.deep.equal([errorMessage, '', cmdMessage]);
+      });
+
+      it('chained on globally', () => {
+        const r = checkUsage(() =>
+          yargs('cmd1 --opt1 hello --extraOpt oops')
+            .command(
+              'cmd1',
+              'cmd1 desc',
+              yargs => yargs.option(options),
+              argv => console.log(argv)
+            )
+            .showHelpOnFail(false, globalMessage)
+            .strict()
+            .parse()
+        );
+        r.should.have.property('result');
+        r.result.should.have.property('_').with.length(1);
+        r.should.have.property('errors');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(true);
+        r.errors
+          .join('\n')
+          .split(/\n/)
+          .should.deep.equal([errorMessage, '', globalMessage]);
+      });
+
+      it('chained on command and globally (priority given to command message)', () => {
+        const r = checkUsage(() =>
+          yargs('cmd1 --opt1 hello --extraOpt oops')
+            .command(
+              'cmd1',
+              'cmd1 desc',
+              yargs => yargs.option(options).showHelpOnFail(false, cmdMessage),
+              argv => console.log(argv)
+            )
+            .showHelpOnFail(false, globalMessage)
+            .strict()
+            .parse()
+        );
+        r.should.have.property('result');
+        r.result.should.have.property('_').with.length(1);
+        r.should.have.property('errors');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(true);
+        r.errors
+          .join('\n')
+          .split(/\n/)
+          .should.deep.equal([errorMessage, '', cmdMessage]);
+      });
     });
   });
 


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/2085

## Problem

When `showHelpOnFail` is used globally, it doesn't work. 
This is because `usage.reset()` sets failMessage to null.

## Solution

I added a `globalFailMessage` variable to capture the global mesage.
On fail, `failMessage || globalFailMessage` is printed. I figured if both are provided, the more specific message should be shown.

## Other

I saw that `null | undefined` was used a lot, so I made type `nil`. (Idea borrowed from lodash isNil)