### PR TITLE
doc: switch legacy .argv to .parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm i yargs@next
 #!/usr/bin/env node
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
-const argv = yargs(hideBin(process.argv)).argv
+const argv = yargs(hideBin(process.argv)).parse()
 
 if (argv.ships > 3 && argv.distance < 53.5) {
   console.log('Plunder more riffiwobbles!')

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -18,7 +18,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
   .command('$0', 'the default command', () => {}, (argv) => {
     console.log('this command will be run by default')
   })
-  .argv
+  .parse()
 ```
 
 The command defined above will be executed if the program
@@ -31,7 +31,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
   .command(['serve', '$0'], 'the serve command', () => {}, (argv) => {
     console.log('this command will be run by default')
   })
-  .argv
+  .parse()
 ```
 
 The command defined above will be executed if the program
@@ -47,7 +47,7 @@ take the form `[bar]`. The parsed positional arguments will be populated in
 ```js
 yargs.command('get <source> [proxy]', 'make a get HTTP request')
   .help()
-  .argv
+  .parse()
 ```
 
 #### Positional Argument Aliases
@@ -59,7 +59,7 @@ an email as the first argument:
 ```js
 yargs.command('get <username|email> [password]', 'fetch a user by username or email.')
   .help()
-  .argv
+  .parse()
 ```
 
 In this way, both `argv.username` and `argv.email` would be populated with the
@@ -73,7 +73,7 @@ values, by using the `..` operator:
 ```js
 yargs.command('download <url> [files..]', 'download several files')
   .help()
-  .argv
+  .parse()
 ```
 
 #### Describing Positional Arguments
@@ -91,7 +91,7 @@ yargs.command('get <source> [proxy]', 'make a get HTTP request', (yargs) => {
   })
 })
 .help()
-.argv
+.parse()
 ```
 
 ### Command Execution
@@ -140,7 +140,7 @@ require('yargs/yargs')(process.argv.slice(2))
   .demandCommand()
   .help()
   .wrap(72)
-  .argv
+  .parse()
 ```
 
 ```
@@ -196,7 +196,7 @@ You then register the module like so:
 ```js
 yargs.command(require('my-module'))
   .help()
-  .argv
+  .parse()
 ```
 
 Or if the module does not export `command` and `describe` (or if you just want to override them):
@@ -204,7 +204,7 @@ Or if the module does not export `command` and `describe` (or if you just want t
 ```js
 yargs.command('get <source> [proxy]', 'make a get HTTP request', require('my-module'))
   .help()
-  .argv
+  .parse()
 ```
 
 #### Testing a Command Module
@@ -311,7 +311,7 @@ require('yargs/yargs')(process.argv.slice(2))
   .commandDir('cmds')
   .demandCommand()
   .help()
-  .argv
+  .parse()
 ```
 
 cmds/init.js:
@@ -391,7 +391,7 @@ import { commands } from './cmds/index.mjs';
 
 yargs(hideBin(process.argv))
   .command(commands)
-  .argv;
+  .parse();
 ```
 
 <a name="configuration"></a>
@@ -419,7 +419,7 @@ const configPath = findUp.sync(['.myapprc', '.myapprc.json'])
 const config = configPath ? JSON.parse(fs.readFileSync(configPath)) : {}
 const argv = require('yargs/yargs')(process.argv.slice(2))
   .config(config)
-  .argv
+  .parse()
 ```
 
 ### Providing Configuration in Your package.json
@@ -447,7 +447,7 @@ method:
 ```js
 const argv = require('yargs/yargs')(process.argv.slice(2))
   .pkgConf('nyc')
-  .argv
+  .parse()
 ```
 
 ### Creating a Plugin Architecture
@@ -552,13 +552,13 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       },
       [normalizeCredentials]
      )
