### PR TITLE
Merge rather than replace parserConfiguration

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1164,7 +1164,7 @@ export class YargsInstance {
   }
   parserConfiguration(config: Configuration) {
     argsert('<object>', [config], arguments.length);
-    this.#parserConfig = config;
+    this.#parserConfig = {...this.#parserConfig, ...config};
     return this;
   }
   pkgConf(key: string, rootPath?: string): YargsInstance {

--- a/test/yargs.cjs
+++ b/test/yargs.cjs
@@ -1870,6 +1870,15 @@ describe('yargs dsl tests', () => {
       argv.noBaz.should.equal(2);
     });
 
+    it('merges over any previously set parser configuration', () => {
+      const argv = yargs('--foo.bar 1 --no-baz 2')
+        .parserConfiguration({'boolean-negation': false, 'dot-notation': true})
+        .parserConfiguration({'dot-notation': false})
+        .parse();
+      expect(argv['foo.bar']).to.equal(1);
+      argv.noBaz.should.equal(2);
+    });
+
     it('supports --unknown-options-as-args', () => {
       const argv = yargs('--foo.bar 1 --no-baz 2')
         .parserConfiguration({'unknown-options-as-args': true})


### PR DESCRIPTION
Additional calls to `parserConfiguration` now merge into the existing configuration rather than replacing all unspecified keys with their default values. 

Addresses one of the items in #2414.

Seems modestly better than the old behavior, though it's technically a breaking change so maybe not worth it?
