### PR TITLE
fix: dont clobber description for multiple option calls

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1044,7 +1044,11 @@ export class YargsInstance {
       }
 
       const desc = opt.describe || opt.description || opt.desc;
-      this.describe(key, desc);
+      const existingDesc = this.#usage.getDescriptions()[key];
+      if (!existingDesc || typeof desc === 'string') {
+        this.describe(key, desc);
+      }
+
       if (opt.hidden) {
         this.hide(key);
       }

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1068,8 +1068,11 @@ export class YargsInstance {
       }
 
       const desc = opt.describe || opt.description || opt.desc;
-      const existingDesc = this.#usage.getDescriptions()[key];
-      if (!existingDesc || typeof desc === 'string') {
+      const descriptions = this.#usage.getDescriptions();
+      if (
+        !Object.prototype.hasOwnProperty.call(descriptions, key) ||
+        typeof desc === 'string'
+      ) {
         this.describe(key, desc);
       }
 

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -3968,7 +3968,6 @@ describe('usage tests', () => {
           .strict()
           .parse()
       );
-      console.log(r);
       r.errors[0]
         .split('\n')
         .should.deep.equal([
@@ -4837,5 +4836,24 @@ describe('usage tests', () => {
         '  -h, --help     Custom help description                               [boolean]',
         '  -v, --version  Custom version description                            [boolean]',
       ]);
+  });
+
+  // https://github.com/yargs/yargs/issues/2169
+  it('allows multiple option calls to not clobber description', () => {
+    const r = checkUsage(() =>
+      yargs('--help')
+        .options({
+          arg: {desc: 'Old description', type: 'string', default: 'old'},
+        })
+        .options({arg: {default: 'new'}})
+        .wrap(null)
+        .parse()
+    );
+    r.logs[0]
+      .split('\n')
+      .slice(-1)[0]
+      .replace(/\s+/g, ' ')
+      .trim()
+      .should.equal('--arg Old description [string] [default: "new"]');
   });
 });


### PR DESCRIPTION
Fixes #2169

My original patch from #2169 broke some existing tests, due to it being necessary to call `this.describe` when initially setting up an option even if no explicit description is set.

So this PR implements this behavior by only calling `this.describe` if there is no existing description OR if the new description is a string.

I added a test that I confirmed fails on main and passes in this PR.