### PR TITLE
fix: ensure completion script uses valid function name

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -5,30 +5,32 @@ export const completionShTemplate = `###-begin-{{app_name}}-completions-###
 # Installation: {{app_path}} {{completion_command}} >> ~/.bashrc
 #    or {{app_path}} {{completion_command}} >> ~/.bash_profile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{safe_app_name}}_yargs_completions()
 {
-    local cur_word args type_list
+    if [[ {{app_name_word_check}} ]]; then
+      local cur_word args type_list
 
-    cur_word="\${COMP_WORDS[COMP_CWORD]}"
-    args=("\${COMP_WORDS[@]}")
+      cur_word="\${COMP_WORDS[COMP_CWORD]}"
+      args=("\${COMP_WORDS[@]}")
 
-    # ask yargs to generate completions.
-    type_list=$({{app_path}} --get-yargs-completions "\${args[@]}")
+      # ask yargs to generate completions.
+      type_list=$({{app_path}} --get-yargs-completions "\${args[@]}")
 
-    COMPREPLY=( $(compgen -W "\${type_list}" -- \${cur_word}) )
+      COMPREPLY=( $(compgen -W "\${type_list}" -- \${cur_word}) )
 
-    # if no match was found, fall back to filename completion
-    if [ \${#COMPREPLY[@]} -eq 0 ]; then
-      COMPREPLY=()
+      # if no match was found, fall back to filename completion
+      if [ \${#COMPREPLY[@]} -eq 0 ]; then
+        COMPREPLY=()
+      fi
     fi
 
     return 0
 }
-complete -o bashdefault -o default -F _{{app_name}}_yargs_completions {{app_name}}
+complete -o bashdefault -o default -F _{{safe_app_name}}_yargs_completions {{app_name_first_word}}
 ###-end-{{app_name}}-completions-###
 `;
 
-export const completionZshTemplate = `#compdef {{app_name}}
+export const completionZshTemplate = `#compdef "{{safe_app_name}}"
 ###-begin-{{app_name}}-completions-###
 #
 # yargs command completion script
