### PR TITLE
fix(yargs-parser): support bun for getting cli name

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1552,7 +1552,9 @@ export class YargsInstance {
     // ignore the node bin, specify this in your
     // bin file with #!/usr/bin/env node
     let default$0: string[];
-    if (/\b(node|iojs|electron|bun)(\.exe)?$/.test(this.#shim.process.argv()[0])) {
+    if (
+      /\b(node|iojs|electron|bun)(\.exe)?$/.test(this.#shim.process.argv()[0])
+    ) {
       default$0 = this.#shim.process.argv().slice(1, 2);
     } else {
       default$0 = this.#shim.process.argv().slice(0, 1);

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1552,7 +1552,7 @@ export class YargsInstance {
     // ignore the node bin, specify this in your
     // bin file with #!/usr/bin/env node
     let default$0: string[];
-    if (/\b(node|iojs|electron)(\.exe)?$/.test(this.#shim.process.argv()[0])) {
+    if (/\b(node|iojs|electron|bun)(\.exe)?$/.test(this.#shim.process.argv()[0])) {
       default$0 = this.#shim.process.argv().slice(1, 2);
     } else {
       default$0 = this.#shim.process.argv().slice(0, 1);


### PR DESCRIPTION
When using `bunx --bun package-name`, it claims bun is the cli name. However this incorrect, so this PR changes the behavior to work like node!

the --bun isn't strictly necessarily as if you don't have bun installed, then it force attempts to use bun runtime by changing the path.

(note, I have indeed tested this behavior and it works)

fixes #2377