### PR TITLE
fix(lang): add missing terms to Russian translation

### DIFF
--- a/locales/ru.json
+++ b/locales/ru.json
@@ -46,6 +46,6 @@
   "Arguments %s and %s are mutually exclusive": "Аргументы %s и %s являются взаимоисключающими",
   "Positionals:": "Позиционные аргументы:",
   "command": "команда",
-  "deprecated": "устаревшая",
-  "deprecated: %s": "устаревшая: %s"
+  "deprecated": "устар.",
+  "deprecated: %s": "устар.: %s"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -42,5 +42,10 @@
   "Path to JSON config file": "Путь к файлу конфигурации JSON",
   "Show help": "Показать помощь",
   "Show version number": "Показать номер версии",
-  "Did you mean %s?": "Вы имели в виду %s?"
+  "Did you mean %s?": "Вы имели в виду %s?",
+  "Arguments %s and %s are mutually exclusive": "Аргументы %s и %s являются взаимоисключающими",
+  "Positionals:": "Позиционные аргументы:",
+  "command": "команда",
+  "deprecated": "устаревшая",
+  "deprecated: %s": "устаревшая: %s"
 }


### PR DESCRIPTION
Resolves #2180.

I’ll put my thoughts here so you can correct me.

```json
"Arguments %s and %s are mutually exclusive": "Аргументы %s и %s являются взаимоисключающими",
```

The translation is verified, see the [English](https://manpages.ubuntu.com/manpages/impish/en/man8/restorecon.8.html) (“`-p` and `-v` options are mutually exclusive”) and [Russian](https://manpages.ubuntu.com/manpages/impish/ru/man8/restorecon.8.html) (“параметры `-p` и `-v` являются взаимоисключающими”) Ubuntu man pages.

```json
"Positionals:": "Позиционные аргументы:",
```

There is no proper translation for the word “positionals”. That’s why the translation contains the noun (“Позиционные аргументы” means “Positional arguments”).

```json
"deprecated": "устарела",
"deprecated: %s": "устарела: %s"
```

The word “устаревшая” (deprecated) is a feminine adjective, because “команда” (command) and “опция” (option) are feminine nouns in Russian. (Is it possible to make a deprecated argument?)

We can use the adjective in most cases. For example, the phrases “Функция помечена как **устаревшая**” (“The function is marked as deprecated”), “Эта функция — **устаревшая**” (“This function is deprecated”), and “Это **устаревшая** функция” (“This is a deprecated function”) are perfectly correct. However, the past tense verb “устарела” seems more natural in the phrase “Эта функция устарела” (“This function has been deprecated”).