### PR TITLE
fix(lang): typo in Finnish unknown argument singular form

### DIFF
--- a/locales/fi.json
+++ b/locales/fi.json
@@ -30,7 +30,7 @@
     "other": "Pakollisia argumentteja puuttuu: %s"
   },
   "Unknown argument: %s": {
-    "one": "Tuntematon argumenttn: %s",
+    "one": "Tuntematon argumentti: %s",
     "other": "Tuntemattomia argumentteja: %s"
   },
   "Invalid values:": "Virheelliset arvot:",


### PR DESCRIPTION
Fixed a typo in the singular unknown argument message (argumenttn -> argumentti). 