### PR TITLE
fix: propagate Dictionary including undefined in value type

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1660,7 +1660,7 @@ export class YargsInstance {
   >(
     builder: (key: K, value: V, ...otherArgs: any[]) => YargsInstance,
     type: T,
-    key: K | K[] | {[key in K]: V},
+    key: K | K[] | {[key in K]: V | undefined},
     value?: V
   ) {
     this[kPopulateParserHintDictionary]<T, K, V>(
@@ -1704,7 +1704,7 @@ export class YargsInstance {
   >(
     builder: (key: K, value: V, ...otherArgs: any[]) => YargsInstance,
     type: T,
-    key: K | K[] | {[key in K]: V},
+    key: K | K[] | {[key in K]: V | undefined},
     value: V | undefined,
     singleKeyHandler: (type: T, key: K, value?: V) => void
   ) {


### PR DESCRIPTION
The value type we use with Dictionary type declarations often includes undefined. I am guessing this is more to ensure the value type is checked for a possibly unknown key than for setting a value of undefined, but paranoia is ok for either reason.

TypeScript 5.4.0 picks up a case where the `undefined` was not being used consistently,

```
lib/yargs-factory.ts:667:7 - error TS2345: Argument of type 'string | string[] | Dictionary<string | undefined>' is not assignable to parameter of type 'string | string[] | { [x: string]: string; }'.
  Type 'Dictionary<string | undefined>' is not assignable to type 'string | string[] | { [x: string]: string; }'.
    Type 'Dictionary<string | undefined>' is missing the following properties from type 'string[]': length, pop, push, concat, and 29 more.
```
