### PR TITLE
docs: missing return in usage builder function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1685,7 +1685,7 @@ to provide configuration for the positional arguments accepted by your program:
 ```js
 const argv = require('yargs/yargs')(process.argv.slice(2))
   .usage('$0 <port>', 'start the application server', (yargs) => {
-    yargs.positional('port', {
+    return yargs.positional('port', {
       describe: 'the port that your application should bind to',
       type: 'number'
     })


### PR DESCRIPTION
A Typescript error was reported which was due to a missing return in a builder function for a `.usage()` call based on the example code. I did not do a deep dive into whether the TypeScript was correct, but the main builder function example has a return so it seemed pretty likely the return is expected for usage too.

Closes: #2321