### PR TITLE
docs: fix typos in .terminalWidth example

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -131,8 +131,8 @@ import { hideBin } from 'yargs/helpers';
 
 const yargsInstance = yargs(hideBin(process.argv));
 
-cosnt args = yargsInstance
-  .wrap(myYargs.terminalWidth())
+const args = yargsInstance
+  .wrap(yargsInstance.terminalWidth())
   // .otherMethods(...)
   .argv
   


### PR DESCRIPTION
Simple fix, prompted by investigation for #2381