### PR TITLE
Fix positional arguments not populated when halt-at-non-option is set

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -548,6 +548,17 @@ export class CommandInstance {
     yargs: YargsInstance
   ) {
     argv._ = argv._.slice(context.commands.length); // nuke the current commands
+    // When halt-at-non-option is configured, yargs-parser places positional
+    // arguments in argv['--'] instead of argv._. Move them into argv._ so
+    // positional validation and mapping work correctly.
+    if (
+      yargs.getOptions().configuration['halt-at-non-option'] &&
+      argv['--'] &&
+      argv['--'].length
+    ) {
+      argv._ = argv._.concat(argv['--'] as string[]);
+      argv['--'] = [];
+    }
     const demanded = commandHandler.demanded.slice(0);
     const optional = commandHandler.optional.slice(0);
     const positionalMap: Dictionary<string[]> = {};

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -303,6 +303,25 @@ describe('Command', () => {
         })
         .parse('--numbers 0 1 2');
     });
+
+    // see: https://github.com/yargs/yargs/issues/2423
+    it('populates positional arguments when halt-at-non-option is set', () => {
+      const argv = yargs(['my-host', 'ls'])
+        .command(
+          '$0 <host> [cmd..]',
+          'run command via ssh',
+          yargs =>
+            yargs
+              .positional('host', {type: 'string', demandOption: true})
+              .positional('cmd', {array: true, type: 'string'})
+        )
+        .strict()
+        .parserConfiguration({'halt-at-non-option': true})
+        .parse();
+
+      argv.host.should.equal('my-host');
+      argv.cmd.should.deep.equal(['ls']);
+    });
   });
 
   describe('variadic', () => {


### PR DESCRIPTION
When `halt-at-non-option` is configured, `yargs-parser` places all positional arguments into `argv['--']` instead of `argv._`. The `populatePositionals` function in `command.ts` reads only `argv._.length` for its required-argument count check and uses `argv._` exclusively when mapping positionals to their named keys. This means that even when the correct number of positionals is provided, the validation reports "Not enough non-option arguments: got 0, need at least 1" and no positional values are populated.

This fix detects when `halt-at-non-option` is active and `argv['--']` has content, then merges those entries into `argv._` before validation and mapping run. Both the count check and the positional population now see the correct arguments.

Fixes #2423