### PR TITLE
Fix async middleware

### DIFF
--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -282,21 +282,14 @@ describe('middleware', () => {
     });
 
     // Addresses: https://github.com/yargs/yargs/issues/2124
-    // This test will fail if the result of async middleware is not treated like a promise
-    it('treats result of async middleware as promise', done => {
-      const input = 'cmd1 -f Hello -b world';
+    // This test will fail if result of async middleware is not handled like a promise
+    it('does not cause an unexpected error when async middleware and strict are both used', done => {
+      const input = 'cmd1';
       yargs(input)
         .command(
           'cmd1',
           'cmd1 desc',
-          yargs =>
-            yargs
-              .option('foo', {type: 'string', alias: 'f', required: true})
-              .option('bar', {type: 'string', alias: 'b', required: true})
-              .middleware(async argv => {
-                await new Promise(r => setTimeout(r, 5));
-                return argv;
-              }, true),
+          yargs => yargs.middleware(async argv => argv, true),
           _argv => {
             done();
           }

--- a/test/middleware.cjs
+++ b/test/middleware.cjs
@@ -283,8 +283,7 @@ describe('middleware', () => {
 
     // Addresses: https://github.com/yargs/yargs/issues/2124
     // This test will fail if the result of async middleware is not treated like a promise
-    // eslint-disable-next-line no-restricted-properties
-    it.only('treats result of async middleware as promise', done => {
+    it('treats result of async middleware as promise', done => {
       const input = 'cmd1 -f Hello -b world';
       yargs(input)
         .command(


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/2124

## Description

The result of `applyMiddleware` is `Arguments | Promise<Arguments>`, but the code treats it synchronously. Whenever it returns a promise, that promise isn't handled as such.

This problem is easier to spot when `strict` is used

## Reproduction

```js
const input = 'cmd1 -f Hello -b world'

yargs(input)
  .command(
    'cmd1',
    'cmd1 desc',
    yargs => yargs
      .option('foo', { type: 'string', alias: 'f', required: true })
      .option('bar', { type: 'string', alias: 'b', required: true })
      .middleware(async argv => {
        console.log('sleeping')
        await new Promise(r => setTimeout(r, 2000))
        console.log('waking up')
        return argv
      }, true),
    argv => {
      console.log(argv)
    })
  .strict()
  .parse()
```

I put a console log after `applyMiddleware` is called, and I could see that 'waking up' showed up after `applyMiddleware` finished.

