### PR TITLE
Normalize quoted string positionals

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -62,6 +62,19 @@ import {isPromise} from './utils/is-promise.js';
 import {maybeAsyncResult} from './utils/maybe-async-result.js';
 import setBlocking from './utils/set-blocking.js';
 
+function stripMatchingQuotes(value: string | number): string | number {
+  if (
+    typeof value === 'string' &&
+    value.length >= 2 &&
+    (value[0] === '"' || value[0] === "'") &&
+    value[0] === value[value.length - 1]
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
 export function YargsFactory(_shim: PlatformShim) {
   return (
     processArgs: string | string[] = [],
@@ -1998,6 +2011,10 @@ export class YargsInstance {
       })
     ) as DetailedArguments;
 
+    if (typeof args === 'string') {
+      parsed.argv._ = parsed.argv._.map(stripMatchingQuotes);
+    }
+
     const argv: Arguments = Object.assign(
       parsed.argv,
       this.#parseContext
@@ -2377,23 +2394,22 @@ export interface OptionDefinition {
   type?: 'array' | 'boolean' | 'count' | 'number' | 'string';
 }
 
-interface PositionalDefinition
-  extends Pick<
-    OptionDefinition,
-    | 'alias'
-    | 'array'
-    | 'coerce'
-    | 'choices'
-    | 'conflicts'
-    | 'default'
-    | 'defaultDescription'
-    | 'demand'
-    | 'desc'
-    | 'describe'
-    | 'description'
-    | 'implies'
-    | 'normalize'
-  > {
+interface PositionalDefinition extends Pick<
+  OptionDefinition,
+  | 'alias'
+  | 'array'
+  | 'coerce'
+  | 'choices'
+  | 'conflicts'
+  | 'default'
+  | 'defaultDescription'
+  | 'demand'
+  | 'desc'
+  | 'describe'
+  | 'description'
+  | 'implies'
+  | 'normalize'
+> {
   type?: 'boolean' | 'number' | 'string';
 }
 

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -68,6 +68,21 @@ describe('Command', () => {
       argv.should.have.property('awesome', 'world');
     });
 
+    it('strips shell-style quotes from string positionals', () => {
+      const argv = yargs()
+        .command('echo [pos]')
+        .parse('echo "a b" --opt "a b"');
+
+      argv.opt.should.equal('a b');
+      argv.pos.should.equal('a b');
+    });
+
+    it('preserves literal quotes for array positionals', () => {
+      const argv = yargs().command('echo [pos]').parse(['echo', '"a b"']);
+
+      argv.pos.should.equal('"a b"');
+    });
+
     it('populates argv with camel-case variants of arguments when possible', () => {
       const argv = yargs('foo hello world')
         .command('foo <foo-bar> [baz-qux]')


### PR DESCRIPTION
## Summary
- strip matching shell-style quotes from positional `_` entries when the original parse input is a single string
- leave array input untouched so literal quote characters are preserved there
- add command regression tests for both behaviors

Closes #2416.

## Validation
- reproduced `pos === ""a b""` with `yargs().command("echo [pos]").parse("echo "a b" --opt "a b"")` before the change
- `npm test -- --grep "strips shell-style quotes from string positionals|preserves literal quotes for array positionals"` passes its mocha assertions before hitting the repo's existing posttest/lint debt
- direct repro now yields `pos === "a b"` for string input and preserves `"a b"` for array input