### PR TITLE
:bug: FIX: esm version to build with vite

### DIFF
--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -10,7 +10,7 @@ import Parser from 'yargs-parser'
 import { basename, dirname, extname, relative, resolve } from 'path'
 import { getProcessArgvBin } from '../../build/lib/utils/process-argv.js'
 import { YError } from '../../build/lib/yerror.js'
-import y18n from 'y18n'
+import * as y18n from 'y18n'
 
 const REQUIRE_ERROR = 'require is not supported by ESM'
 const REQUIRE_DIRECTORY_ERROR = 'loading a directory of commands is not supported yet for ESM'


### PR DESCRIPTION
I'm using vite & pnpm in a project to bundle everything (a lot of libs are involved)
But during the `build` process I get:

```bash
Error: 'default' is not exported by .../y18n@5.0.8/node_modules/y18n/build/lib/index.js, 
imported by .../yargs@17.6.2/node_modules/yargs/lib/platform-shims/esm.mjs
```

I think that this `import * as y18n from 'y18n'` would fix the issue.

✅ Tests are still passing.