-  .argv;
+  .parse();
 ```
 
 ## Using Yargs with Async/await
 
-If you use async middleware or async builders/handlers for commands, `yargs.parse` and
-`yargs.argv` will return a `Promise`. When you `await` this promise the
+If you use async middleware or async builders/handlers for commands, `yargs.parse()`
+will return a `Promise`. When you `await` this promise the
 parsed arguments object will be returned after the handler completes:
 
 ```js

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,22 +22,20 @@ You can pass Yargs the `process.argv` without any additional configuration
 and it will do its best to parse it into an object:
 
 ```javascript
-require('yargs/yargs')(process.argv.slice(2)).argv
+require('yargs/yargs')(process.argv.slice(2)).parse()
 ```
 
 You can also pass in an arbitrary array of arguments:
 
 ```javascript
-require('yargs/yargs')([ '-x', '1', '-y', '2' ]).argv
+require('yargs/yargs')([ '-x', '1', '-y', '2' ]).parse()
 ```
 
-or use `.parse()` to do the same thing:
+or pass the arguments to `.parse()` to do the same thing:
 
 ```javascript
 require('yargs/yargs')().parse([ '-x', '1', '-y', '2' ])
 ```
-
-Calling `.parse()` with no arguments is equivalent to calling `.argv`:
 
 ```javascript
 require('yargs/yargs')(process.argv.slice(2)).parse()
@@ -56,10 +54,10 @@ Node, pass `process.argv.slice(2)` to Yargs.
 
 ```javascript
 const { hideBin } = require('yargs/helpers')
-const argv = yargs(hideBin(process.argv)).argv
+const argv = yargs(hideBin(process.argv)).parse()
 ```
 
-The rest of these methods below come in just before the terminating `.argv` or
+The rest of these methods below come in just before the terminating
 terminating `.parse()`.
 
 <a name="alias"></a>.alias(key, alias)
@@ -72,7 +70,7 @@ Optionally `.alias()` can take an object that maps keys to aliases.
 Each key of this object should be the canonical version of the option, and each
 value should be a string or an array of strings.
 
-.argv
+.parse()
 -----
 
 Get the arguments as a plain old object.
@@ -81,13 +79,6 @@ Arguments without a corresponding flag show up in the `argv._` array. Note that 
 
 The script name or node command is available at `argv.$0` similarly to how `$0`
 works in bash or perl.
-
-If `yargs` is executed in an environment that embeds node and there's no script name (e.g.
-[Electron](http://electron.atom.io/) or [nw.js](http://nwjs.io/)), it will ignore the first parameter since it
-expects it to be the script name. In order to override this behavior, use `.parse(process.argv.slice(1))`
-instead of `.argv` and the first parameter won't be ignored.
-
-***Note:*** `.argv` should only be used at the top level, not inside a command's builder function.
 
 <a name="array"></a>.array(key)
 ----------
@@ -141,7 +132,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
       return true // tell Yargs that the arguments passed the check
     }
   })
-  .argv
+  .parse()
 ```
 
 <a name="choices"></a>.choices(key, choices)
@@ -156,7 +147,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   .describe('i', 'choose your sandwich ingredients')
   .choices('i', ['peanut-butter', 'jelly', 'banana', 'pickles'])
   .help('help')
-  .argv
+  .parse()
 ```
 
 If this method is called multiple times, all enumerated values will be merged
@@ -175,7 +166,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     describe: 'choose a size',
     choices: ['xs', 's', 'm', 'l', 'xl']
   })
-  .argv
+  .parse()
 ```
 
 <a name="coerce"></a>.coerce(key, fn)
@@ -217,7 +208,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     date: Date.parse,
     json: JSON.parse
   })
-  .argv
+  .parse()
 ```
 
 You can also map the same function to several keys at one time. Just pass an array of keys as the first argument to `.coerce()`:
@@ -226,7 +217,7 @@ You can also map the same function to several keys at one time. Just pass an arr
 var path = require('path')
 var argv = require('yargs/yargs')(process.argv.slice(2))
   .coerce(['src', 'dest'], path.resolve)
-  .argv
+  .parse()
 ```
 
 If you are using dot-notion or arrays, .e.g., `user.email` and `user.password`, coercion will be applied to the final object that has been parsed:
