### PR TITLE
fix(deps): update dependency yargs-parser to v21.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "require-directory": "^2.1.1",
     "string-width": "^4.2.3",
     "y18n": "^5.0.5",
-    "yargs-parser": "^21.0.0"
+    "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",


### PR DESCRIPTION
Currently `yargs` is not usable in Deno when using`.env()` because `Deno.env.toObject()` is not returned, causing a fatal error.

This was fixed in https://github.com/yargs/yargs-parser/pull/432 and released in yargs-parser v21.0.1.

This dependency bump will fix `.env` in `yargs` for Deno users.