### PR TITLE
Reapply formatting to fix lint checks

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -791,13 +791,9 @@ export function command(
   return new CommandInstance(usage, validation, globalMiddleware, shim);
 }
 
-export interface CommandHandlerDefinition
-  extends Partial<
-    Pick<
-      CommandHandler,
-      'deprecated' | 'description' | 'handler' | 'middlewares'
-    >
-  > {
+export interface CommandHandlerDefinition extends Partial<
+  Pick<CommandHandler, 'deprecated' | 'description' | 'handler' | 'middlewares'>
+> {
   aliases?: string[];
   builder?: CommandBuilder | CommandBuilderDefinition;
   command?: string | string[];

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2377,23 +2377,22 @@ export interface OptionDefinition {
   type?: 'array' | 'boolean' | 'count' | 'number' | 'string';
 }
 
-interface PositionalDefinition
-  extends Pick<
-    OptionDefinition,
-    | 'alias'
-    | 'array'
-    | 'coerce'
-    | 'choices'
-    | 'conflicts'
-    | 'default'
-    | 'defaultDescription'
-    | 'demand'
-    | 'desc'
-    | 'describe'
-    | 'description'
-    | 'implies'
-    | 'normalize'
-  > {
+interface PositionalDefinition extends Pick<
+  OptionDefinition,
+  | 'alias'
+  | 'array'
+  | 'coerce'
+  | 'choices'
+  | 'conflicts'
+  | 'default'
+  | 'defaultDescription'
+  | 'demand'
+  | 'desc'
+  | 'describe'
+  | 'description'
+  | 'implies'
+  | 'normalize'
+> {
   type?: 'boolean' | 'number' | 'string';
 }
 


### PR DESCRIPTION
Lint tests failing on new PRs due to formatting changes. This PR has the changes from simply running:

```console
npm run fix
```