@@ -241,7 +232,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     opt.password = '[SECRET]'
     return opt
   })
-  .argv
+  .parse()
 ```
 
 <a name="commandDir"></a>
@@ -298,7 +289,7 @@ yargs
     }
   })
   .help()
-  .argv
+  .parse()
 ```
 
 `builder` can also be a function. This function is executed
@@ -316,7 +307,7 @@ yargs
     })
   })
   .help()
-  .argv
+  .parse()
 ```
 
 You can also provide a handler function, which will be executed with the
@@ -338,10 +329,10 @@ yargs
     }
   )
   .help()
-  .argv
+  .parse()
 ```
 
-***Note:*** `.parse()` and `.argv` should only be used at the top level, not inside a command's builder function.
+***Note:*** `.parse()` should only be used at the top level, not inside a command's builder function.
 
 Please see [Advanced Topics: Commands](https://github.com/yargs/yargs/blob/main/docs/advanced.md#commands) for a thorough
 discussion of the advanced features exposed in the Command API.
@@ -376,7 +367,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       'bar'
     ];
   })
-  .argv;
+  .parse();
 ```
 
 You can also provide asynchronous completions.
@@ -391,7 +382,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       ]);
     }, 500);
   })
-  .argv;
+  .parse();
 ```
 
 But wait, there's more! You can return an asynchronous promise.
@@ -405,7 +396,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       }, 10)
     })
   })
-  .argv;
+  .parse();
 ```
 
 Using default completions in a custom implementation. When invoked with no arguments, `completionFilter` will fallback to the default completion function. There is no need to call `done` in this case. When provided with a callback function, you can get access to `defaultCompletions` and call `done` with your processed version of them.
@@ -426,7 +417,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       });
     }
   })
-  .argv;
+  .parse();
 ```
 
 <a name="config"></a>.config([key], [description], [parseFn])
@@ -454,7 +445,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   .config('settings', function (configPath) {
     return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
   })
-  .argv
+  .parse()
 ```
 
 You can also pass an explicit configuration `object`, it will be parsed
@@ -463,7 +454,7 @@ and its properties will be set as arguments.
 ```js
 var argv = require('yargs/yargs')(process.argv.slice(2))
   .config({foo: 1, bar: 2})
-  .argv
+  .parse()
 console.log(argv)
 ```
 
@@ -544,7 +535,7 @@ a value. The name of the function will be used in the usage string:
 var argv = require('yargs/yargs')(process.argv.slice(2))
   .default('random', function randomValue() {
     return Math.random() * 256;
-  }).argv;
+  }).parse();
 ```
 
 Optionally, `description` can also be provided and will take precedence over
@@ -589,7 +580,7 @@ require('yargs/yargs')(process.argv.slice(2))
   })
   .demandOption(['run', 'path'], 'Please provide both run and path arguments to work with this tool')
   .help()
-  .argv
+  .parse()
 ```
 which will provide the following output:
 ```bash
@@ -626,7 +617,7 @@ require('yargs/yargs')(process.argv.slice(2))
     }
   })
   .help()
-  .argv
+  .parse()
 ```
 which will provide the following output:
 ```bash
@@ -659,7 +650,7 @@ require('yargs/yargs')(process.argv.slice(2))
   // provide a minimum demand and a minimum demand message
   .demandCommand(1, 'You need at least one command before moving on')
   .help()
-  .argv
+  .parse()
 ```
 
 which will provide the following output:
@@ -759,7 +750,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     alias: 'fruit-thing',
     default: 'apple'
   })
-  .argv
+  .parse()
 console.log(argv)
 ```
 
@@ -863,7 +854,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     console.error('You should be doing', yargs.help())
     process.exit(1)
   })
