### PR TITLE
fix: config array combine logic

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -638,17 +638,31 @@ export class CommandInstance {
           // any new aliases need to be placed in positionalMap, which
           // is used for validation.
           if (!positionalMap[key]) positionalMap[key] = parsed.argv[key];
+
           // Addresses: https://github.com/yargs/yargs/issues/1637
-          // If both positionals/options provided,
-          // and no default or config values were set for that key,
-          // and if at least one is an array: don't overwrite, combine.
+          // In most cases, positionals will overwrite existing values on argv.
+          // They will be combined if both positionals/options are provided, and at least one is array type
           if (
-            !this.isInConfigs(yargs, key) &&
-            !this.isDefaulted(yargs, key) &&
             Object.prototype.hasOwnProperty.call(argv, key) &&
             Object.prototype.hasOwnProperty.call(parsed.argv, key) &&
             (Array.isArray(argv[key]) || Array.isArray(parsed.argv[key]))
           ) {
+            if (this.isInConfigs(yargs, key)) {
+              const shouldCombineArrays =
+                yargs.getInternalMethods().getParserConfiguration()[
+                  'combine-arrays'
+                ] === true;
+              if (shouldCombineArrays) {
+                // TODO: remove config values from argv[key] and parsed.argv[key], then re-add one set
+              } else {
+                // TODO: remove config values from argv[key] and parsed.argv[key],
+                // unless those values were specifically passed as options/positionals.
+              }
+            }
+            if (!this.isDefaulted(yargs, key)) {
+              // TODO: remove default values from argv[key] and parsed.argv[key],
+              // unless those values were specifically passed as options/positionals
+            }
             argv[key] = ([] as string[]).concat(argv[key], parsed.argv[key]);
           } else {
             argv[key] = parsed.argv[key];

--- a/test/command.cjs
+++ b/test/command.cjs
@@ -246,7 +246,7 @@ describe('Command', () => {
     });
 
     it('does not combine positional default and provided values', () => {
-      yargs()
+      yargs('cmd apples cherries grapes')
         .command({
           command: 'cmd [foods..]',
           desc: 'cmd desc',
@@ -261,7 +261,7 @@ describe('Command', () => {
             argv.foods.should.not.include('pizza');
           },
         })
-        .parse('cmd apples cherries grapes');
+        .parse();
     });
 
     it('does not combine config values and provided values', () => {
@@ -273,7 +273,7 @@ describe('Command', () => {
             yargs
               .option('arg-1', {type: 'string'})
               .option('arg-2', {type: 'string'})
-              .option('arg-3', {type: 'string'})
+              .option('arg-3', {type: 'array'})
               .config({
                 arg2: 'bar',
                 arg3: ['baz', 'qux'],
@@ -285,6 +285,39 @@ describe('Command', () => {
             argv['arg-3'].should.deep.equal(['baz', 'qux']);
           },
         })
+        .strict()
+        .parse();
+    });
+
+    it('correctly combines config values and provided values when combine-arrays is true', () => {
+      yargs('cmd1 a b2 c3 c4 --arg-3 c5 --arg-3 c6')
+        .command(
+          'cmd1 <arg-1> [arg-2] [arg-3..]',
+          'cmd1 description',
+          yargs =>
+            yargs
+              .parserConfiguration({
+                'combine-arrays': true,
+              })
+              .option('arg-1', {type: 'string'})
+              .option('arg-2', {type: 'string'})
+              .option('arg-3', {type: 'array', default: ['c0']})
+              .config({
+                arg2: 'b1',
+                arg3: ['c1', 'c2'],
+              }),
+          argv => {
+            argv.arg1.should.equal('a');
+            argv['arg-1'].should.equal('a');
+
+            argv.arg2.should.equal('b2');
+            argv['arg-2'].should.equal('b2');
+
+            const arrayValues = ['c5', 'c6', 'c1', 'c2', 'c3', 'c4'];
+            argv.arg3.should.deep.equal(arrayValues);
+            argv['arg-3'].should.deep.equal(arrayValues);
+          }
+        )
         .strict()
         .parse();
     });


### PR DESCRIPTION
## Description

I added a unit test to make sure that all the different scenarios around combining arrays work:
- `combine-array: true`
- config
- defaults
- positionals and options

I don't think it's possible to cover every scenario. 

More specifically, my problem is in `postProcessPositionals`. 
I need to know which values in `argv[key]` (options, config, and defaults), and `parsed.argv[key]` (positionals, config, and defaults) are passed by the user. 

Within the context of `postProcessPositionals`:
- I can figure out which values in `parsed.argv[key]` are positionals using `positionalMap`
- I can't figure out which values in `argv[key]` came from user-provided options. (At that moment, `argv` has values from the first run through yargs-parser.) I can compare `options.configObjects` and `options.default` to `argv[key]`, and remove them if they match exactly. The problem is, if the user provided the same values as the default or config, I would accidentally remove those values (because I don't think I can tell the difference).
- `combine-array: true` adds more complexity, as I would need to make sure that there is only one copy of the default values (but both `argv[key]` and `parsed.argv[key]` will both have those values appended to the end.)


## Questions

Do you have an idea how to make this work without a lot of changes to the parser?

I saw that you were experimenting with using parseArgs instead of yargs-parser. Would that change help fix any of the pain points around array options / variadic args? 

I feel like many of the bugs around array values come from the first parser run being positional-agnostic, and the second parser run being option-agnostic. Does that make sense?

## Different approach

At first I wanted to be flexible with a user providing both positional and optional args under the same namespace, but it causes unnecessary complexity and buggy behavior to try and support both. Would it be too heavy-handed to give a warning or throw an error if someone does this? Would it be a more reasonable solution?
