### PR TITLE
fix: show-hidden breaks when parser has strip-dashed config

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -610,9 +610,14 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   }
 
   function filterHiddenOptions(key: string) {
+    const showHiddenOpt = yargs.getOptions().showHiddenOpt;
+    const argv = (yargs.parsed as DetailedArguments).argv;
+    const isStripDashed =
+      yargs.getInternalMethods().getParserConfiguration()['strip-dashed'];
     return (
       yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
-      (yargs.parsed as DetailedArguments).argv[yargs.getOptions().showHiddenOpt]
+      argv[showHiddenOpt] ||
+      (isStripDashed && argv[shim.Parser.camelCase(showHiddenOpt)])
     );
   }
 


### PR DESCRIPTION
When the parser configuration includes `'strip-dashed': true` (with default `'camel-case-expansion': true`), yargs-parser deletes all dashed keys from `argv`, leaving only their camelCase equivalents. This causes `filterHiddenOptions()` to fail because it looks up `argv[showHiddenOpt]` using the dashed key (e.g., `'show-hidden'`), which no longer exists in `argv`.

## Changes
- Modified `filterHiddenOptions()` in `lib/usage.ts` to fall back to the camelCase version of `showHiddenOpt` when `strip-dashed` is enabled
- Uses `shim.Parser.camelCase()` to convert the option name, consistent with how other parts of the codebase handle `strip-dashed` (see `validation.ts`)

## Why
Without this fix, users who enable `strip-dashed` lose the ability to show hidden options via `--show-hidden`, even though the option is correctly declared.

## Closes
Closes #2356
