### PR TITLE
fix: add missing entries to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "files": [
     "browser.mjs",
+    "browser.d.ts",
     "index.cjs",
     "helpers/*.js",
     "helpers/*",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "helpers/*",
     "index.mjs",
     "yargs",
+    "yargs.mjs",
     "build",
     "locales",
     "LICENSE",


### PR DESCRIPTION
Due to the `yargs.mjs` file not being published, the fix merged with #2151 is not effective yet. This change should fix that.

```
Cannot find module './node_modules/yargs/yargs.mjs' imported from ./cli.js
```

_Edit:_ Also added missing `browser.d.ts`