### PR TITLE
fix: parser-configuration should work well with generated completion script

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2058,7 +2058,16 @@ export class YargsInstance {
       this.#isGlobalContext = false;
 
       const handlerKeys = this.#command.getCommands();
-      const requestCompletions = this.#completion!.completionKey in argv;
+
+      const requestCompletions = this.#completion?.completionKey
+        ? [
+            this.#completion?.completionKey,
+            ...(this.getAliases()[this.#completion?.completionKey] ?? []),
+          ].some((key: string) =>
+            Object.prototype.hasOwnProperty.call(argv, key)
+          )
+        : false;
+
       const skipRecommendation = helpOptSet || requestCompletions || helpOnly;
       if (argv._.length) {
         if (handlerKeys.length) {

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1191,17 +1191,24 @@ describe('Completion', () => {
   });
 
   describe('parser-configuration', () => {
-    it('should support strip-dashed', () => {
-      process.env.SHELL = '/bin/bash';
+    const configurations = [
+      {'strip-dashed': true},
+      {'camel-case-expansion': true, 'strip-aliased': true},
+    ];
 
-      const r = checkUsage(
-        () =>
-          yargs(['--get-yargs-completions', 'a'])
-            .parserConfiguration({'strip-dashed': true})
-            .command('apple', 'banana').argv
-      );
+    for (const configuration of configurations) {
+      it(`should support ${Object.keys(configuration).join(' ')}`, () => {
+        process.env.SHELL = '/bin/bash';
 
-      r.logs.should.include('apple');
-    });
+        const r = checkUsage(
+          () =>
+            yargs(['--get-yargs-completions', 'a'])
+              .parserConfiguration(configuration)
+              .command('apple', 'banana').argv
+        );
+
+        r.logs.should.include('apple');
+      });
+    }
   });
 });

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1200,7 +1200,7 @@ describe('Completion', () => {
       it(`should support ${Object.keys(configuration).join(' ')}`, () => {
         process.env.SHELL = '/bin/bash';
 
-        const r = checkUsage(
+        const r = checkOutput(
           () =>
             yargs(['--get-yargs-completions', 'a'])
               .parserConfiguration(configuration)

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1189,4 +1189,19 @@ describe('Completion', () => {
       });
     });
   });
+
+  describe('parser-configuration', () => {
+    it('should support strip-dashed', () => {
+      process.env.SHELL = '/bin/bash';
+
+      const r = checkUsage(
+        () =>
+          yargs(['--get-yargs-completions', 'a'])
+            .parserConfiguration({'strip-dashed': true})
+            .command('apple', 'banana').argv
+      );
+
+      r.logs.should.include('apple');
+    });
+  });
 });


### PR DESCRIPTION
There is an incompatibility between the parser configuration options and the completion feature within yargs. Setting strip-dashed: true in the parser configuration causes the completion feature to fail.

This is because the completion feature relies on passing '--get-yargs-completions' verbatim to yargs. Within the [Completion class](https://github.com/yargs/yargs/blob/main/lib/completion.ts?rgh-link-date=2023-05-08T17%3A03%3A24Z), the completionKey is explicitly set to get-yargs-completions. Within the YargsInstance, we explicitly check the following condition: completionKey in argv, in this location: [main/lib/yargs-factory.ts#L2054](https://github.com/yargs/yargs/blob/main/lib/yargs-factory.ts?rgh-link-date=2023-05-08T17%3A03%3A24Z#L2054)

Since the argv has been parsed already at this point, the argument is now 'getYargsCompletions' instead of 'get-yargs-completions'. This causes the completion feature to never be called.

Fixes: #2330