-  .argv
+  .parse()
 ```
 
 .getCompletion(args, done);
@@ -923,7 +914,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   })
   .help('help')
   .global('a')
-  .argv
+  .parse()
 ```
 
 If the `foo` command is executed the `all` option will remain, but the `none`
@@ -943,7 +934,7 @@ require('yargs/yargs')(['--help'])
   .group('batman', 'Heroes:')
   .describe('batman', "world's greatest detective")
   .wrap(null)
-  .argv
+  .parse()
 ```
 ***
     Heroes:
@@ -980,7 +971,7 @@ Example:
 var yargs = require("yargs")(['--info'])
   .usage("$0 -operand1 number -operand2 number -operation [add|subtract]")
   .help('info')
-  .argv
+  .parse()
 ```
 
 <a name="implies"></a>.implies(x, y)
@@ -1023,7 +1014,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   .help('help')
   .wrap(70)
   .locale('pirate')
-  .argv
+  .parse()
 ```
 
 ***
@@ -1093,7 +1084,7 @@ yargs
   .command('myCommand', 'some command', {}, function(argv){
     console.log('Running myCommand!');
   })
-  .middleware([mwFunc1, mwFunc2]).argv;
+  .middleware([mwFunc1, mwFunc2]).parse();
 ```
 
 When calling `myCommand` from the command line, mwFunc1 gets called first, then mwFunc2, and finally the command's handler.  The console output is:
@@ -1208,7 +1199,7 @@ Note that decimals, hexadecimals, and scientific notation are all accepted.
 var argv = require('yargs/yargs')(process.argv.slice(2))
   .number('n')
   .number(['width', 'height'])
-  .argv
+  .parse()
 ```
 
 <a name="option"></a>.option(key, [opt])
@@ -1231,7 +1222,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
         describe: 'x marks the spot',
         type: 'string'
     })
-    .argv
+    .parse()
 ;
 ```
 
@@ -1244,7 +1235,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .default('f', '/etc/passwd')
     .describe('f', 'x marks the spot')
     .string('f')
-    .argv
+    .parse()
 ;
 ```
 
@@ -1261,7 +1252,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
         type: 'string'
       }
     })
-    .argv
+    .parse()
 ;
 ```
 
@@ -1422,7 +1413,7 @@ const argv = require('yargs/yargs')('run --help')
       describe: 'a unique identifier for the server',
       type: 'string'
     })
-  }).argv
+  }).parse()
 console.log(argv)
 ```
 
@@ -1477,7 +1468,7 @@ Example:
 var yargs = require("yargs")
   .scriptName("my-script")
   .help()
-  .argv
+  .parse()
 ```
 
 .showCompletionScript()
@@ -1512,7 +1503,7 @@ If a function is specified, it is called with a single argument - the usage data
 yargs.showHelp(s => myStream.write(s)); //prints to myStream
 ```
 
-Later on, `argv` can be retrieved with `yargs.argv`.
+Later on, `argv` can be retrieved with `yargs.parse()`.
 
 .showVersion([consoleLevel | printCallback])
 ---------------------------
@@ -1539,7 +1530,7 @@ If a function is specified, it is called with a single argument - the version da
 yargs.showVersion(s => myStream.write(s)); //prints to myStream
 ```
 
-Later on, `argv` can be retrieved with `yargs.argv`.
+Later on, `argv` can be retrieved with `yargs.parse()`.
 
 .showHelpOnFail(enable, [message])
 ----------------------------------
@@ -1561,7 +1552,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .string('f')
     .showHelpOnFail(false, 'Specify --help for available options')
     .help('help')
-    .argv;
+    .parse();
 
 // etc.
 ```
@@ -1595,7 +1586,7 @@ Example:
 ```js
 var yargs = require("yargs")(['--help'])
   .showHidden('show-hidden', 'Show hidden options')
