### PR TITLE
fix: copy yargs/yargs entrypoint file yargs to yargs.cjs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ assigned, opened, synchronize, reopened, labeled ]
+    types: [assigned, opened, synchronize, reopened, labeled]
 name: ci
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install -g npm@7
       - run: node --version
-      - run: npm install --engine-strict
+      - run: npm install
       - run: npm test
   windows:
     runs-on: windows-latest
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install -g npm@7
       - run: node --version
-      - run: npm install --engine-strict
+      - run: npm install
       - run: npm run test:esm
   deno:
     runs-on: ubuntu-latest

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -30,7 +30,7 @@ export default {
     throw new YError(REQUIRE_DIRECTORY_ERROR);
   },
   getProcessArgvBin,
-  mainFilename: 'yargs',
+  mainFilename: 'index.mjs',
   Parser,
   path: {
     basename: str => str,

--- a/lib/platform-shims/browser.mjs
+++ b/lib/platform-shims/browser.mjs
@@ -30,7 +30,7 @@ export default {
     throw new YError(REQUIRE_DIRECTORY_ERROR);
   },
   getProcessArgvBin,
-  mainFilename: 'index.mjs',
+  mainFilename: 'yargs',
   Parser,
   path: {
     basename: str => str,

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rollup": "^2.23.0",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-ts": "^2.0.4",
+    "rollup-plugin-ts": "^3.4.5",
     "typescript": "^4.0.2",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "./yargs": [
       {
         "import": "./yargs.mjs",
-        "require": "./yargs"
+        "require": "./yargs.cjs"
       },
-      "./yargs"
+      "./yargs.cjs"
     ]
   },
   "type": "module",
@@ -43,7 +43,7 @@
     "helpers/*.js",
     "helpers/*",
     "index.mjs",
-    "yargs",
+    "yargs.cjs",
     "yargs.mjs",
     "build",
     "locales",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "18.16.1",
     "c8": "^7.7.0",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
@@ -80,7 +80,8 @@
     "rollup": "^2.23.0",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-ts": "^3.4.5",
+    "rollup-plugin-ts": "^2.0.4",
+    "tslib": "^2.4.0",
     "typescript": "^4.0.2",
     "which": "^2.0.0",
     "yargs-test-extends": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "helpers/*.js",
     "helpers/*",
     "index.mjs",
+    "yargs",
     "yargs.cjs",
     "yargs.mjs",
     "build",

--- a/test/helpers.cjs
+++ b/test/helpers.cjs
@@ -2,8 +2,8 @@
 
 const {describe, it} = require('mocha');
 const assert = require('assert');
-const yargs = require('../yargs');
-const {applyExtends} = require('../yargs');
+const yargs = require('../yargs.cjs');
+const {applyExtends} = require('../yargs.cjs');
 
 const HELPER_COUNT = 3;
 

--- a/yargs
+++ b/yargs
@@ -1,9 +1,0 @@
-// TODO: consolidate on using a helpers file at some point in the future, which
-// is the approach currently used to export Parser and applyExtends for ESM:
-const {applyExtends, cjsPlatformShim, Parser, Yargs, processArgv} = require('./build/index.cjs')
-Yargs.applyExtends = (config, cwd, mergeExtends) => {
-  return applyExtends(config, cwd, mergeExtends, cjsPlatformShim)
-}
-Yargs.hideBin = processArgv.hideBin
-Yargs.Parser = Parser
-module.exports = Yargs

--- a/yargs
+++ b/yargs
@@ -1,18 +1,5 @@
-// This file gets hit before node 12.17.0 when require('yargs/yargs') from CommonJS
-// because conditional exports not processed successfully.
+// This file gets hit in node versions below node 12.17.0
+// when require('yargs/yargs') from CommonJS
+// because conditional exports not fully supported and treats as filename.
 
-// TODO: consolidate on using a helpers file at some point in the future, which
-// is the approach currently used to export Parser and applyExtends for ESM:
-const {
-  applyExtends,
-  cjsPlatformShim,
-  Parser,
-  Yargs,
-  processArgv,
-} = require('./build/index.cjs');
-Yargs.applyExtends = (config, cwd, mergeExtends) => {
-  return applyExtends(config, cwd, mergeExtends, cjsPlatformShim);
-};
-Yargs.hideBin = processArgv.hideBin;
-Yargs.Parser = Parser;
-module.exports = Yargs;
+module.exports = require('./yargs.cjs');

--- a/yargs
+++ b/yargs
@@ -1,0 +1,18 @@
+// This file gets hit before node 12.17.0 when require('yargs/yargs') from CommonJS
+// because conditional exports not processed successfully.
+
+// TODO: consolidate on using a helpers file at some point in the future, which
+// is the approach currently used to export Parser and applyExtends for ESM:
+const {
+  applyExtends,
+  cjsPlatformShim,
+  Parser,
+  Yargs,
+  processArgv,
+} = require('./build/index.cjs');
+Yargs.applyExtends = (config, cwd, mergeExtends) => {
+  return applyExtends(config, cwd, mergeExtends, cjsPlatformShim);
+};
+Yargs.hideBin = processArgv.hideBin;
+Yargs.Parser = Parser;
+module.exports = Yargs;

--- a/yargs.cjs
+++ b/yargs.cjs
@@ -1,0 +1,15 @@
+// TODO: consolidate on using a helpers file at some point in the future, which
+// is the approach currently used to export Parser and applyExtends for ESM:
+const {
+  applyExtends,
+  cjsPlatformShim,
+  Parser,
+  Yargs,
+  processArgv,
+} = require('./build/index.cjs');
+Yargs.applyExtends = (config, cwd, mergeExtends) => {
+  return applyExtends(config, cwd, mergeExtends, cjsPlatformShim);
+};
+Yargs.hideBin = processArgv.hideBin;
+Yargs.Parser = Parser;
+module.exports = Yargs;


### PR DESCRIPTION
Copy `yargs/yargs` entrypoint file from extension-less `yargs` to `yargs.cjs` (for compatibility with Node.js 25.7 and Node.js 26). Anything understanding `"exports"` will now use `yargs.cjs` for `require('yargs/yargs')`.

Mostly revert #1747 (but do not delete `yargs` file).

Fixes #2509

Branch 17.x.x created with
```
git checkout v17.7.2 
git checkout -b 17.x.x  
```

Started work with a usable local install created using Node.js 18 and dependencies from around v17.7.2 release using idea from https://github.com/yargs/yargs/issues/2408#issuecomment-2097468538
```
git checkout v17.7.2
rm -rf node_modules package-lock.json
npm --before 2023-04-27 install
```

Lint for newly noticed file `yargs.cjs` fixed with
```
npm run fix
```

Tests run locally with Node.js 12, 14, 16, 18, 24, 25.7. 

`require('yargs/yargs')` works with Node.js 12, 14, 16, 18, 24, 25.7 with following test file.

```js
const yargsFactory = require('yargs/yargs');

const yargs = yargsFactory(process.argv.slice(2))
  .help()
  .strict();

const argv = yargs.parse();
console.log(argv);
```

-----

Phase 2. 

Get builds working in CI. 

- added `tslib` and pinned `@types/node` to get typescript and rollup happy. (After some experimentation.)

Get `require('yargs/yargs')` working with node 12 before 12.17.0. Conditional exports were not implemented or not turned on or not full working before 12.17.0, and hence the extension-less `yargs` needed so early node 12 finds a file for `yargs/yargs` without using `"exports"`. (I had worked that out at one stage, but forgotten!)

- added back extension-less `yargs` file for early node 12 (and other old environments before `"exports"`.)
