### PR TITLE
docs: Fix example of coerce

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -198,13 +198,14 @@ all other modifications, such as [`.normalize()`](#normalize).
 _Examples:_
 
 ```js
-var fs = require('fs').promises
-var argv = await require('yargs/yargs')(process.argv.slice(2))
+import { readFile } from 'node:fs/promises';
+import yargs from 'yargs';
+const argv = await yargs(process.argv.slice(2))
   .coerce('file', async (arg) => {
-    var content = await fs.readFile(arg, 'utf8')
-    return content
+    const content = await readFile(arg, 'utf8');
+    return JSON.parse(content);
   })
-  .argv
+  .parseAsync();
 ```
 
 Optionally `.coerce()` can take an object that maps several keys to their

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,9 +198,10 @@ all other modifications, such as [`.normalize()`](#normalize).
 _Examples:_
 
 ```js
+var fs = require('fs').promises
 var argv = require('yargs/yargs')(process.argv.slice(2))
-  .coerce('file', function (arg) {
-    return await require('fs').promises.readFile(arg, 'utf8')
+  .coerce('file', arg => {
+    return fs.readFile(arg, 'utf8')
   })
   .argv
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -199,7 +199,7 @@ _Examples:_
 
 ```js
 var fs = require('fs').promises
-var argv = require('yargs/yargs')(process.argv.slice(2))
+var argv = await require('yargs/yargs')(process.argv.slice(2))
   .coerce('file', async (arg) => {
     var content = await fs.readFile(arg, 'utf8')
     return content

--- a/docs/api.md
+++ b/docs/api.md
@@ -200,8 +200,9 @@ _Examples:_
 ```js
 var fs = require('fs').promises
 var argv = require('yargs/yargs')(process.argv.slice(2))
-  .coerce('file', arg => {
-    return fs.readFile(arg, 'utf8')
+  .coerce('file', async (arg) => {
+    var content = await fs.readFile(arg, 'utf8')
+    return content
   })
   .argv
 ```


### PR DESCRIPTION
The first example of [`.coerce(key, fn)`](https://yargs.js.org/docs/#api-reference-coercekey-fn) is invalid: an `await` is used in a non-`async` function.

```js
var argv = require('yargs/yargs')(process.argv.slice(2))
  .coerce('file', function (arg) {
    return await require('fs').promises.readFile(arg, 'utf8')
  })
  .argv
```