-  .argv
+  .parse()
 ```
 
 <a name="skipValidation"></a>.skipValidation(key)
@@ -1653,7 +1644,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     'Commands:': 'My Commands -->\n'
   })
   .wrap(null)
-  .argv
+  .parse()
 ```
 
 ***
@@ -1689,7 +1680,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
       describe: 'the port that your application should bind to',
       type: 'number'
     })
-  }).argv
+  }).parse()
 ```
 
 <a name="version"></a>

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -74,7 +74,7 @@ In a new project (see: [npm-init](https://docs.npmjs.com/cli/v7/commands/npm-ini
 2. Create the following **index.js**
 ```js
 const yargs = require('yargs')
-const argv = yargs(process.argv).argv
+const argv = yargs(process.argv).parse()
 
 if (argv.ships > 3 && argv.distance < 53.5) {
   console.log('Plunder more riffiwobbles!')

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,7 +11,7 @@ plunder.js:
 
 ```javascript
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 
 if (argv.ships > 3 && argv.distance < 53.5) {
     console.log('Plunder more riffiwobbles!');
@@ -35,7 +35,7 @@ short.js:
 
 ```javascript
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 console.log('(%d,%d)', argv.x, argv.y);
 ```
 
@@ -51,7 +51,7 @@ bool.js:
 
 ```javascript
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 
 if (argv.s) {
     process.stdout.write(argv.fr ? 'Le perroquet dit: ' : 'The parrot says: ');
@@ -79,7 +79,7 @@ nonopt.js:
 
 ```javascript
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 console.log('(%d,%d)', argv.x, argv.y);
 console.log(argv._);
 ```
@@ -104,7 +104,7 @@ count.js:
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .count('verbose')
     .alias('v', 'verbose')
-    .argv;
+    .parse();
 
 VERBOSE_LEVEL = argv.verbose;
 
@@ -145,7 +145,7 @@ area.js:
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .usage('Usage: $0 -w [num] -h [num]')
     .demandOption(['w','h'])
-    .argv;
+    .parse();
 
 console.log("The area is:", argv.w * argv.h);
 ```
@@ -173,7 +173,7 @@ demand_count.js:
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .demandCommand(2)
-    .argv;
+    .parse();
 console.dir(argv);
 ```
 
@@ -199,7 +199,7 @@ default_singles.js:
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .default('x', 10)
     .default('y', 10)
-    .argv
+    .parse()
 ;
 console.log(argv.x + argv.y);
 ```
@@ -215,7 +215,7 @@ default_hash.js:
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .default({ x : 10, y : 10 })
-    .argv
+    .parse()
 ;
 console.log(argv.x + argv.y);
 ```
@@ -234,7 +234,7 @@ boolean_single.js:
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .boolean(['r','v'])
-    .argv
+    .parse()
 ;
 console.dir([ argv.r, argv.v ]);
 console.dir(argv._);
@@ -253,7 +253,7 @@ boolean_double.js:
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .boolean(['x','y','z'])
-    .argv
+    .parse()
 ;
 console.dir([ argv.x, argv.y, argv.z ]);
 console.dir(argv._);
@@ -286,7 +286,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .help('h')
     .alias('h', 'help')
     .epilog('copyright 2019')
-    .argv;
+    .parse();
 
 var fs = require('fs');
 var s = fs.createReadStream(argv.file);
@@ -364,5 +364,6 @@ const argv = yargs(process.argv.splice(2))
   .command('sing', 'a classic yargs command without prompting', () => {}, sing)
   .demandCommand(1, 1, 'choose a command: ask or sing')
   .strict()
-  .help('h').argv;
+  .help('h')
+  .parse();
 ```

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -35,7 +35,7 @@ const argv = yargs(process.argv.slice(2)).options({
   d: { type: 'array' },
   e: { type: 'count' },
   f: { choices: ['1', '2', '3'] }
-}).argv;
+}).parse();
 ```
 
 Will result in an `argv` that's typed like so:
@@ -67,7 +67,7 @@ Will result in an `argv` that's typed like so:
 As you can see it's a union of the arguments and a promise which resolves to the arguments.
 The reason for this is because in yargs, you can have commands, and those commands can be asynchronous. If they are asynchronous, the parser would resolve after the command is finished.
 
-The reason it's a union is because when you call `.argv`, yargs typing doesn't know if you have any asynchronous commands, so it just gives both of them.
+The reason it's a union is because when you call `.parse()`, yargs typing doesn't know if you have any asynchronous commands, so it just gives both of them.
 
 This might result in some errors when accessing the properties:
 
@@ -75,7 +75,7 @@ This might result in some errors when accessing the properties:
 const argv = yargs(process.argv.slice(2)).options({
   a: { type: 'boolean', default: false },
   ...
-}).argv;
+}).parse();
 
 argv.a // => Property 'a' does not exist on type...
 ```
@@ -101,7 +101,7 @@ const parser = yargs(process.argv.slice(2)).options({
 
 
 (async() => {
-  const argv = await parser.argv;
+  const argv = await parser.parse();
   argv.a // => No error, type: boolean
 })();
 ```
