### PR TITLE
Fix 'count' for de locale

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -3,7 +3,7 @@
   "Options:": "Optionen:",
   "Examples:": "Beispiele:",
   "boolean": "boolean",
-  "count": "Zähler",
+  "count": "Anzahl",
   "string": "string",
   "number": "Zahl",
   "array": "array",


### PR DESCRIPTION
Changing de localization for 'count' to 'Anzahl' because 'Zähler' is closer to 'counter'