### PR TITLE
fix(typescript): address warning with objectKeys

### DIFF
--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -61,7 +61,7 @@ export function assertSingleKey(
 /**
  * Typing wrapper around Object.keys()
  */
-export function objectKeys<T>(object: T) {
+export function objectKeys<T extends {}>(object: T) {
   return Object.keys(object) as (keyof T)[];
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/yargs/yargs/issues/2236, by following the suggestion of the Typescript compiler.