@@ -134,7 +134,7 @@ const yargsInstance = yargs(hideBin(process.argv));
 cosnt args = yargsInstance
   .wrap(myYargs.terminalWidth())
   // .otherMethods(...)
-  .argv
+  .parse()
   
 ```
 
@@ -146,7 +146,7 @@ To improve the `choices` option typing you can also specify it as const:
 const argv = yargs.option('difficulty', {
   choices: ["normal", "nightmare", "hell"] as const,
   demandOption: true
-}).argv;
+}).parse();
 ```
 
 `argv.difficulty` will get  type `'normal' | 'nightmare' | 'hell'`.

--- a/example/bool.js
+++ b/example/bool.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 
 if (argv.s) {
     console.log(argv.fr ? 'Le chat dit: ' : 'The cat says: ');

--- a/example/boolean_double.js
+++ b/example/boolean_double.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .boolean(['x','y','z'])
-    .argv
+    .parse()
 ;
 console.dir([ argv.x, argv.y, argv.z ]);
 console.dir(argv._);

--- a/example/boolean_single.js
+++ b/example/boolean_single.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .boolean(['r','v'])
-    .argv
+    .parse()
 ;
 console.dir([ argv.r, argv.v ]);
 console.dir(argv._);

--- a/example/command_hierarchy.js
+++ b/example/command_hierarchy.js
@@ -3,4 +3,4 @@ require('yargs/yargs')(process.argv.slice(2))
   .commandDir('cmds')
   .demandCommand()
   .help()
-  .argv
+  .parse()

--- a/example/complex.js
+++ b/example/complex.js
@@ -27,7 +27,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
   // disable showing help on failures, provide a final message
   // to display for errors.
   .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
-  .argv;
+  .parse();
 
 // the parsed data is stored in argv.
 console.log(argv);

--- a/example/count.js
+++ b/example/count.js
@@ -2,7 +2,7 @@
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .count('verbose')
     .alias('v', 'verbose')
-    .argv;
+    .parse();
 
 VERBOSE_LEVEL = argv.verbose;
 

--- a/example/default_hash.js
+++ b/example/default_hash.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .default({ x : 10, y : 10 })
-    .argv
+    .parse()
 ;
 
 console.log(argv.x + argv.y);

--- a/example/default_singles.js
+++ b/example/default_singles.js
@@ -2,6 +2,6 @@
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .default('x', 10)
     .default('y', 10)
-    .argv
+    .parse()
 ;
 console.log(argv.x + argv.y);

--- a/example/demand_count.js
+++ b/example/demand_count.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .demand(2)
-    .argv;
+    .parse();
 console.dir(argv)

--- a/example/divide.js
+++ b/example/divide.js
@@ -2,6 +2,6 @@
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .usage('Usage: $0 -x [num] -y [num]')
     .demand(['x','y'])
-    .argv;
+    .parse();
 
 console.log(argv.x / argv.y);

--- a/example/help.js
+++ b/example/help.js
@@ -17,7 +17,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
       required: true
     }
   })
