### PR TITLE
chore: remove unused coveralls dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
     "concurrently": "^7.6.0",
-    "coveralls": "^3.0.9",
     "cpr": "^3.0.1",
     "cross-env": "^7.0.2",
     "cross-spawn": "^7.0.0",


### PR DESCRIPTION
There are multiple warnings during `npm install` in this repo about stale dependencies that turn out to be due to `coveralls`.

For example:
```
$ npm install
...
npm WARN deprecated har-validator@5.1.5: this library is no longer supported


$ npm ls har-validator
yargs@17.7.2 /Users/john/Documents/Sandpits/yargs/my-yargs
└─┬ coveralls@3.1.1
  └─┬ request@2.88.2
    └── har-validator@5.1.5

```

`coveralls` was removed from the coverage workflow in #1578.

So remove `coveralls` as a dependency.