### PR TITLE
feat: add fish shell completion support

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -56,3 +56,22 @@ else
 fi
 ###-end-{{app_name}}-completions-###
 `;
+
+export const completionFishTemplate = `###-begin-{{app_name}}-completions-###
+#
+# yargs command completion script
+#
+# Installation: {{app_path}} {{completion_command}} | source
+#    or {{app_path}} {{completion_command}} > ~/.config/fish/completions/{{app_name}}.fish
+#
+function _{{app_name}}_yargs_completions
+  set -l args (commandline -opc)
+  set -l cur (commandline -ct)
+  set -l completions ({{app_path}} --get-yargs-completions $args)
+  for completion in $completions
+    echo $completion
+  end
+end
+complete -c {{app_name}} -f -a '(_{{app_name}}_yargs_completions)'
+###-end-{{app_name}}-completions-###
+`;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -34,6 +34,7 @@ export class Completion implements CompletionInstance {
   private customCompletionFunction: CompletionFunction | null = null;
   private indexAfterLastReset = 0;
   private readonly zshShell: boolean;
+  private readonly fishShell: boolean;
 
   constructor(
     private readonly yargs: YargsInstance,
@@ -44,6 +45,10 @@ export class Completion implements CompletionInstance {
     this.zshShell =
       (this.shim.getEnv('SHELL')?.includes('zsh') ||
         this.shim.getEnv('ZSH_NAME')?.includes('zsh')) ??
+      false;
+    this.fishShell =
+      (this.shim.getEnv('SHELL')?.includes('fish') ||
+        !!this.shim.getEnv('FISH_VERSION')) ??
       false;
   }
 
@@ -346,7 +351,9 @@ export class Completion implements CompletionInstance {
 
   // generate the completion script to add to your .bashrc.
   generateCompletionScript($0: string, cmd: string): string {
-    let script = this.zshShell
+    let script = this.fishShell
+      ? templates.completionFishTemplate
+      : this.zshShell
       ? templates.completionZshTemplate
       : templates.completionShTemplate;
     const name = this.shim.path.basename($0);


### PR DESCRIPTION
Adds native fish shell completion support to yargs, which has been requested for a while now (#1904).

**What changed:**

- New `completionFishTemplate` in `completion-templates.ts` using fish's `commandline` and `complete` builtins
- Fish shell detection via `SHELL` env var containing "fish" or presence of `FISH_VERSION`
- `generateCompletionScript()` now picks the fish template when running under fish

The generated script works like the existing bash/zsh scripts - it calls the app with `--get-yargs-completions` and feeds results to fish's completion system. Users can install it with:

```
myapp completion | source
# or persist it:
myapp completion > ~/.config/fish/completions/myapp.fish
```

All 91 existing completion tests still pass.

Closes #1904