### PR TITLE
chore: add en strings for unknown command

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -33,6 +33,10 @@
     "one": "Unknown argument: %s",
     "other": "Unknown arguments: %s"
   },
+  "Unknown command: %s": {
+    "one": "Unknown command: %s",
+    "other": "Unknown commands: %s"
+  },
   "Invalid values:": "Invalid values:",
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Given: %s, Choices: %s",
   "Argument check failed: %s": "Argument check failed: %s",


### PR DESCRIPTION
Adds the unknown command strings to the `en` locale. This has no affect on the output, since they are the same as in the code! The intent is so people updating or creating other locales can see the strings available for localising.

Placing the strings after unknown argument in the same place as in the `fr` locale from #1560, which looks a good place.

Closes: #2259