### PR TITLE
Minor edit to documentation for option 'global' example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -908,8 +908,7 @@ is executed, as an example:
 var argv = require('yargs/yargs')(process.argv.slice(2))
   .option('a', {
     alias: 'all',
-    default: true,
-    global: false
+    default: true
   })
   .option('n', {
     alias: 'none',


### PR DESCRIPTION
The current example shows two different arguments with the same configuration and then explains how they should behave differently due to the default behaviour being used in that case.

This change removes the setting overriding the default behaviour, allowing the example to behave as expected.