### PR TITLE
feature: add method to hide option extras

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -768,7 +768,6 @@ export interface UsageInstance {
   getUsage(): [string, string][];
   getUsageDisabled(): boolean;
   help(): string;
-  hideOptionExtras(): void;
   reset(localLookup: Dictionary<boolean>): UsageInstance;
   showHelp(level?: 'error' | 'log' | ((message: string) => void)): void;
   showHelpOnFail(enabled?: boolean | string, message?: string): UsageInstance;

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -443,7 +443,8 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
           desc
         );
 
-        if (extra) ui.div({text: extra, padding: [0, 0, 0, 2], align: 'right'});
+        if (extra && !shouldHideOptionExtras)
+          ui.div({text: extra, padding: [0, 0, 0, 2], align: 'right'});
         else ui.div();
       });
 
@@ -734,6 +735,11 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
     }
   };
 
+  let shouldHideOptionExtras = false;
+  self.hideOptionExtras = function hideOptionExtras() {
+    shouldHideOptionExtras = true;
+  };
+
   return self;
 }
 
@@ -763,6 +769,7 @@ export interface UsageInstance {
   getUsage(): [string, string][];
   getUsageDisabled(): boolean;
   help(): string;
+  hideOptionExtras(): void;
   reset(localLookup: Dictionary<boolean>): UsageInstance;
   showHelp(level?: 'error' | 'log' | ((message: string) => void)): void;
   showHelpOnFail(enabled?: boolean | string, message?: string): UsageInstance;

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -443,6 +443,10 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
           desc
         );
 
+        const shouldHideOptionExtras =
+          yargs.getInternalMethods().getUsageConfiguration()['hide-types'] ===
+          true;
+
         if (extra && !shouldHideOptionExtras)
           ui.div({text: extra, padding: [0, 0, 0, 2], align: 'right'});
         else ui.div();
@@ -733,11 +737,6 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         descriptions,
       } = frozen);
     }
-  };
-
-  let shouldHideOptionExtras = false;
-  self.hideOptionExtras = function hideOptionExtras() {
-    shouldHideOptionExtras = true;
   };
 
   return self;

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2293,7 +2293,7 @@ export interface Configuration extends Partial<ParserConfiguration> {
 }
 
 export interface UsageConfiguration {
-  /** Should types be hideen when usage is displayed */
+  /** Should types be hidden when usage is displayed */
   'hide-types'?: boolean;
 }
 

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -843,6 +843,10 @@ export class YargsInstance {
     this.#options.hiddenOptions.push(key);
     return this;
   }
