### PR TITLE
    fix: do not crash completion when having negable options

### DIFF
--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -1139,6 +1139,28 @@ describe('Completion', () => {
       r.logs.should.include('--foo:bar');
     });
 
+    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+      process.env.SHELL = '/bin/zsh';
+
+      const r = checkUsage(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', '--'])
+            .options({
+              foo: {describe: 'foo flag', type: 'boolean', default: true},
+              bar: {describe: 'bar flag', type: 'boolean'},
+            })
+            .parserConfiguration({'boolean-negation': true}).argv
+      );
+
+      r.logs.should.eql([
+        '--help:Show help',
+        '--version:Show version number',
+        '--foo:foo flag',
+        '--no-foo:foo flag',
+        '--bar:bar flag',
+      ]);
+    });
+
     it('bails out early when full command matches', () => {
       process.env.SHELL = '/bin/zsh';
       const r = checkUsage(() => {


### PR DESCRIPTION

  
  Current completion crashes when using ZSH and having negable options.
  
  ```
  [error] TypeError: Cannot read properties of undefined (reading 'find')
      at D.completeOptionKey (//node_modules/yargs/build/index.cjs:1255:20)
      at //node_modules/yargs/build/index.cjs:1191:37
      at Array.forEach (<anonymous>)
      at D.optionCompletions (//node_modules/yargs/build/index.cjs:1184:26)
      at D.defaultCompletion (//node_modules/yargs/build/index.cjs:1158:12)
      at n (//node_modules/yargs/build/index.cjs:1313:23)
      at D.getCompletion (//node_modules/yargs/build/index.cjs:1314:31)
      at te.[runYargsParserAndExecuteCommands] (//node_modules/yargs/build/index.cjs:3161:27)
      at _.parseAndUpdateUsage (//node_modules/yargs/build/index.cjs:426:8)
      at _.applyBuilderUpdateUsageAndParse (//node_modules/yargs/build/index.cjs:412:17)
  ```
