### PR TITLE
fix: setting `default: undefined` causes implies to throw

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -328,7 +328,7 @@ export function validation(
     return implied;
   };
 
-  function keyExists(argv: Arguments, val: any): any {
+  function keyDefined(argv: Arguments, val: any): any {
     // convert string '1' to number 1
     const num = Number(val);
     val = isNaN(num) ? val : num;
@@ -339,10 +339,14 @@ export function validation(
     } else if (val.match(/^--no-.+/)) {
       // check if key/value doesn't exist
       val = val.match(/^--no-(.+)/)[1];
-      val = !Object.prototype.hasOwnProperty.call(argv, val);
+      val =
+        !Object.prototype.hasOwnProperty.call(argv, val) ||
+        argv[val] === undefined;
     } else {
       // check if key/value exists
-      val = Object.prototype.hasOwnProperty.call(argv, val);
+      val =
+        Object.prototype.hasOwnProperty.call(argv, val) &&
+        argv[val] !== undefined;
     }
     return val;
   }
@@ -355,8 +359,8 @@ export function validation(
       (implied[key] || []).forEach(value => {
         let key = origKey;
         const origValue = value;
-        key = keyExists(argv, key);
-        value = keyExists(argv, value);
+        key = keyDefined(argv, key);
+        value = keyDefined(argv, value);
 
         if (key && !value) {
           implyFail.push(` ${origKey} -> ${origValue}`);

--- a/test/validation.cjs
+++ b/test/validation.cjs
@@ -191,6 +191,19 @@ describe('validation tests', () => {
       failCalled.should.equal(true);
     });
 
+    it("doesn't fail if implied key exists with value undefined", () => {
+      yargs()
+        .option('foo', {
+          type: 'string',
+          default: undefined,
+        })
+        .implies('foo', 'bar')
+        .fail(() => {
+          expect.fail();
+        })
+        .parse();
+    });
+
     it("doesn't fail if implied key exists with value 0", () => {
       yargs('--foo --bar 0')
         .implies('foo', 'bar')


### PR DESCRIPTION
When setting `.implies(key, otherKey)`, yargs will throw always throw a validation error if `key` has a default set, even if the default is `undefined`.

I do concede that setting an explicit default of `undefined` is a bit weird, but this is something I came across while setting up better validations in a codebase that already had yargs configured. In my case, I did just remove the default, but it seemed like something that shouldn't have necessarily been needed to change.

If you think this is unnecessary, I can close it out.