### PR TITLE
fix: addDirectory do not support absolute command dir

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -61,7 +61,7 @@ export class CommandInstance {
   ): void {
     opts = opts || {};
     this.requireCache.add(callerFile);
-    const fullDirPath = this.shim.path.join(
+    const fullDirPath = this.shim.path.resolve(
       this.shim.path.dirname(callerFile),
       dir
     );

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -5,7 +5,7 @@ import * as assert from 'assert';
 import yargs from '../index.mjs';
 import {expect, should} from 'chai';
 import {checkOutput} from './helpers/utils.mjs';
-import {join} from 'node:path';
+import {join, resolve} from 'node:path';
 
 should();
 
@@ -2185,6 +2185,28 @@ describe('Command', () => {
   });
 
   describe('commandDir', () => {
+    it('supports absolute dirs', () => {
+      const absoluteDir = resolve('test/fixtures/cmddir');
+      const r = checkOutput(() => {
+        yargs('--help').wrap(null).commandDir(absoluteDir).parse();
+      });
+      r.exit.should.equal(true);
+      r.exitCode.should.equal(0);
+      r.errors.length.should.equal(0);
+      r.should.have.property('logs');
+      r.logs
+        .join('\n')
+        .split(/\n+/)
+        .should.deep.equal([
+          'usage [command]',
+          'Commands:',
+          '  usage dream [command] [opts]  Go to sleep and dream',
+          'Options:',
+          '  --help     Show help  [boolean]',
+          '  --version  Show version number  [boolean]',
+        ]);
+    });
+
     it('supports relative dirs', () => {
       const r = checkOutput(() =>
         yargs('--help').wrap(null).commandDir('fixtures/cmddir').parse()


### PR DESCRIPTION
The issue context is under https://github.com/yargs/yargs/pull/2451/files/9e920df512e869d3d5f7917f9dbd79f99b26b93c#diff-3378419d97c7d3aa5e4c5a36f8744505164ed98aeda47707e070f8df8496b91f

The main problem is that the commandDir API function no longer supports the absolute commands directory, which was supported previously. @shadowspawn suggested changing from path.join to path.resolve. I tested his solution and it worked. Therefore, I've created this pull request.

BTW, I ran the `npm run test` with all the passes. but `npm run test:esm` with failed "throws an error if commndDir() used in ESM mode" I think it will not be a test case in yargs@next