### PR TITLE
fix: copy the description of the option to its alias in completion

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -258,7 +258,9 @@ export class Completion implements CompletionInstance {
     if (!this.zshShell) {
       completions.push(dashes + key);
     } else {
-      const desc = descs[key] || '';
+      const aliasKey = this?.aliases?.[key]?.[0];
+      const descFromAlias = aliasKey ? descs[aliasKey] : undefined;
+      const desc = descs[key] ?? descFromAlias ?? '';
       completions.push(
         dashes +
           `${key.replace(/:/g, '\\:')}:${desc.replace('__yargsString__:', '')}`

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -258,7 +258,10 @@ export class Completion implements CompletionInstance {
     if (!this.zshShell) {
       completions.push(dashes + key);
     } else {
-      const aliasKey = this?.aliases?.[key]?.[0];
+      const aliasKey = this?.aliases?.[key].find(alias => {
+        const desc = descs[alias];
+        return typeof desc === 'string' && desc.length > 0;
+      });
       const descFromAlias = aliasKey ? descs[aliasKey] : undefined;
       const desc = descs[key] ?? descFromAlias ?? '';
       completions.push(

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -1055,6 +1055,27 @@ describe('Completion', () => {
       r.logs.should.include('--help:Show help');
     });
 
+    it('completes options and alias with the same description', () => {
+      process.env.SHELL = '/bin/zsh';
+      const r = checkUsage(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', '-'])
+            .options({
+              foo: {describe: 'Foo option', alias: 'f', type: 'string'},
+              bar: {describe: 'Bar option', alias: 'b', type: 'string'},
+            })
+            .help(false)
+            .version(false)
+            .completion().argv
+      );
+
+      r.logs.should.have.length(4);
+      r.logs.should.include('--foo:Foo option');
+      r.logs.should.include('-f:Foo option');
+      r.logs.should.include('--bar:Bar option');
+      r.logs.should.include('-b:Bar option');
+    });
+
     it('replaces application variable with $0 in script', () => {
       process.env.SHELL = '/bin/zsh';
       const r = checkUsage(() => yargs([]).showCompletionScript(), ['ndm']);

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -1055,7 +1055,7 @@ describe('Completion', () => {
       r.logs.should.include('--help:Show help');
     });
 
-    it('completes options and alias with the same description', () => {
+    it('completes options and aliases with the same description', () => {
       process.env.SHELL = '/bin/zsh';
       const r = checkUsage(
         () =>

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -1062,18 +1062,19 @@ describe('Completion', () => {
           yargs(['./completion', '--get-yargs-completions', '-'])
             .options({
               foo: {describe: 'Foo option', alias: 'f', type: 'string'},
-              bar: {describe: 'Bar option', alias: 'b', type: 'string'},
+              bar: {describe: 'Bar option', alias: ['b', 'B'], type: 'string'},
             })
             .help(false)
             .version(false)
             .completion().argv
       );
 
-      r.logs.should.have.length(4);
+      r.logs.should.have.length(5);
       r.logs.should.include('--foo:Foo option');
       r.logs.should.include('-f:Foo option');
       r.logs.should.include('--bar:Bar option');
       r.logs.should.include('-b:Bar option');
+      r.logs.should.include('-B:Bar option');
     });
 
     it('replaces application variable with $0 in script', () => {


### PR DESCRIPTION
This PR fixes https://github.com/yargs/yargs/issues/2268.  
I find the original option for the alias and copy its description to the alias.
As a result, the option and its alias are collected together and aligned in the completion.