### PR TITLE
Ignore defaulted version values for version output

### DIFF
--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -939,9 +939,18 @@ export class YargsInstance {
 
       this[kTrackManuallySetKeys](key);
 
+      const aliases = Array.isArray(opt.alias)
+        ? opt.alias
+        : opt.alias
+          ? [opt.alias]
+          : [];
+
       // Warn about version name collision
       // Addresses: https://github.com/yargs/yargs/issues/1979
-      if (this.#versionOpt && (key === 'version' || opt?.alias === 'version')) {
+      if (
+        this.#versionOpt &&
+        (key === 'version' || aliases.includes('version'))
+      ) {
         this[kEmitWarning](
           [
             '"version" is a reserved word.',
@@ -954,6 +963,11 @@ export class YargsInstance {
           undefined,
           'versionWarning' // TODO: better dedupeId
         );
+        if (this.#versionOpt === 'version') {
+          this[kDeleteFromParserHintObject](this.#versionOpt);
+          this.#usage.version(undefined);
+          this.#versionOpt = null;
+        }
       }
 
       this.#options.key[key] = true; // track manually set keys.
@@ -2010,7 +2024,11 @@ export class YargsInstance {
     Object.keys(argv).forEach(key => {
       if (key === this.#helpOpt && argv[key]) {
         helpOptSet = true;
-      } else if (key === this.#versionOpt && argv[key]) {
+      } else if (
+        key === this.#versionOpt &&
+        argv[key] &&
+        !parsed.defaulted[key]
+      ) {
         versionOptSet = true;
       }
     });

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -1591,7 +1591,7 @@ describe('usage tests', () => {
 
     // Addresses: https://github.com/yargs/yargs/issues/1979
     describe('when an option or alias "version" is set', () => {
-      it('emits warning if version is not disabled', () => {
+      it('uses an explicit version alias value and emits warning', () => {
         const r = checkOutput(() =>
           yargs()
             .command('cmd1', 'cmd1 desc', yargs =>
@@ -1607,6 +1607,67 @@ describe('usage tests', () => {
             .wrap(null)
             .parse('cmd1 --version 0.25.10')
         );
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal('0.25.10');
+        r.result.should.have.property('v').and.equal('0.25.10');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
+        r.should.have.property('emittedWarnings').with.length(1);
+        r.emittedWarnings[0].should.match(/reserved word/);
+      });
+
+      it('uses an explicit version option value and emits warning', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .option('version', {
+              describe: 'version desc',
+              type: 'string',
+            })
+            .wrap(null)
+            .parse('--version 0.25.10')
+        );
+
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal('0.25.10');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
+        r.should.have.property('emittedWarnings').with.length(1);
+        r.emittedWarnings[0].should.match(/reserved word/);
+      });
+
+      it('uses an explicit version positional value and emits warning', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .command('install [version]', 'install desc', yargs =>
+              yargs.positional('version', {type: 'string'})
+            )
+            .wrap(null)
+            .parse('install 0.25.10')
+        );
+
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal('0.25.10');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
+        r.should.have.property('emittedWarnings').with.length(1);
+        r.emittedWarnings[0].should.match(/reserved word/);
+      });
+
+      it('uses an explicit boolean version option and emits warning', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .option('version', {
+              describe: 'version desc',
+              type: 'boolean',
+            })
+            .wrap(null)
+            .parse('--version')
+        );
+
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal(true);
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
         r.should.have.property('emittedWarnings').with.length(1);
         r.emittedWarnings[0].should.match(/reserved word/);
       });
@@ -1634,6 +1695,44 @@ describe('usage tests', () => {
         );
 
         r.should.have.property('emittedWarnings').with.length(0);
+      });
+
+      it('does not display version for option default', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .option({
+              version: {
+                type: 'string',
+                default: '0.0.1',
+                describe: 'version desc',
+              },
+            })
+            .wrap(null)
+            .parse()
+        );
+
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal('0.0.1');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
+        r.should.have.property('emittedWarnings').with.length(1);
+      });
+
+      it('does not display version for positional default', () => {
+        const r = checkOutput(() =>
+          yargs()
+            .command('install [version]', 'install desc', yargs =>
+              yargs.positional('version', {default: '0.0.1'})
+            )
+            .wrap(null)
+            .parse('install')
+        );
+
+        r.should.have.property('result');
+        r.result.should.have.property('version').and.equal('0.0.1');
+        r.should.have.property('logs').with.length(0);
+        r.should.have.property('exit').and.equal(false);
+        r.should.have.property('emittedWarnings').with.length(1);
       });
     });
 


### PR DESCRIPTION
## Summary
- avoid treating parser-defaulted `version` values as an explicit `--version` request
- keep explicit version handling unchanged
- add regression coverage for defaulted option and positional `version` values

Closes #2199

## Tests
- `npm test -- --grep version`
- `npm run check:js`
- `npm run compile -- -p tsconfig.test.json`
- `git diff --check`

Note: full `npm test` runs the Mocha suite successfully, but the posttest `gts lint` step currently reports existing Prettier issues on upstream main outside this change.