-  .argv;
+  .parse();
 
 console.log('Inspecting options');
 console.dir(argv);

--- a/example/implies.js
+++ b/example/implies.js
@@ -2,7 +2,7 @@
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .usage('Usage: $0 -x [num] -y [num]')
     .implies('x', 'y')
-    .argv;
+    .parse();
 
 if (argv.x) {
     console.log(argv.x / argv.y);

--- a/example/implies_hash.js
+++ b/example/implies_hash.js
@@ -6,7 +6,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
         w: '--no-h',
         1: 'h'
     })
-    .argv;
+    .parse();
 
 if (argv.x) {
     console.log('x / y : ' + (argv.x / argv.y));

--- a/example/line_count.js
+++ b/example/line_count.js
@@ -4,7 +4,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .demand('f')
     .alias('f', 'file')
     .describe('f', 'Load a file')
-    .argv
+    .parse()
 ;
 
 var fs = require('fs');

--- a/example/line_count_options.js
+++ b/example/line_count_options.js
@@ -13,7 +13,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
             default : 10,
         },
     })
-    .argv
+    .parse()
 ;
 
 var fs = require('fs');

--- a/example/line_count_wrap.js
+++ b/example/line_count_wrap.js
@@ -13,7 +13,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .default('b', 10)
     .describe('x', 'Super-secret optional parameter which is secret')
     .default('x', '')
-    .argv
+    .parse()
 ;
 
 var fs = require('fs');

--- a/example/nested.js
+++ b/example/nested.js
@@ -43,7 +43,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2)).command(
           console.log(`The sum of numbers is ${sum}`);
         }
       )
-).argv;
+).parse();
 
 console.log(argv);
 
@@ -51,4 +51,4 @@ function isArrayOfNumbers(arr) {
   return Array.isArray(arr) && arr.every(n => typeof n === 'number');
 }
 
-// NOTE: ".argv" and ".parse()" should only be used at top level, not inside builder functions.
+// NOTE: ".parse()" should only be used at top level, not inside builder functions.

--- a/example/nonopt.js
+++ b/example/nonopt.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 console.log('(%d,%d)', argv.x, argv.y);
 console.log(argv._);

--- a/example/requires_arg.js
+++ b/example/requires_arg.js
@@ -12,7 +12,7 @@ var argv = yargs.usage('This is my awesome program').options({
     requiresArg: true,
     alias: 'o',
   },
-}).argv;
+}).parse();
 
 yargs.showHelp();
 

--- a/example/short.js
+++ b/example/short.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 console.log('(%d,%d)', argv.x, argv.y);

--- a/example/strict.js
+++ b/example/strict.js
@@ -12,7 +12,7 @@ var argv = yargs.usage('This is my awesome program', {
     boolean: true,
     alias: 'i'
   }
-}).strict().argv;
+}).strict().parse();
 
 yargs.showHelp();
 

--- a/example/string.js
+++ b/example/string.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .string('x', 'y')
-    .argv
+    .parse()
 ;
 console.dir([ argv.x, argv.y ]);
 

--- a/example/usage-options.js
+++ b/example/usage-options.js
@@ -13,7 +13,7 @@ var argv = yargs.usage('This is my awesome program')
       boolean: true,
       alias: 'i'
     }
-  }).argv;
+  }).parse();
 
 yargs.showHelp();
 

--- a/example/xup.js
+++ b/example/xup.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var argv = require('yargs/yargs')(process.argv.slice(2)).argv;
+var argv = require('yargs/yargs')(process.argv.slice(2)).parse();
 
 if (argv.rif - 5 * argv.xup > 7.138) {
     console.log('Buy more riffiwobbles');

--- a/test/fixtures/no-extension
+++ b/test/fixtures/no-extension
@@ -7,4 +7,4 @@ var parser = require('../../')(process.argv.slice(2))
 console.log(parser.parserConfiguration({
     'dot-notation': false,
     'boolean-negation': false
-}).argv)
+}).parse())

