### PR TITLE
Ignore defaulted version collisions

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2010,7 +2010,11 @@ export class YargsInstance {
     Object.keys(argv).forEach(key => {
       if (key === this.#helpOpt && argv[key]) {
         helpOptSet = true;
-      } else if (key === this.#versionOpt && argv[key]) {
+      } else if (
+        key === this.#versionOpt &&
+        argv[key] &&
+        !parsed.defaulted[key]
+      ) {
         versionOptSet = true;
       }
     });
@@ -2377,23 +2381,22 @@ export interface OptionDefinition {
   type?: 'array' | 'boolean' | 'count' | 'number' | 'string';
 }
 
-interface PositionalDefinition
-  extends Pick<
-    OptionDefinition,
-    | 'alias'
-    | 'array'
-    | 'coerce'
-    | 'choices'
-    | 'conflicts'
-    | 'default'
-    | 'defaultDescription'
-    | 'demand'
-    | 'desc'
-    | 'describe'
-    | 'description'
-    | 'implies'
-    | 'normalize'
-  > {
+interface PositionalDefinition extends Pick<
+  OptionDefinition,
+  | 'alias'
+  | 'array'
+  | 'coerce'
+  | 'choices'
+  | 'conflicts'
+  | 'default'
+  | 'defaultDescription'
+  | 'demand'
+  | 'desc'
+  | 'describe'
+  | 'description'
+  | 'implies'
+  | 'normalize'
+> {
   type?: 'boolean' | 'number' | 'string';
 }
 

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -1635,6 +1635,40 @@ describe('usage tests', () => {
 
         r.should.have.property('emittedWarnings').with.length(0);
       });
+
+      it('does not print the built-in version for a defaulted version option', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .option('version', {
+              type: 'string',
+              default: '0.0.1',
+              describe: 'Version string',
+            })
+            .parse()
+        );
+
+        r.result.version.should.equal('0.0.1');
+        r.logs.should.deep.equal([]);
+        r.exit.should.equal(false);
+        r.emittedWarnings.should.have.length(1);
+      });
+
+      it('does not print the built-in version for a defaulted version positional', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .command(
+              'install [version]',
+              'Install a thing',
+              yargs => yargs.positional('version', {default: 'hello'}),
+              argv => argv.version
+            )
+            .parse('install')
+        );
+
+        r.result.version.should.equal('hello');
+        r.logs.should.deep.equal([]);
+        r.exit.should.equal(false);
+      });
     });
 
     describe('when exitProcess is false', () => {
@@ -2882,7 +2916,8 @@ describe('usage tests', () => {
       const r = checkOutput(() =>
         yargs(['-h'])
           .help('h')
-          .default('f', function randomNumber() { // eslint-disable-line
+          .default('f', function randomNumber() {
+            // eslint-disable-line
             return Math.random() * 256;
           })
           .wrap(null)


### PR DESCRIPTION
## Summary
- stop treating parser-defaulted `version` values as if the user explicitly requested the built-in version output
- keep the reserved-word warning in place for colliding `version` option/positional names
- add regressions for both a defaulted `option("version")` and a defaulted `install [version]` positional

Closes #2199.

## Validation
- reproduced both `option("version", { default: ... })` and `command("install [version]")` printing the built-in version before the change
- `npm test -- --grep "defaulted version option|defaulted version positional"` passes the mocha assertions before the repo's pre-existing posttest/lint failures in unrelated files
- direct repro now leaves the built-in version silent while still emitting the reserved-word warning