### PR TITLE
fix(browser): fix shims so that yargs continues working in browser context

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -6,7 +6,7 @@ the browser:
 
 ```html
 <script type="module">
-  import Yargs from 'https://unpkg.com/yargs@16.0.0-beta.1/browser.mjs';
+  import Yargs from 'https://unpkg.com/yargs@18.0.0-browser.2/browser.mjs';
   const yargs = Yargs()
     .scriptName('>')
     .command('clear', 'clear the output window', () => {}, () => {
@@ -23,4 +23,4 @@ the browser:
 ```
 
 A full example can be found in [example/yargs.html](/example/yargs.html), or
-on [jsfiddle](https://jsfiddle.net/bencoe/m9fv2oet/3/).
+on [jsfiddle](https://jsfiddle.net/juL5zonp/).

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -25,7 +25,6 @@ import {
   DetailedArguments,
 } from './yargs-factory.js';
 import {maybeAsyncResult} from './utils/maybe-async-result.js';
-import {readdirSync} from 'node:fs';
 import {join, dirname} from 'node:path';
 
 const DEFAULT_MARKER = /(^\*)|(^\$0)/;
@@ -64,7 +63,7 @@ export class CommandInstance {
     opts = opts || {};
     this.requireCache.add(callerFile);
     const fullDirPath = join(dirname(callerFile), dir);
-    const files = readdirSync(fullDirPath, {
+    const files = this.shim.readdirSync(fullDirPath, {
       recursive: opts.recurse ? true : false,
     });
     // exclude 'json', 'coffee' from require-directory defaults
@@ -72,7 +71,7 @@ export class CommandInstance {
     // allow consumer to define their own visitor function
     const visit = typeof opts.visit === 'function' ? opts.visit : (o: any) => o;
     for (const fileb of files) {
-      const file = fileb.toString('utf8');
+      const file = fileb.toString();
 
       // Support include / exclude logic from require-directory.
       if (opts.exclude) {

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -25,7 +25,6 @@ import {
   DetailedArguments,
 } from './yargs-factory.js';
 import {maybeAsyncResult} from './utils/maybe-async-result.js';
-import {join, dirname} from 'node:path';
 
 const DEFAULT_MARKER = /(^\*)|(^\$0)/;
 export type DefinitionOrCommandName = string | CommandHandlerDefinition;
@@ -62,7 +61,10 @@ export class CommandInstance {
   ): void {
     opts = opts || {};
     this.requireCache.add(callerFile);
-    const fullDirPath = join(dirname(callerFile), dir);
+    const fullDirPath = this.shim.path.join(
+      this.shim.path.dirname(callerFile),
+      dir
+    );
     const files = this.shim.readdirSync(fullDirPath, {
       recursive: opts.recurse ? true : false,
     });
@@ -98,7 +100,7 @@ export class CommandInstance {
         if (file.endsWith(ext)) supportedExtension = true;
       }
       if (supportedExtension) {
-        const joined = join(fullDirPath, file);
+        const joined = this.shim.path.join(fullDirPath, file);
         const module = req(joined);
         const visited = visit(module, joined, file);
         if (visited) {

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -54,6 +54,9 @@ export default {
   readFileSync: () => {
     return '';
   },
+  readdirSync: () => {
+    return [];
+  },
   require: () => {
     throw new YError(REQUIRE_ERROR);
   },

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -37,6 +37,7 @@ export default {
     dirname: str => str,
     extname: str => str,
     relative: str => str,
+    join: (str, _str2) => str,
   },
   process: {
     argv: () => [],

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -94,6 +94,9 @@ export default {
     stdColumns: columns ?? null,
   },
   readFileSync: Deno.readTextFileSync,
+  readdirSync: () => {
+    return [];
+  },
   require: () => {
     throw new YError(REQUIRE_ERROR);
   },

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -9,6 +9,7 @@ import {
   dirname,
   extname,
   posix,
+  join,
 } from 'https://deno.land/std/path/mod.ts';
 
 import cliui from 'https://deno.land/x/cliui@v7.0.4-deno/deno.ts';
@@ -54,6 +55,7 @@ const path = {
     }
   },
   resolve: posix.resolve,
+  join,
 };
 
 // TODO: replace with Deno.consoleSize(Deno.stdout.rid)

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -6,7 +6,7 @@ import escalade from 'escalade/sync'
 import { inspect } from 'util'
 import { fileURLToPath } from 'url';
 import Parser from 'yargs-parser'
-import { basename, dirname, extname, relative, resolve } from 'path'
+import { basename, dirname, extname, relative, resolve, join } from 'path'
 import { getProcessArgvBin } from '../../build/lib/utils/process-argv.js'
 import stringWidth from 'string-width';
 import y18n from 'y18n'
@@ -37,7 +37,8 @@ export default {
     dirname,
     extname,
     relative,
-    resolve
+    resolve,
+    join
   },
   process: {
     argv: () => process.argv,

--- a/lib/platform-shims/esm.mjs
+++ b/lib/platform-shims/esm.mjs
@@ -4,7 +4,6 @@ import { notStrictEqual, strictEqual } from 'assert'
 import cliui from 'cliui'
 import escalade from 'escalade/sync'
 import { inspect } from 'util'
-import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url';
 import Parser from 'yargs-parser'
 import { basename, dirname, extname, relative, resolve } from 'path'
@@ -13,6 +12,7 @@ import stringWidth from 'string-width';
 import y18n from 'y18n'
 import { createRequire } from 'node:module';
 import getCallerFile from 'get-caller-file';
+import { readFileSync, readdirSync } from 'node:fs'
 
 const __dirname = fileURLToPath(import.meta.url);
 const mainFilename = __dirname.substring(0, __dirname.lastIndexOf('node_modules'));
@@ -52,6 +52,7 @@ export default {
     stdColumns: typeof process.stdout.columns !== 'undefined' ? process.stdout.columns : null
   },
   readFileSync,
+  readdirSync,
   require,
   getCallerFile: () => {
     const callerFile = getCallerFile(3);

--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -106,6 +106,7 @@ export interface PlatformShim {
     dirname: (path: string) => string;
     relative: (p1: string, p2: string) => string;
     resolve: (p1: string, p2: string) => string;
+    join: (p1: string, p2: string) => string;
   };
   process: {
     argv: () => string[];

--- a/lib/typings/common-types.ts
+++ b/lib/typings/common-types.ts
@@ -117,6 +117,10 @@ export interface PlatformShim {
     stdColumns: number | null;
   };
   readFileSync: (path: string, encoding: string) => string;
+  readdirSync: (
+    path: string,
+    opts: object
+  ) => Array<string | Buffer<ArrayBufferLike>>[];
   require: RequireType;
   y18n: Y18N;
 }

--- a/lib/utils/apply-extends.ts
+++ b/lib/utils/apply-extends.ts
@@ -1,7 +1,5 @@
 import {Dictionary, PlatformShim} from '../typings/common-types.js';
 import {YError} from '../yerror.js';
-import {createRequire} from 'node:module';
-const require = createRequire(import.meta.url);
 
 let previouslyVisitedConfigs: string[] = [];
 let shim: PlatformShim;
@@ -36,7 +34,7 @@ export function applyExtends(
 
     defaultConfig = isPath
       ? JSON.parse(shim.readFileSync(pathToDefault, 'utf8'))
-      : require(config.extends);
+      : _shim.require(config.extends);
     delete config.extends;
     defaultConfig = applyExtends(
       defaultConfig,


### PR DESCRIPTION
The shim files abstract Node specific logic away from Deno and browser entry points. I had drifted away form using shims when implementing the addDirectory logic.