--- a/test/fixtures/no-require-main.js
+++ b/test/fixtures/no-require-main.js
@@ -12,5 +12,5 @@ console.log(
   parser.parserConfiguration({
     'dot-notation': false,
     'boolean-negation': false,
-  }).argv
+  }).parse()
 );

--- a/test/fixtures/normal-bin.js
+++ b/test/fixtures/normal-bin.js
@@ -4,5 +4,5 @@
 const argv = require('../../').help('help').version().parserConfiguration({
   'dot-notation': false,
   'boolean-negation': false,
-}).argv;
+}).parse();
 console.log(argv);

--- a/test/fixtures/symlink-bin.js
+++ b/test/fixtures/symlink-bin.js
@@ -7,5 +7,5 @@ const argv = require('./yargs-symlink')
   .parserConfiguration({
     'dot-notation': false,
     'boolean-negation': false,
-  }).argv;
+  }).parse();
 console.log(argv);

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1019,8 +1019,7 @@ describe('usage tests', () => {
           .strict()
           .fail(msg => {
             return done();
-          })
-          .parse();
+          }).argv;
       });
 
       it('accepts valid options', () => {
@@ -4397,8 +4396,7 @@ describe('usage tests', () => {
             qux: {
               group: 'Shown:',
             },
-          })
-          .parse()
+          }).argv
       );
 
       r.logs[0]

--- a/test/usage.cjs
+++ b/test/usage.cjs
@@ -1019,7 +1019,8 @@ describe('usage tests', () => {
           .strict()
           .fail(msg => {
             return done();
-          }).argv;
+          })
+          .parse();
       });
 
       it('accepts valid options', () => {
@@ -4396,7 +4397,8 @@ describe('usage tests', () => {
             qux: {
               group: 'Shown:',
             },
-          }).argv
+          })
+          .parse()
       );
 
       r.logs[0]
@@ -4736,7 +4738,7 @@ describe('usage tests', () => {
             },
             {command: 'foo', desc: 'Foo command description'},
           ]);
-        await y.argv;
+        await y.parse();
         help.split('\n').should.deep.equal(expected);
       });
     });

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -2605,11 +2605,13 @@ describe('yargs dsl tests', () => {
 
   // See: https://github.com/yargs/yargs/issues/1098
   it('should allow array and requires arg to be used in conjunction', () => {
-    const argv = yargs(['-i', 'item1', 'item2', 'item3']).option('i', {
-      alias: 'items',
-      type: 'array',
-      requiresArg: true,
-    }).argv;
+    const argv = yargs(['-i', 'item1', 'item2', 'item3'])
+      .option('i', {
+        alias: 'items',
+        type: 'array',
+        requiresArg: true,
+      })
+      .parse();
     argv.items.should.eql(['item1', 'item2', 'item3']);
     argv.i.should.eql(['item1', 'item2', 'item3']);
   });


### PR DESCRIPTION
This PR is acting on notes in https://github.com/yargs/yargs/issues/2045#issuecomment-1445248108

The magic `yargs.argv` mystified me, until I found it is a getter. I have switched the user facing uses of `.argv` in documentation and examples to `.parse()`.

Supporting links for making the change:
- #2036 updated README
- https://github.com/yargs/yargs/issues/2068#issuecomment-1020344904
- https://github.com/yargs/yargs/blob/e517318cea0087b813f5de414b3cdec7b70efe33/lib/yargs-factory.ts#L72

I have not updated all the tests, as it was going to trigger big code reformats. On that note, this PR may clash miserably with #2172 and might need to redo one or the other! But should be easy to redo the formatting steps rather than do a cold merge.