### PR TITLE
fix: coerce pollutes argv

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -603,9 +603,9 @@ export class CommandInstance {
           // If both positionals/options provided, no default was set,
           // and if at least one is an array: don't overwrite, combine.
           if (
-            !Object.prototype.hasOwnProperty.call(defaults, key) &&
-            Object.prototype.hasOwnProperty.call(argv, key) &&
-            Object.prototype.hasOwnProperty.call(parsed.argv, key) &&
+            !Object.hasOwnProperty.call(defaults, key) &&
+            Object.hasOwnProperty.call(argv, key) &&
+            Object.hasOwnProperty.call(parsed.argv, key) &&
             (Array.isArray(argv[key]) || Array.isArray(parsed.argv[key]))
           ) {
             argv[key] = ([] as string[]).concat(argv[key], parsed.argv[key]);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -389,7 +389,6 @@ export class YargsInstance {
         let aliases: Dictionary<string[]>;
 
         // Skip coerce logic if related arg was not provided
-        // Addresses: https://github.com/yargs/yargs/issues/2130
         const shouldCoerce = Object.prototype.hasOwnProperty.call(argv, keys);
         if (!shouldCoerce) {
           return argv;

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -404,7 +404,10 @@ export class YargsInstance {
           },
           (result: any): Partial<Arguments> => {
             argv[keys] = result;
-            if (aliases[keys]) {
+            const stripAliased = yargs
+              .getInternalMethods()
+              .getParserConfiguration()['strip-aliased'];
+            if (aliases[keys] && stripAliased !== true) {
               for (const alias of aliases[keys]) {
                 argv[alias] = result;
               }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -389,7 +389,7 @@ export class YargsInstance {
         let aliases: Dictionary<string[]>;
 
         // Skip coerce logic if related arg was not provided
-        const shouldCoerce = Object.prototype.hasOwnProperty.call(argv, keys);
+        const shouldCoerce = Object.hasOwnProperty.call(argv, keys);
         if (!shouldCoerce) {
           return argv;
         }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -383,6 +383,14 @@ export class YargsInstance {
         yargs: YargsInstance
       ): Partial<Arguments> | Promise<Partial<Arguments>> => {
         let aliases: Dictionary<string[]>;
+
+        // Skip coerce logic if related arg was not provided
+        // Addresses: https://github.com/yargs/yargs/issues/2130
+        const shouldCoerce = Object.prototype.hasOwnProperty.call(argv, keys);
+        if (!shouldCoerce) {
+          return argv;
+        }
+
         return maybeAsyncResult<
           Partial<Arguments> | Promise<Partial<Arguments>> | any
         >(

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1647,6 +1647,35 @@ describe('Command', () => {
         argv.rest.should.equal('bar baz');
         coerceExecutionCount.should.equal(1);
       });
+
+      // Addresses: https://github.com/yargs/yargs/issues/2130
+      it('should not run or set new properties on argv when related argument is not passed', () => {
+        yargs('cmd1')
+          .command(
+            'cmd1',
+            'cmd1 desc',
+            yargs =>
+              yargs
+                .option('foo', {alias: 'f', type: 'string'})
+                .option('bar', {
+                  alias: 'b',
+                  type: 'string',
+                  implies: 'f',
+                  coerce: () => expect.fail(), // Should not be called
+                })
+                .fail(() => {
+                  expect.fail(); // Should not fail because of implies
+                }),
+            argv => {
+              // eslint-disable-next-line no-prototype-builtins
+              if (Object.prototype.hasOwnProperty(argv, 'b')) {
+                expect.fail(); // 'b' was not provided, coerce should not set it
+              }
+            }
+          )
+          .strict()
+          .parse();
+      });
     });
 
     describe('defaults', () => {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1676,6 +1676,29 @@ describe('Command', () => {
           .strict()
           .parse();
       });
+
+      it('should not add aliases to argv if strip-aliased config is true', () => {
+        yargs('cmd1 -f hello -b world')
+          .parserConfiguration({'strip-aliased': true})
+          .command(
+            'cmd1',
+            'cmd1 desc',
+            yargs =>
+              yargs.option('foo', {alias: 'f', type: 'string'}).option('bar', {
+                type: 'string',
+                alias: 'b',
+                coerce: val => val,
+              }),
+            argv => {
+              // eslint-disable-next-line no-prototype-builtins
+              if (Object.prototype.hasOwnProperty(argv, 'b')) {
+                expect.fail(); // 'b' is an alias, it should not be in argv
+              }
+            }
+          )
+          .strict()
+          .parse();
+      });
     });
 
     describe('defaults', () => {

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -1677,6 +1677,7 @@ describe('Command', () => {
           .parse();
       });
 
+      // Addresses: https://github.com/yargs/yargs/issues/2159
       it('should not add aliases to argv if strip-aliased config is true', () => {
         yargs('cmd1 -f hello -b world')
           .parserConfiguration({'strip-aliased': true})


### PR DESCRIPTION
## Related

- https://github.com/yargs/yargs/issues/2130
- https://github.com/yargs/yargs/issues/2158
- https://github.com/yargs/yargs/issues/2159
- https://github.com/yargs/yargs/issues/2162

## TLDR

- coerce always runs, even if arg isn't provided
- coerce sets the value on argv, resulting in keys existing on argv that weren't passed.
- any validation around certain keys (not) existing on argv manifest unintended behavior

## Description

I'm fixing two coerce bugs:
- bug one: coerce and related argument not passed
- bug two: coerce and strip-aliased

## Bug one

### Details

Coerce doesn't behave correctly when the related arg is not passed. 
There are two unintentional side-effects:
- a new arg is set on argv
- coerce function is run

`coerce > maybeAsyncResult > resultHandler` sets argv, which shouldn't happen.

### Reproduction
    
```js
const input = 'cmd1'

yargs(input)
  .command(
    'cmd1',
    'cmd1 desc',
    yargs => yargs
      .option('foo', { alias: 'f', type: 'string' })
      .option('bar', { 
        type: 'string', 
        alias: 'b',
        coerce: val => console.log('Why was I called?') || val,
      }),
    argv => {
      console.log({ argv })
    })
  .strict()
  .parse()
```

```
Why was I called?
{
  argv: {
    _: [ 'cmd1' ],
    '$0': 'example.js',
    bar: undefined,
    b: undefined
  }
}
```

'b' was not provided, so:
- its coerce function should not run
- it should not be defined on `argv`

## Bug two

### Details

Coerce adds aliases to argv (even when strip-aliased is true)

### Reproduction

```js
const input = 'cmd1 -f hello -b world'

yargs(input)
  .parserConfiguration({ "strip-aliased": true })
  .command(
    'cmd1',
    'cmd1 desc',
    yargs => yargs
      .option('foo', { alias: 'f', type: 'string' })
      .option('bar', { 
        type: 'string', 
        alias: 'b',
        coerce: val => val,
      }),
    argv => {
      console.log({ argv })
    })
  .strict()
  .parse()
```

```
{
  argv: {
    _: [ 'cmd1' ],
    foo: 'hello',
    bar: 'world',
    '$0': 'example.js',
    b: 'world'
  }
}
```

`b` should not be defined on `argv`
