### PR TITLE
fix: prototype pollution vulnerability in apply-extends

### DIFF
--- a/lib/utils/apply-extends.ts
+++ b/lib/utils/apply-extends.ts
@@ -68,6 +68,7 @@ function mergeDeep(config1: Dictionary, config2: Dictionary) {
   }
   Object.assign(target, config1);
   for (const key of Object.keys(config2)) {
+    if (key === '__proto__') continue;
     if (isObject(config2[key]) && isObject(target[key])) {
       target[key] = mergeDeep(config1[key], config2[key]);
     } else {

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -15,4 +15,11 @@ describe('applyExtends', () => {
     expect(conf.batman).to.equal('Caped Crusader');
     expect(conf.version).to.equal('1.0.2');
   });
+
+  it('does not allow prototype pollution via __proto__', () => {
+    const polluted = JSON.parse('{"__proto__": {"polluted": true}}');
+    const conf = applyExtends(polluted, process.cwd(), true);
+    expect(conf.polluted).to.equal(undefined);
+    expect({}.polluted).to.equal(undefined);
+  });
 });


### PR DESCRIPTION
fixes #2497 

The vulnerability existed in the `mergeDeep` function within `lib/utils/apply-extends.ts`. This function recursively merged two objects without checking if the key being merged was `__proto__`.

### Impact
Prototype pollution can lead to:
- **Denial of Service (DoS)**: By overwriting methods like `toString` or `valueOf`.
- **Logic Errors**: By injecting unexpected properties that alter application flow.
- **Remote Code Execution (RCE)**: In some specific scenarios where polluted properties are used in sensitive operations (e.g., template engines, child process execution).

### Reproduction
The following script demonstrated the vulnerability:

```javascript
// repro_proto.js
import { applyExtends } from './build/lib/utils/apply-extends.js';
// ... setup ...

const config = JSON.parse('{"__proto__":{"polluted":true}}');
applyExtends(config, ...);

console.log(config.polluted); // true (before fix)
```

The fix involves explicitly checking for and skipping the `__proto__` key during the iteration of object keys in the `mergeDeep` function.

BEGIN_COMMIT_OVERRIDE
fix: local prototype pollution vulnerability in apply-extends
END_COMMIT_OVERRIDE