### PR TITLE
Fix/missing command module array type

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -29,6 +29,11 @@ import whichModule from './utils/which-module.js';
 
 const DEFAULT_MARKER = /(^\*)|(^\$0)/;
 export type DefinitionOrCommandName = string | CommandHandlerDefinition;
+export type CommandInput =
+  | string
+  | CommandHandlerDefinition
+  | string[]
+  | CommandHandlerDefinition[];
 
 export class CommandInstance {
   shim: PlatformShim;
@@ -84,7 +89,7 @@ export class CommandInstance {
     this.shim.requireDirectory({require: req, filename: callerFile}, dir, opts);
   }
   addHandler(
-    cmd: string | CommandHandlerDefinition | DefinitionOrCommandName[],
+    cmd: CommandInput,
     description?: CommandHandler['description'],
     builder?: CommandBuilderDefinition | CommandBuilder,
     handler?: CommandHandlerCallback,
@@ -99,7 +104,7 @@ export class CommandInstance {
     // each handler individually:
     if (Array.isArray(cmd)) {
       if (isCommandAndAliases(cmd)) {
-        [cmd, ...aliases] = cmd;
+        [cmd, ...aliases] = cmd as [CommandHandlerDefinition, ...string[]];
       } else {
         for (const command of cmd) {
           this.addHandler(command);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -11,8 +11,7 @@ import {
   CommandBuilderDefinition,
   CommandBuilder,
   CommandHandlerCallback,
-  CommandHandlerDefinition,
-  DefinitionOrCommandName,
+  CommandInput,
 } from './command.js';
 import type {
   Dictionary,
@@ -504,7 +503,7 @@ export class YargsInstance {
     return this;
   }
   command(
-    cmd: string | CommandHandlerDefinition | DefinitionOrCommandName[],
+    cmd: CommandInput,
     description?: CommandHandler['description'],
     builder?: CommandBuilderDefinition | CommandBuilder,
     handler?: CommandHandlerCallback,
@@ -527,7 +526,7 @@ export class YargsInstance {
     return this;
   }
   commands(
-    cmd: string | CommandHandlerDefinition | DefinitionOrCommandName[],
+    cmd: CommandInput,
     description?: CommandHandler['description'],
     builder?: CommandBuilderDefinition | CommandBuilder,
     handler?: CommandHandlerCallback,


### PR DESCRIPTION
This PR fixes a missing type on `yargs` generated bundler. 

Looks like typescript is having issues while concatenating different subtypes. This is happening with `DefinitionOrCommandName` type while compiling 👀

As a result, types such as `cmd: string | CommandHandlerDefinition | DefinitionOrCommandName[]` are missing the `CommandHandlerDefinition[]` type case on the generated bundler. 

I tested this behaviour on `yargs` version `17.7.2`, but looks like this issue is still present.

Under this PR, this issue should be fixed as now the types will be more explicit and won't get lost on typescript compiler 🎉
