### PR TITLE
fix: scriptName with whitespace breaks completion script

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -354,7 +354,11 @@ export class Completion implements CompletionInstance {
     // add ./ to applications not yet installed as bin.
     if ($0.match(/\.js$/)) $0 = `./${$0}`;
 
-    script = script.replace(/{{app_name}}/g, name);
+    // sanitize app name for use in bash/zsh function names
+    // replaces non-alphanumeric, non-underscore chars with '_'
+    const sanitizedName = name.replace(/[^a-zA-Z0-9_]/g, '_');
+
+    script = script.replace(/{{app_name}}/g, sanitizedName);
     script = script.replace(/{{completion_command}}/g, cmd);
     return script.replace(/{{app_path}}/g, $0);
   }


### PR DESCRIPTION
When `scriptName()` is called with a name containing whitespace (e.g., `"yarn whatever"`), the generated bash/zsh completion script replaces `{{app_name}}` directly into function names and the `complete` command. This produces invalid bash syntax such as `_yarn whatever_yargs_completions` as a function name.

## Changes
- Sanitize the app name before substituting into the completion templates
- Replace any non-alphanumeric, non-underscore characters with underscores
- The sanitized name is used in function names and the `complete` command, while the original is preserved for user-facing display

## Why
Completion scripts with whitespace in the script name are broken and fail to load in the shell.

## Closes
Closes #2387