### PR TITLE
fix: sanitize scriptName spaces in completion script function names

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -5,7 +5,7 @@ export const completionShTemplate = `###-begin-{{app_name}}-completions-###
 # Installation: {{app_path}} {{completion_command}} >> ~/.bashrc
 #    or {{app_path}} {{completion_command}} >> ~/.bash_profile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{app_function_name}}_yargs_completions()
 {
     local cur_word args type_list
 
@@ -25,7 +25,7 @@ _{{app_name}}_yargs_completions()
 
     return 0
 }
-complete -o bashdefault -o default -F _{{app_name}}_yargs_completions {{app_name}}
+complete -o bashdefault -o default -F _{{app_function_name}}_yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###
 `;
 
@@ -37,7 +37,7 @@ export const completionZshTemplate = `#compdef {{app_name}}
 # Installation: {{app_path}} {{completion_command}} >> ~/.zshrc
 #    or {{app_path}} {{completion_command}} >> ~/.zprofile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{app_function_name}}_yargs_completions()
 {
   local reply
   local si=$IFS
@@ -50,9 +50,9 @@ _{{app_name}}_yargs_completions()
   fi
 }
 if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
-  _{{app_name}}_yargs_completions "$@"
+  _{{app_function_name}}_yargs_completions "$@"
 else
-  compdef _{{app_name}}_yargs_completions {{app_name}}
+  compdef _{{app_function_name}}_yargs_completions {{app_name}}
 fi
 ###-end-{{app_name}}-completions-###
 `;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -350,10 +350,16 @@ export class Completion implements CompletionInstance {
       ? templates.completionZshTemplate
       : templates.completionShTemplate;
     const name = this.shim.path.basename($0);
+    // Sanitize the name for use as a shell function identifier: replace any
+    // character that is not alphanumeric or underscore with an underscore.
+    // The unsanitized name is still used where the literal command is needed
+    // (e.g. the `complete` built-in's command-match argument).
+    const functionName = name.replace(/[^a-zA-Z0-9_]/g, '_');
 
     // add ./ to applications not yet installed as bin.
     if ($0.match(/\.js$/)) $0 = `./${$0}`;
 
+    script = script.replace(/{{app_function_name}}/g, functionName);
     script = script.replace(/{{app_name}}/g, name);
     script = script.replace(/{{completion_command}}/g, cmd);
     return script.replace(/{{app_path}}/g, $0);

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -622,6 +622,18 @@ describe('Completion', () => {
         /Installation: \/path\/to\/my\/app show-completions-script/
       );
     });
+
+    it('generates a valid bash function name when scriptName contains spaces', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkOutput(
+        () => yargs([]).scriptName('my tool').showCompletionScript()
+      );
+
+      // The shell function name must use underscores, not spaces
+      r.logs[0].should.match(/_my_tool_yargs_completions\(\)/);
+      // The complete built-in should still reference the original name with spaces
+      r.logs[0].should.match(/complete -o bashdefault -o default -F _my_tool_yargs_completions my tool/);
+    });
   });
 
   describe('completion()', () => {
@@ -918,6 +930,18 @@ describe('Completion', () => {
 
         r.logs[0].should.match(/bashrc/);
         r.logs[0].should.match(/ndm --get-yargs-completions/);
+      });
+
+      it('generates a valid zsh function name when scriptName contains spaces', () => {
+        process.env.SHELL = '/bin/zsh';
+        const r = checkOutput(
+          () => yargs([]).scriptName('my tool').showCompletionScript()
+        );
+
+        // The shell function name must use underscores, not spaces
+        r.logs[0].should.match(/_my_tool_yargs_completions\(\)/);
+        // compdef should still reference the original name with spaces
+        r.logs[0].should.match(/compdef _my_tool_yargs_completions my tool/);
       });
     });
 


### PR DESCRIPTION
## Problem

When `scriptName` contains spaces (e.g. `.scriptName('my tool')`), the generated bash/zsh completion script uses the raw name as a shell function identifier, producing invalid syntax:

```bash
_my tool_yargs_completions()   # invalid — spaces not allowed in function names
```

This breaks `source`ing the completion script entirely.

Reported in #2387.

## Solution

Introduce a separate `{{app_function_name}}` template token that sanitizes the name for use as a shell identifier by replacing any character outside `[a-zA-Z0-9_]` with an underscore.

The existing `{{app_name}}` token is preserved unchanged for places where the literal command string is needed — the `complete` builtin's command-match argument and `compdef`'s command argument — so tab completion still triggers on the actual invocation (e.g. `my tool <TAB>`).

**Before:**
```bash
_my tool_yargs_completions()             # syntax error
complete ... -F _my tool_yargs_completions my tool
```

**After:**
```bash
_my_tool_yargs_completions()             # valid identifier
complete ... -F _my_tool_yargs_completions my tool
```

## Changes

- `lib/completion-templates.ts` — replace `_{{app_name}}_yargs_completions` with `_{{app_function_name}}_yargs_completions` in both bash and zsh templates
- `lib/completion.ts` — compute `functionName` from `name` via `replace(/[^a-zA-Z0-9_]/g, '_')` and substitute `{{app_function_name}}` before `{{app_name}}`
- `test/completion.mjs` — add test cases for bash and zsh completion scripts with a space in `scriptName`