### PR TITLE
Docs: Update the list of supported locales

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1047,9 +1047,11 @@ Ye be havin' to set the followin' argument land lubber: option
 Locales currently supported:
 
 * **be:** Belarusian.
+* **cs:** Czech.
 * **de:** German.
 * **en:** American English.
 * **es:** Spanish.
+* **fi:** Finnish.
 * **fr:** French.
 * **hi:** Hindi.
 * **hu:** Hungarian.
@@ -1065,9 +1067,10 @@ Locales currently supported:
 * **pt:** Portuguese.
 * **pt_BR:** Brazilian Portuguese.
 * **ru:** Russian.
-* **uz:** Uzbek.
 * **th:** Thai.
 * **tr:** Turkish.
+* **uk_UA:** Ukrainian (Ukraine).
+* **uz:** Uzbek.
 * **zh_CN:** Chinese (Mainland China).
 * **zh_TW:** Chinese (Taiwan).
 


### PR DESCRIPTION
I was on my way to creating _Ukrainian_ translation... but it was just missing in the list of supported languages in docs, along with _Czech_ and _Finnish_ ;)