### PR TITLE
feat: support creating completions for fish shell

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -351,10 +351,10 @@ discussion of the advanced features exposed in the Command API.
 .completion([cmd], [description], [fn])
 ---------------------------------------
 
-Enable bash/zsh-completion shortcuts for commands and options.
+Enable bash/zsh/fish-completion shortcuts for commands and options.
 
-`cmd`: When present in `argv._`, will result in the `.bashrc` or `.zshrc` completion script
-being outputted.
+`cmd`: When present in `argv._`, will result in the `.bashrc`, `.zshrc`, or fish
+completion script being outputted.
 
 To enable bash/zsh completions, you can either: 
 1. Concat the generated script to your
@@ -373,6 +373,11 @@ To enable bash/zsh completions, you can either:
    command name.
 
    e.g. `./command completion > /usr/local/share/zsh/site-functions/_command_yargs_completions`
+
+For Fish, write it to a file in your fish completions directory (`$XDG_CONFIG_HOME/fish/completions`),
+   with the same name as the command.
+
+   e.g. `./command completion > ~/.config/fish/completions/command.fish`
 
 `description`: Provide a description in your usage instructions for the command
 that generates the completion scripts.
@@ -1547,9 +1552,9 @@ const yargs = yargs()
 .showCompletionScript()
 ----------------------
 
-Generate a bash completion script. Users of your application can install this
-script in their `.bashrc`, and yargs will provide completion shortcuts for
-commands and options.
+Generate a completion script for bash, zsh, or fish (depending on the current shell).
+Users of your application can install this script in their `.bashrc`, `.zshrc`, or fish
+completions directory, and yargs will provide completion shortcuts for commands and options.
 
 <a name="show-help">.showHelp([consoleLevel | printCallback])
 ---------------------------

