### PR TITLE
chore: pin back TypeScript to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^2.0.4",
-    "typescript": "^4.0.2",
+    "typescript": "4.6.4",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"
   },


### PR DESCRIPTION
This is a quick fix to the build for an incompatibility between old TypeScript and old Rollup. Pin back the TypeScript version.

(Same fix as used in `cliui`: https://github.com/yargs/cliui/pull/143#issuecomment-1823917900)