### PR TITLE
chore: typo-paramter-yargs-factory-ts

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -1263,7 +1263,7 @@ export class YargsInstance {
     return this.demand(keys, max, msg);
   }
   requiresArg(keys: string | string[] | Dictionary): YargsInstance {
-    // the 2nd paramter [number] in the argsert the assertion is mandatory
+    // the 2nd parameter [number] in the argsert the assertion is mandatory
     // as populateParserHintSingleValueDictionary recursively calls requiresArg
     // with Nan as a 2nd parameter, although we ignore it
     argsert('<array|string|object> [number]', [keys], arguments.length);


### PR DESCRIPTION
## Summary

Fixes # — __
Source issue: 

## Spec

Problem: "paramter" is misspelled in lib/yargs-factory.ts (should be "parameter").
Fix: Replace "paramter" with "parameter" at the affected line.
Test: Verify the word "paramter" no longer appears in lib/yargs-factory.ts.

## Work breakdown (TDD)

_todo missing_

## Visual verification


_No screenshots captured (stub or non-UI change)._

## Blockers / open questions



## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] Manual smoke on the affected surface (see screenshots)

---

_Generated by the `auto-github-contributor` skill. The agent followed a red-green-refactor loop and captured visual artefacts under `.auto-pr/screenshots/`._