@@ -36,7 +38,7 @@ export const completionZshTemplate = `#compdef {{app_name}}
 # Installation: {{app_path}} {{completion_command}} >> ~/.zshrc
 #    or {{app_path}} {{completion_command}} >> ~/.zprofile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{safe_app_name}}_yargs_completions()
 {
   local reply
   local si=$IFS
@@ -44,6 +46,6 @@ _{{app_name}}_yargs_completions()
   IFS=$si
   _describe 'values' reply
 }
-compdef _{{app_name}}_yargs_completions {{app_name}}
+compdef _{{safe_app_name}}_yargs_completions "{{zsh_app_name}}"
 ###-end-{{app_name}}-completions-###
 `;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -18,6 +18,7 @@ type CompletionCallback = (
 /** Instance of the completion module. */
 export interface CompletionInstance {
   completionKey: string;
+  completionKeys: string[];
   generateCompletionScript($0: string, cmd: string): string;
   getCompletion(
     args: string[],
@@ -29,6 +30,10 @@ export interface CompletionInstance {
 
 export class Completion implements CompletionInstance {
   completionKey = 'get-yargs-completions';
+  // we need to handle the completion key in multiple formats because the
+  // `strip-dashed` parser option might remove the hyphenated version from the
+  // parsed arguments
+  completionKeys = [this.completionKey, 'getYargsCompletions'];
 
   private aliases: DetailedArguments['aliases'] | null = null;
   private customCompletionFunction: CompletionFunction | null = null;

--- a/lib/platform-shims/cjs.ts
+++ b/lib/platform-shims/cjs.ts
@@ -30,7 +30,7 @@ export default {
       process.emitWarning(warning, type),
     execPath: () => process.execPath,
     exit: (code: number) => {
-      // eslint-disable-next-line no-process-exit
+      // eslint-disable-next-line n/no-process-exit
       process.exit(code);
     },
     nextTick: process.nextTick,

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1660,7 +1660,7 @@ export class YargsInstance {
   >(
     builder: (key: K, value: V, ...otherArgs: any[]) => YargsInstance,
     type: T,
-    key: K | K[] | {[key in K]: V},
+    key: K | K[] | {[key in K]: V | undefined},
     value?: V
   ) {
     this[kPopulateParserHintDictionary]<T, K, V>(
@@ -1704,7 +1704,7 @@ export class YargsInstance {
   >(
     builder: (key: K, value: V, ...otherArgs: any[]) => YargsInstance,
     type: T,
-    key: K | K[] | {[key in K]: V},
+    key: K | K[] | {[key in K]: V | undefined},
     value: V | undefined,
     singleKeyHandler: (type: T, key: K, value?: V) => void
   ) {

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2001,11 +2001,17 @@ export class YargsInstance {
 
     let helpOptSet = false;
     let versionOptSet = false;
+    let requestCompletions = false;
     Object.keys(argv).forEach(key => {
       if (key === this.#helpOpt && argv[key]) {
         helpOptSet = true;
       } else if (key === this.#versionOpt && argv[key]) {
         versionOptSet = true;
+      } else if (
+        key in argv &&
+        this.#completion!.completionKeys.includes(key)
+      ) {
+        requestCompletions = true;
       }
     });
 
@@ -2054,7 +2060,6 @@ export class YargsInstance {
       this.#isGlobalContext = false;
 
       const handlerKeys = this.#command.getCommands();
-      const requestCompletions = this.#completion!.completionKey in argv;
       const skipRecommendation = helpOptSet || requestCompletions || helpOnly;
       if (argv._.length) {
         if (handlerKeys.length) {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "rollup": "^3.29.4",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-ts": "^3.4.5",
-    "typescript": "^5.3.3",
+    "typescript": "5.3.3",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"
   },

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -594,6 +594,22 @@ describe('Completion', () => {
 
           r.logs.should.have.length(0);
         });
+
+        it('works if strip-dashed is set to `true`', () => {
+          const r = checkUsage(
+            () =>
+              yargs([...firstArguments, './completion', '--foo', '--'])
+                .parserConfiguration({'strip-dashed': true})
+                .options({
+                  foo: {describe: 'foo option'},
+                  bar: {describe: 'bar option'},
+                })
+                .completion().argv
+          );
+
+          r.logs.should.include('--bar');
+          r.logs.should.not.include('--foo');
+        });
       });
     }
   });

--- a/test/completion.cjs
+++ b/test/completion.cjs
@@ -624,6 +624,37 @@ describe('Completion', () => {
       r.logs[0].should.match(/ndm flintlock >>/);
     });
 
+    describe('bash shell', () => {
+      it('generates multi-word completion handler', () => {
+        process.env.SHELL = '/bin/bash';
+        const r = checkUsage(() =>
+          yargs([]).scriptName('1 test ing').showCompletionScript()
+        );
+
+        r.logs[0].should.match(
+          /"\${COMP_WORDS\[0]}" == "1" && "\${COMP_WORDS\[1]}" == "test" && "\${COMP_WORDS\[2]}" == "ing"/
+        );
+      });
+
+      it('uses a "safe" app name for the bash completion function name', () => {
+        process.env.SHELL = '/bin/bash';
+        const r = checkUsage(() =>
+          yargs([]).scriptName('1 test ing').showCompletionScript()
+        );
+
+        r.logs[0].should.match(/_1_test_ing/);
+      });
+
+      it('replaces the bash `complete` word with only the first word of the app name', () => {
+        process.env.SHELL = '/bin/bash';
+        const r = checkUsage(() =>
+          yargs([]).scriptName('1 test ing').showCompletionScript()
+        );
+
+        r.logs[0].should.match(/_yargs_completions 1/);
+      });
+    });
+
     it('if $0 has a .js extension, a ./ prefix is added', () => {
       const r = checkUsage(() => yargs([]).showCompletionScript(), ['test.js']);
 
@@ -1116,6 +1147,24 @@ describe('Completion', () => {
 
       r.logs[0].should.match(/zshrc/);
       r.logs[0].should.match(/ndm --get-yargs-completions/);
+    });
+
+    it('uses a "safe" app name for the bash completion function name', () => {
+      process.env.SHELL = '/bin/zsh';
+      const r = checkUsage(() =>
+        yargs([]).scriptName('1 test ing').showCompletionScript()
+      );
+
+      r.logs[0].should.match(/_1_test_ing/);
+    });
+
+    it('generates multi-word completion handler', () => {
+      process.env.SHELL = '/bin/zsh';
+      const r = checkUsage(() =>
+        yargs([]).scriptName('1 test ing').showCompletionScript()
+      );
+      console.log(r.logs[0]);
+      r.logs[0].should.match(/_yargs_completions "1=test=ing"/);
     });
 
     describe('getCompletion()', () => {


### PR DESCRIPTION
I finally got around to working on the multi-word completion script. It was a bit more complicated than I thought!

Fixes #2387, supersedes PR #2388

This PR has some other fixes, all in separate commits you can cherry pick or drop/revert as needed:

  * pins TypeScript (typescript minor versions contain breaking changes)
  * renames an eslint rule to match its new name
  * fixes types by using the fix in #2393
  * fixes `--get-yargs-completion` when the parser options strip-dashed setting is `true`
  * and finally, adds support for multi-word completion
   
Please do let me know if you think you'll be able to merge and release this. I can always just patch `yargs` in our codebase (MetaMask) if needed.