### PR TITLE
Replace EOL node 23 in CI version matrix with node 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ assigned, opened, synchronize, reopened, labeled ]
+    types: [assigned, opened, synchronize, reopened, labeled]
 name: ci
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 23]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 23
+          node-version: 24
       - run: npm install -g npm@8
       - run: npm install
       - run: npm test


### PR DESCRIPTION
CI tests broken on node 23 with engine dependency changes in typescript-eslint related to supporting eslint 10. Node 23 is EOL, and typescript-eslint does not explicitly support odd node versions,  so time to drop it from matrix and replace with 24.

PR with broken tests: #2505

Explanation: https://github.com/typescript-eslint/typescript-eslint/issues/12081#issuecomment-3950141924