--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -56,3 +56,13 @@ else
 fi
 ###-end-{{app_name}}-completions-###
 `;
+
+export const completionFishTemplate = `###-begin-{{app_name}}-completions-###
+#
+# yargs command completion script
+#
+# Installation: {{app_path}} {{completion_command}} > $XDG_CONFIG_HOME/fish/completions/{{app_name}}.fish
+#
+complete -f -c {{app_name}} -a '({{app_path}} --get-yargs-completions (commandline -o)[2..-1])'
+###-end-{{app_name}}-completions-###
+`;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -34,6 +34,7 @@ export class Completion implements CompletionInstance {
   private customCompletionFunction: CompletionFunction | null = null;
   private indexAfterLastReset = 0;
   private readonly zshShell: boolean;
+  private readonly fishShell: boolean;
 
   constructor(
     private readonly yargs: YargsInstance,
@@ -45,6 +46,7 @@ export class Completion implements CompletionInstance {
       (this.shim.getEnv('SHELL')?.includes('zsh') ||
         this.shim.getEnv('ZSH_NAME')?.includes('zsh')) ??
       false;
+    this.fishShell = this.shim.getEnv('SHELL')?.includes('fish') ?? false;
   }
 
   private defaultCompletion(
@@ -92,11 +94,13 @@ export class Completion implements CompletionInstance {
       this.usage.getCommands().forEach(usageCommand => {
         const commandName = parseCommand(usageCommand[0]).cmd;
         if (args.indexOf(commandName) === -1) {
-          if (!this.zshShell) {
-            completions.push(commandName);
-          } else {
-            const desc = usageCommand[1] || '';
+          const desc = usageCommand[1] || '';
+          if (this.fishShell) {
+            completions.push(commandName + '\t' + desc);
+          } else if (this.zshShell) {
             completions.push(commandName.replace(/:/g, '\\:') + ':' + desc);
+          } else {
+            completions.push(commandName);
           }
         }
       });
@@ -150,7 +154,11 @@ export class Completion implements CompletionInstance {
     if (this.previousArgHasChoices(args)) {
       const choices = this.getPreviousArgChoices(args);
       if (choices && choices.length > 0) {
-        completions.push(...choices.map(c => c.replace(/:/g, '\\:')));
+        if (this.fishShell) {
+          completions.push(...choices);
+        } else {
+          completions.push(...choices.map(c => c.replace(/:/g, '\\:')));
+        }
       }
     }
   }
@@ -185,7 +193,11 @@ export class Completion implements CompletionInstance {
     const choices = this.yargs.getOptions().choices[positionalKey] || [];
     for (const choice of choices) {
       if (choice.startsWith(current)) {
-        completions.push(choice.replace(/:/g, '\\:'));
+        if (this.fishShell) {
+          completions.push(choice);
+        } else {
+          completions.push(choice.replace(/:/g, '\\:'));
+        }
       }
     }
   }
@@ -255,7 +267,7 @@ export class Completion implements CompletionInstance {
     negable: boolean
   ) {
     let keyWithDesc = key;
-    if (this.zshShell) {
+    if (this.zshShell || this.fishShell) {
       const descs = this.usage.getDescriptions();
       const aliasKey = this?.aliases?.[key]?.find(alias => {
         const desc = descs[alias];
@@ -263,9 +275,14 @@ export class Completion implements CompletionInstance {
       });
       const descFromAlias = aliasKey ? descs[aliasKey] : undefined;
       const desc = descs[key] ?? descFromAlias ?? '';
-      keyWithDesc = `${key.replace(/:/g, '\\:')}:${desc
+      const cleanedDesc = desc
         .replace('__yargsString__:', '')
-        .replace(/(\r\n|\n|\r)/gm, ' ')}`;
+        .replace(/(\r\n|\n|\r)/gm, ' ');
+      if (this.fishShell) {
+        keyWithDesc = `${key}\t${cleanedDesc}`;
+      } else {
+        keyWithDesc = `${key.replace(/:/g, '\\:')}:${cleanedDesc}`;
+      }
     }
 
     const startsByTwoDashes = (s: string) => /^--/.test(s);
@@ -348,7 +365,9 @@ export class Completion implements CompletionInstance {
   generateCompletionScript($0: string, cmd: string): string {
     let script = this.zshShell
       ? templates.completionZshTemplate
-      : templates.completionShTemplate;
+      : this.fishShell
+        ? templates.completionFishTemplate
+        : templates.completionShTemplate;
     const name = this.shim.path.basename($0);
 
     // add ./ to applications not yet installed as bin.

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1158,6 +1158,189 @@ describe('Completion', () => {
     });
   });
 
+  describe('fish', () => {
+    it('returns a list of commands as completion suggestions', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', ''])
+            .command('foo', 'bar')
+            .command('apple', 'banana')
+            .completion().argv
+      );
+
+      r.logs.should.include('apple\tbanana');
+      r.logs.should.include('foo\tbar');
+    });
+
+    it('avoids interruption from command recommendations', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs([
+            './completion',
+            '--get-yargs-completions',
+            './completion',
+            'a',
+          ])
+            .command('apple', 'fruit')
+            .command('aardvark', 'animal')
+            .recommendCommands()
+            .completion().argv
+      );
+
+      r.errors.should.deep.equal([]);
+      r.logs.should.include('apple\tfruit');
+      r.logs.should.include('aardvark\tanimal');
+    });
+
+    it('avoids interruption from default command', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs(['./usage', '--get-yargs-completions', './usage', ''])
+            .usage('$0 [thing]', 'skipped', subYargs => {
+              subYargs.command('aardwolf', 'is a thing according to google');
+            })
+            .command('aardvark', 'animal')
+            .completion().argv
+      );
+
+      r.errors.should.deep.equal([]);
+      r.logs.should.not.include('aardwolf');
+      r.logs.should.include('aardvark\tanimal');
+    });
+
+    it('completes options for a command', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', 'foo', '--b'])
+            .command('foo', 'foo command', subYargs =>
+              subYargs
+                .options({
+                  bar: {
+                    describe: 'bar option',
+                  },
+                })
+                .help(true)
+                .version(false)
+            )
+            .completion().argv
+      );
+
+      r.logs.should.have.length(2);
+      r.logs.should.include('--bar\tbar option');
+      r.logs.should.include('--help\tShow help');
+    });
+
+    it('completes options and aliases with the same description', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', '-'])
+            .options({
+              foo: {describe: 'Foo option', alias: 'f', type: 'string'},
+              bar: {describe: 'Bar option', alias: ['b', 'B'], type: 'string'},
+            })
+            .help(false)
+            .version(false)
+            .completion().argv
+      );
+
+      r.logs.should.have.length(5);
+      r.logs.should.include('--foo\tFoo option');
+      r.logs.should.include('-f\tFoo option');
+      r.logs.should.include('--bar\tBar option');
+      r.logs.should.include('-b\tBar option');
+      r.logs.should.include('-B\tBar option');
+    });
+
+    it('completes options with line break', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', '-'])
+            .options({
+              foo: {describe: 'Foo option\nFoo option', type: 'string'},
+            })
+            .help(false)
+            .version(false)
+            .completion().argv
+      );
+
+      r.logs.should.have.length(1);
+      r.logs.should.include('--foo\tFoo option Foo option');
+    });
+
+    it('replaces application variable with $0 in script', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(() => yargs([]).showCompletionScript(), ['ndm']);
+
+      r.logs[0].should.match(/fish\/completions/);
+      r.logs[0].should.match(/ndm --get-yargs-completions/);
+    });
+
+    describe('getCompletion()', () => {
+      it('returns default completion to callback', () => {
+        process.env.SHELL = '/usr/bin/fish';
+        const r = checkOutput(() => {
+          yargs()
+            .command('foo', 'bar')
+            .command('apple', 'banana')
+            .completion()
+            .getCompletion([''], (_err, completions) => {
+              (completions || []).forEach(completion => {
+                console.log(completion);
+              });
+            });
+        });
+
+        r.logs.should.include('apple\tbanana');
+        r.logs.should.include('foo\tbar');
+      });
+    });
+
+    it('does not apply validation when --get-yargs-completions is passed in', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(() => {
+        try {
+          return yargs(['./completion', '--get-yargs-completions', '--'])
+            .option('foo', {describe: 'bar'})
+            .completion()
+            .strict().argv;
+        } catch (e) {
+          console.log(e.message);
+        }
+      });
+
+      r.errors.length.should.equal(0);
+      r.logs.should.include('--foo\tbar');
+    });
+
+    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+      process.env.SHELL = '/usr/bin/fish';
+
+      const r = checkOutput(
+        () =>
+          yargs(['./completion', '--get-yargs-completions', '--'])
+            .options({
+              foo: {describe: 'foo flag', type: 'boolean', default: true},
+              bar: {describe: 'bar flag', type: 'boolean'},
+            })
+            .parserConfiguration({'boolean-negation': true}).argv
+      );
+
+      r.logs.should.eql([
+        '--help\tShow help',
+        '--version\tShow version number',
+        '--foo\tfoo flag',
+        '--no-foo\tfoo flag',
+        '--bar\tbar flag',
+      ]);
+    });
+  });
+
   describe('async', () => {
     before(() => {
       process.env.SHELL = '/bin/bash';

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1339,6 +1339,45 @@ describe('Completion', () => {
         '--bar\tbar flag',
       ]);
     });
+
+    it('completes choices if previous option requires a choice', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(() => {
+        return yargs(['./completion', '--get-yargs-completions', '--fruit'])
+          .options({
+            fruit: {
+              describe: 'fruit option',
+              choices: ['apple', 'banana', 'pear'],
+            },
+            amount: {describe: 'amount', type: 'number'},
+          })
+          .completion().argv;
+      });
+
+      r.logs.should.include('apple');
+      r.logs.should.include('banana');
+      r.logs.should.include('pear');
+    });
+
+    it('completes positional choices', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      const r = checkOutput(() => {
+        return yargs(['./completion', '--get-yargs-completions', 'cmd', 'ap'])
+          .help(false)
+          .version(false)
+          .command('cmd [fruit]', 'fruit command', subYargs => {
+            subYargs.positional('fruit', {
+              describe: 'choose a fruit',
+              choices: ['apple', 'banana', 'pear'],
+            });
+          })
+          .completion().argv;
+      });
+
+      r.logs.should.include('apple');
+      r.logs.should.not.include('banana');
+      r.logs.should.not.include('pear');
+    });
   });
 
   describe('async', () => {


### PR DESCRIPTION
Adds support for creating completions in fish shell with `<command> completion > ~/.config/fish/completions/<command>.fish` 

Ref #2282 and #1904 