### PR TITLE
fix(completion): correct zsh installation instructions

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -34,7 +34,7 @@ export const completionZshTemplate = `#compdef {{app_name}}
 # yargs command completion script
 #
 # Installation: {{app_path}} {{completion_command}} >> ~/.zshrc
-#    or {{app_path}} {{completion_command}} >> ~/.zsh_profile on OSX.
+#    or {{app_path}} {{completion_command}} >> ~/.zprofile on OSX.
 #
 _{{app_name}}_yargs_completions()
 {


### PR DESCRIPTION
Replace reference to `~/.zsh_profile` with the correct `~/.zprofile`. [Source](https://stackoverflow.com/questions/23090390/is-there-anything-in-zsh-like-bash-profile)