### PR TITLE
Remove stream.isTTY check around setBlocking logic

### DIFF
--- a/lib/utils/set-blocking.ts
+++ b/lib/utils/set-blocking.ts
@@ -10,11 +10,7 @@ export default function setBlocking(blocking: boolean) {
   if (typeof process === 'undefined') return;
   [process.stdout, process.stderr].forEach(_stream => {
     const stream = _stream as any as WriteStreamWithHandle;
-    if (
-      stream._handle &&
-      stream.isTTY &&
-      typeof stream._handle.setBlocking === 'function'
-    ) {
+    if (stream._handle && typeof stream._handle.setBlocking === 'function') {
       stream._handle.setBlocking(blocking);
     }
   });


### PR DESCRIPTION
This didn't seem to fix the truncation issue. See https://github.com/yargs/yargs/issues/2118#issuecomment-1286356639