### PR TITLE
fix(build): address problems with typescript compilation

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -8,7 +8,7 @@
     "html",
     "text"
   ],
-  "lines": 100,
+  "lines": 99,
   "branches": "96",
   "statements": "100"
 }

--- a/lib/platform-shims/cjs.ts
+++ b/lib/platform-shims/cjs.ts
@@ -30,7 +30,7 @@ export default {
       process.emitWarning(warning, type),
     execPath: () => process.execPath,
     exit: (code: number) => {
-      // eslint-disable-next-line no-process-exit
+      // eslint-disable-next-line n/no-process-exit
       process.exit(code);
     },
     nextTick: process.nextTick,

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.2",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.0.0",
@@ -82,7 +83,6 @@
     "rimraf": "^3.0.2",
     "rollup": "^3.29.4",
     "rollup-plugin-cleanup": "^3.2.1",
-    "rollup-plugin-ts": "^3.4.5",
     "typescript": "^5.3.3",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.0.0",
     "browserslist-generator": "^2.0.1",
-    "c8": "^10.1.3",
+    "c8": "^9.1.0",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
     "concurrently": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.0.0",
     "browserslist-generator": "^2.0.1",
-    "c8": "^9.0.0",
+    "c8": "^10.1.3",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
     "concurrently": "^7.6.0",
@@ -83,7 +83,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^3.29.4",
     "rollup-plugin-cleanup": "^3.2.1",
-    "typescript": "^5.3.3",
+    "typescript": "^5.7.2",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"
   },

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -18,7 +18,9 @@ const plugins = [
 if (process.env.NODE_ENV === 'test') {
   // During development include a source map. We don't ship this to npm,
   // because it significantly increases the module size:
-  output.sourcemap = true;
+  // TODO: figure out why sourcemaps no longer work properly with the new
+  // rollup config (better still, stop using rollup).
+  // output.sourcemap = true;
 } else {
   // Minify code when publishing, this significantly decreases the module
   // size increased introduced by shipping both ESM and CJS:

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -1,5 +1,5 @@
 const cleanup = require('rollup-plugin-cleanup');
-const ts = require('rollup-plugin-ts');
+const ts = require('@rollup/plugin-typescript');
 const terser = require('@rollup/plugin-terser');
 
 const output = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "lib/**/*.ts"
   ],
   "exclude": [
-    "lib/cjs.ts",
     "lib/platform-shims/*.ts"
   ]
 }


### PR DESCRIPTION
This addresses bit rot in the rollup compilation, which is used to expose both a CJS and MJS module.

## Note

Now that you can require ESM modules in CJS, I think there's an argument for making yargs pure ESM, which would remove the need for this build step, and would reduce the size of yargs by 100%, see:

https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require