### PR TITLE
fix: prevent infinite loop with locale

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -871,7 +871,7 @@ export class YargsInstance {
   }
   locale(locale?: string): YargsInstance | string {
     argsert('[string]', [locale], arguments.length);
-    if (!locale) {
+    if (locale === undefined) {
       this[kGuessLocale]();
       return this.#shim.y18n.getLocale();
     }

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -757,6 +757,38 @@ describe('yargs dsl tests', () => {
       r.logs.join(' ').should.match(/Parlay this here code of conduct/);
     });
 
+    // Addresses: https://github.com/yargs/yargs/issues/2178
+    it('does not enter infinite loop when locale is invalid', () => {
+      // Save env vars
+      const lcAll = process.env.LC_ALL;
+      const lcMessages = process.env.LC_MESSAGES;
+      const lang = process.env.LANG;
+      const language = process.env.LANGUAGE;
+      // Change
+      delete process.env.LC_ALL;
+      delete process.env.LC_MESSAGES;
+      process.env.LANG = '.UTF-8';
+      delete process.env.LANGUAGE;
+      try {
+        yargs
+          .command({
+            command: 'cmd1',
+            desc: 'cmd1 desc',
+            builder: () => {},
+            handler: _argv => {},
+          })
+          .parse();
+      } catch {
+        expect.fail();
+      } finally {
+        // Restore
+        process.env.LC_ALL = lcAll;
+        process.env.LC_MESSAGES = lcMessages;
+        process.env.LANG = lang;
+        process.env.LANGUAGE = language;
+      }
+    });
+
     describe('updateLocale', () => {
       it('allows you to override the default locale strings', () => {
         const r = checkOutput(() => {


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/2178

## Description

locale and kGuessLocale can enter an infinite loop

## Details

There's regex logic that turns '.UTF-8' into '', and downstream there is logic checking if that value is falsey (instead of undefined).

As a result, kGuessLocale and locale call each other infinitely.

## Todo

```js
this.locale(locale.replace(/[.:].*/, ''))
```
This line is what converts `'.UTF-8'` into `''`. I don't know if my fix is sufficient or if the real problem is here.