### PR TITLE
fix(lang): fix "Not enough non-option arguments" message for the Czech language

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -15,7 +15,7 @@
   "generated-value": "generovaná-hodnota",
   "Not enough non-option arguments: got %s, need at least %s": {
     "one": "Nedostatek argumentů: zadáno %s, je potřeba alespoň %s",
-    "other": "Nedostatek argumentů: zadáno %s, je potřeba alespoň %s",
+    "other": "Nedostatek argumentů: zadáno %s, je potřeba alespoň %s"
   },
   "Too many non-option arguments: got %s, maximum of %s": {
     "one": "Příliš mnoho argumentů: zadáno %s, maximálně %s",


### PR DESCRIPTION
Removing an extra comma at the end of the line.