### PR TITLE
chore: typo-succesful-dream-js

### DIFF
--- a/test/fixtures/cmddir/dream.js
+++ b/test/fixtures/cmddir/dream.js
@@ -22,7 +22,7 @@ exports.handler = function (argv) {
     if (!argv.shared)
       throw new Error('Dream is not shared, there is no one to extract from!');
     if (!chancesLevel1()) throw new Error('Extraction failed!');
-    if (!argv._msg) argv._msg = 'Extraction succesful';
+    if (!argv._msg) argv._msg = 'Extraction successful';
   }
   if (argv._msg) console.log(argv._msg);
   else


### PR DESCRIPTION
## Summary

Fixes # — __
Source issue: 

## Spec

Problem: "succesful" is misspelled in test/fixtures/cmddir/dream.js (should be "successful").
Fix: Replace "succesful" with "successful" at line 25.
Test: Verify the word "succesful" no longer appears in the file.

## Work breakdown (TDD)

_todo missing_

## Visual verification


_No screenshots captured (stub or non-UI change)._

## Blockers / open questions



## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] Manual smoke on the affected surface (see screenshots)

---

_Generated by the `auto-github-contributor` skill. The agent followed a red-green-refactor loop and captured visual artefacts under `.auto-pr/screenshots/`._
