### PR TITLE
docs(wrap): clarify terminalWidth() is an instance method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1783,5 +1783,16 @@ If the boolean argument `false` is provided, it will disable `--version`.
 Format usage output to wrap at `columns` many columns.
 
 By default wrap will be set to `Math.min(80, windowWidth)`. Use `.wrap(null)` to
-specify no column limit (no right-align). Use `.wrap(yargs.terminalWidth())` to
+specify no column limit (no right-align). Use `.wrap(yargsInstance.terminalWidth())` to
 maximize the width of yargs' usage instructions.
+
+> **Note:** `.terminalWidth()` is an _instance_ method, not a static method.
+> When using the chained API, create the yargs instance first:
+>
+> ```js
+> const yargsInstance = yargs(hideBin(process.argv));
+> const argv = yargsInstance
+>   .wrap(yargsInstance.terminalWidth())
+>   // ...
+>   .parse();
+> ```


### PR DESCRIPTION
Closes #2477

The [`.wrap()` docs](https://yargs.js.org/docs/#api-reference-wrapcolumns) showed:

```
Use `.wrap(yargs.terminalWidth())` to maximize the width...
```

This reads as a static call on the `yargs` export and fails at runtime:

```
TypeError: yargs_1.default.terminalWidth is not a function
```

`.terminalWidth()` is an **instance** method. This PR:

1. Updates the inline reference from `yargs.terminalWidth()` to `yargsInstance.terminalWidth()`
2. Adds a note with the correct pattern for the chained API

The [TypeScript docs](./typescript.md) already showed the correct pattern since an earlier contribution — this aligns the main API docs to match.