### PR TITLE
feat: add prolog option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1442,6 +1442,19 @@ Valid `opt` keys include:
       - `'number'`: synonymous for `number: true`, see [`number()`](#number)
       - `'string'`: synonymous for `string: true`, see [`string()`](#string)
 
+.prolog(str)
+------------
+.prologue(str)
+--------------
+
+A message to print at the beginning of the usage instructions,
+just after the header, e.g.
+
+```js
+var argv = require('yargs/yargs')(process.argv.slice(2))
+  .prologue('HTTP download tool.')
+```
+
 .recommendCommands()
 ---------------------------
 

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -151,6 +151,11 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   };
   self.getDescriptions = () => descriptions;
 
+  let prologs: string[] = [];
+  self.prolog = msg => {
+    prologs.push(msg);
+  };
+
   let epilogs: string[] = [];
   self.epilog = msg => {
     epilogs.push(msg);
@@ -232,6 +237,14 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         }
         ui.div(`${u}`);
       }
+    }
+
+    // the prolog.
+    if (prologs.length > 0) {
+      const p = prologs
+        .map(prolog => prolog.replace(/\$0/g, base$0))
+        .join('\n');
+      ui.div(`${p}\n`);
     }
 
     // your application's commands, i.e., non-option
@@ -702,6 +715,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
     failureOutput = false;
     usages = [];
     usageDisabled = false;
+    prologs = [];
     epilogs = [];
     examples = [];
     commands = [];
@@ -716,6 +730,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
       failureOutput,
       usages,
       usageDisabled,
+      prologs,
       epilogs,
       examples,
       commands,
@@ -734,6 +749,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
       commands = [...frozen.commands, ...commands];
       usages = [...frozen.usages, ...usages];
       examples = [...frozen.examples, ...examples];
+      prologs = [...frozen.prologs, ...prologs];
       epilogs = [...frozen.epilogs, ...epilogs];
     } else {
       ({
@@ -741,6 +757,7 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
         failureOutput,
         usages,
         usageDisabled,
+        prologs,
         epilogs,
         examples,
         commands,
@@ -779,6 +796,7 @@ export interface UsageInstance {
   getUsageDisabled(): boolean;
   getWrap(): number | nil;
   help(): string;
+  prolog(msg: string): void;
   reset(localLookup: Dictionary<boolean>): UsageInstance;
   showHelp(level?: 'error' | 'log' | ((message: string) => void)): void;
   showHelpOnFail(enabled?: boolean | string, message?: string): UsageInstance;
@@ -803,6 +821,7 @@ export interface FrozenUsageInstance {
   failureOutput: boolean;
   usages: [string, string][];
   usageDisabled: boolean;
+  prologs: string[];
   epilogs: string[];
   examples: [string, string][];
   commands: [string, string, boolean, string[], boolean][];

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1236,6 +1236,14 @@ export class YargsInstance {
     this.group(key, this.#usage.getPositionalGroupName());
     return this.option(key, opts);
   }
+  prologue(msg: string): YargsInstance {
+    argsert('<string>', [msg], arguments.length);
+    this.#usage.prolog(msg);
+    return this;
+  }
+  prolog(msg: string): YargsInstance {
+    return this.prologue(msg);
+  }
   recommendCommands(recommend = true): YargsInstance {
     argsert('[boolean]', [recommend], arguments.length);
     this.#recommendCommands = recommend;

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -3241,6 +3241,74 @@ describe('usage tests', () => {
     });
   });
 
+  describe('prologue', () => {
+    it('should display a prolog message at the beginning of the usage instructions', () => {
+      const r = checkUsage(() =>
+        yargs('').prolog('HTTP download tool.').demand('y').wrap(null).parse()
+      );
+
+      r.errors
+        .join('\n')
+        .split(/\n+/)
+        .should.deep.equal([
+          'HTTP download tool.',
+          'Options:',
+          '      --help     Show help  [boolean]',
+          '      --version  Show version number  [boolean]',
+          '  -y  [required]',
+          'Missing required argument: y',
+        ]);
+    });
+
+    it('supports multiple prologs', () => {
+      const r = checkUsage(() =>
+        yargs('')
+          .prolog('HTTP download tool.')
+          .prolog('for bringing the web to you')
+          .prolog('at light speed')
+          .demand('y')
+          .wrap(null)
+          .parse()
+      );
+
+      r.errors
+        .join('\n')
+        .split(/\n+/)
+        .should.deep.equal([
+          'HTTP download tool.',
+          'for bringing the web to you',
+          'at light speed',
+          'Options:',
+          '      --help     Show help  [boolean]',
+          '      --version  Show version number  [boolean]',
+          '  -y  [required]',
+          'Missing required argument: y',
+        ]);
+    });
+
+    it('replaces $0 in prolog string', () => {
+      const r = checkUsage(() =>
+        yargs('')
+          .prolog("Try '$0 --long-help' for more information")
+          .demand('y')
+          .wrap(null)
+          .parse()
+      );
+
+      r.errors
+        .join('\n')
+        .split(/\n+/)
+        .should.deep.equal([
+          "Try 'usage --long-help' for more information",
+          'Options:',
+          '      --help     Show help  [boolean]',
+          '      --version  Show version number  [boolean]',
+          '  -y  [required]',
+          'Missing required argument: y',
+        ]);
+    });
+  });
+
   describe('showHelp', () => {
     // see #143.
     it('should show help regardless of whether argv has been called', () => {


### PR DESCRIPTION
Adds a prolog option, for a tagline under the program header. Named prolog for parity with epilog, and because description already has multiple other meanings. This works for me in a local patched version.

Possible solution to #2337.

```js
yargs(..)
  .scriptName('gadget')
  .prolog('Never eat a pirate. He'll spend the rest of his afterlife hunting you.')
```

```
gadget <command>

Never eat a pirate. He'll spend the rest of his afterlife hunting you.

Commands:
  gadget mix   Mix it up well
  gadget stir  Stir a little

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Not enough non-option arguments: got 0, need at least 1
```