+  hideOptionExtras(): YargsInstance {
+    this.#usage.hideOptionExtras();
+    return this;
+  }
   implies(
     key: string | Dictionary<KeyOrPos | KeyOrPos[]>,
     value?: KeyOrPos | KeyOrPos[]

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -92,6 +92,7 @@ const kEmitWarning = Symbol('emitWarning');
 const kFreeze = Symbol('freeze');
 const kGetDollarZero = Symbol('getDollarZero');
 const kGetParserConfiguration = Symbol('getParserConfiguration');
+const kGetUsageConfiguration = Symbol('getUsageConfiguration');
 const kGuessLocale = Symbol('guessLocale');
 const kGuessVersion = Symbol('guessVersion');
 const kParsePositionalNumbers = Symbol('parsePositionalNumbers');
@@ -132,6 +133,7 @@ export interface YargsInternalMethods {
   getLoggerInstance(): LoggerInstance;
   getParseContext(): Object;
   getParserConfiguration(): Configuration;
+  getUsageConfiguration(): UsageConfiguration;
   getUsageInstance(): UsageInstance;
   getValidationInstance(): ValidationInstance;
   hasParseCallback(): boolean;
@@ -197,6 +199,7 @@ export class YargsInstance {
   #strictCommands = false;
   #strictOptions = false;
   #usage: UsageInstance;
+  #usageConfig: UsageConfiguration = {};
   #versionOpt: string | null = null;
   #validation: ValidationInstance;
 
@@ -843,10 +846,6 @@ export class YargsInstance {
     this.#options.hiddenOptions.push(key);
     return this;
   }
-  hideOptionExtras(): YargsInstance {
-    this.#usage.hideOptionExtras();
-    return this;
-  }
   implies(
     key: string | Dictionary<KeyOrPos | KeyOrPos[]>,
     value?: KeyOrPos | KeyOrPos[]
@@ -1388,6 +1387,11 @@ export class YargsInstance {
       return this;
     }
   }
+  usageConfiguration(config: UsageConfiguration) {
+    argsert('<object>', [config], arguments.length);
+    this.#usageConfig = config;
+    return this;
+  }
   version(opt?: string | false, msg?: string, ver?: string): YargsInstance {
     const defaultVersionOpt = 'version';
     argsert(
@@ -1550,6 +1554,9 @@ export class YargsInstance {
   }
   [kGetParserConfiguration](): Configuration {
     return this.#parserConfig;
+  }
+  [kGetUsageConfiguration](): UsageConfiguration {
+    return this.#usageConfig;
   }
   [kGuessLocale]() {
     if (!this.#detectLocale) return;
@@ -1761,6 +1768,7 @@ export class YargsInstance {
       getLoggerInstance: this[kGetLoggerInstance].bind(this),
       getParseContext: this[kGetParseContext].bind(this),
       getParserConfiguration: this[kGetParserConfiguration].bind(this),
+      getUsageConfiguration: this[kGetUsageConfiguration].bind(this),
       getUsageInstance: this[kGetUsageInstance].bind(this),
       getValidationInstance: this[kGetValidationInstance].bind(this),
       hasParseCallback: this[kHasParseCallback].bind(this),
@@ -2282,6 +2290,11 @@ export interface Configuration extends Partial<ParserConfiguration> {
   'deep-merge-config'?: boolean;
   /** Should commands be sorted in help? */
   'sort-commands'?: boolean;
+}
+
+export interface UsageConfiguration {
+  /** Should types be hideen when usage is displayed */
+  'hide-types'?: boolean;
 }
 
 export interface OptionDefinition {

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -4755,4 +4755,46 @@ describe('usage tests', () => {
         '  -v, --version  Custom version description                            [boolean]',
       ]);
   });
+
+  describe('usage configuration', () => {
+    it('allows extras to be disabled when "hide-types" is true', () => {
+      const r = checkUsage(() =>
+        yargs('cmd1 --help')
+          .command(
+            'cmd1',
+            'cmd1 desc',
+            yargs =>
+              yargs.option('opt1', {
+                type: 'string',
+                choices: ['foo', 'bar', 'baz'],
+                alias: 'o',
+                required: true,
+                description: 'A long description that might break formatting',
+              }),
+            argv => console.log(argv)
+          )
+          // .hideOptionExtras()
+          .usageConfiguration({'hide-types': true})
+          .strict()
+          .parse()
+      );
+      r.should.have.property('result');
+      r.result.should.have.property('_').with.length(1);
+      r.should.have.property('errors');
+      r.should.have.property('logs').with.length(1);
+      r.should.have.property('exit').and.equal(true);
+      r.logs[0]
+        .split(/\n/)
+        .should.deep.equal([
+          'usage cmd1',
+          '',
+          'cmd1 desc',
+          '',
+          'Options:',
+          '      --help     Show help',
+          '      --version  Show version number',
+          '  -o, --opt1     A long description that might break formatting',
+        ]);
+    });
+  });
 });

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -4771,7 +4771,7 @@ describe('usage tests', () => {
                 required: true,
                 description: 'A long description that might break formatting',
               }),
-            argv => console.log(argv)
+            () => {}
           )
           .usageConfiguration({'hide-types': true})
           .strict()

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -4773,7 +4773,6 @@ describe('usage tests', () => {
               }),
             argv => console.log(argv)
           )
-          // .hideOptionExtras()
           .usageConfiguration({'hide-types': true})
           .strict()
           .parse()


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/2153

## Description

Given the following:

```js
yargs('cmd1 --help')
  .command(
    'cmd1',
    'cmd1 desc',
    yargs => yargs
      .option('opt1', {
        type: 'string',
        choices: ['foo', 'bar', 'baz'],
        alias: 'o',
        required: true,
        description: "A long description that might break formatting"
      }),
    argv => console.log(argv)
  )
  .hideOptionExtras()
  .strict()
  .parse()
```

The `hideOptionExtras` would cause the following output

```
cmd1 desc

Options:
      --help     Show help                                             [boolean]
      --version  Show version number                                   [boolean]
  -o, --opt1     A long description that might break formatting
                              [string] [required] [choices: "foo", "bar", "baz"]
```

to look like this instead

```
cmd1 desc

Options:
      --help     Show help
      --version  Show version number
  -o, --opt1     A long description that might break formatting
```

## Questions

If this works, I'll add unit tests.
What other things would need to change? (docs, examples, etc)