### PR TITLE
fix: sanitize generated completion function names

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -5,7 +5,7 @@ export const completionShTemplate = `###-begin-{{app_name}}-completions-###
 # Installation: {{app_path}} {{completion_command}} >> ~/.bashrc
 #    or {{app_path}} {{completion_command}} >> ~/.bash_profile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{completion_function_name}}_yargs_completions()
 {
     local cur_word args type_list
 
@@ -25,7 +25,7 @@ _{{app_name}}_yargs_completions()
 
     return 0
 }
-complete -o bashdefault -o default -F _{{app_name}}_yargs_completions {{app_name}}
+complete -o bashdefault -o default -F _{{completion_function_name}}_yargs_completions {{app_name}}
 ###-end-{{app_name}}-completions-###
 `;
 
@@ -37,7 +37,7 @@ export const completionZshTemplate = `#compdef {{app_name}}
 # Installation: {{app_path}} {{completion_command}} >> ~/.zshrc
 #    or {{app_path}} {{completion_command}} >> ~/.zprofile on OSX.
 #
-_{{app_name}}_yargs_completions()
+_{{completion_function_name}}_yargs_completions()
 {
   local reply
   local si=$IFS
@@ -50,9 +50,9 @@ _{{app_name}}_yargs_completions()
   fi
 }
 if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
-  _{{app_name}}_yargs_completions "$@"
+  _{{completion_function_name}}_yargs_completions "$@"
 else
-  compdef _{{app_name}}_yargs_completions {{app_name}}
+  compdef _{{completion_function_name}}_yargs_completions {{app_name}}
 fi
 ###-end-{{app_name}}-completions-###
 `;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -355,6 +355,10 @@ export class Completion implements CompletionInstance {
     if ($0.match(/\.js$/)) $0 = `./${$0}`;
 
     script = script.replace(/{{app_name}}/g, name);
+    script = script.replace(
+      /{{completion_function_name}}/g,
+      sanitizeCompletionFunctionName(name)
+    );
     script = script.replace(/{{completion_command}}/g, cmd);
     return script.replace(/{{app_path}}/g, $0);
   }
@@ -413,4 +417,8 @@ function isFallbackCompletionFunction(
   completionFunction: CompletionFunction
 ): completionFunction is FallbackCompletionFunction {
   return completionFunction.length > 3;
+}
+
+function sanitizeCompletionFunctionName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_]/g, '_');
 }

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -622,6 +622,25 @@ describe('Completion', () => {
         /Installation: \/path\/to\/my\/app show-completions-script/
       );
     });
+
+    it('sanitizes application name for completion function names', () => {
+      process.env.SHELL = '/bin/bash';
+      const r = checkOutput(() =>
+        yargs([])
+          .scriptName('yarn whatever')
+          .completion()
+          .showCompletionScript()
+      );
+
+      r.logs[0].should.include('_yarn_whatever_yargs_completions()');
+      r.logs[0].should.include(
+        '-F _yarn_whatever_yargs_completions yarn whatever'
+      );
+      r.logs[0].should.include(
+        'yarn whatever --get-yargs-completions "${args[@]}"'
+      );
+      r.logs[0].should.not.include('_yarn whatever_yargs_completions');
+    });
   });
 
   describe('completion()', () => {


### PR DESCRIPTION
Sanitize the generated shell completion function name separately from the displayed application name. This keeps commands like `scriptName("yarn whatever")` from producing invalid shell function declarations while preserving the original app path used to request completions.

fixes #2387

Tests:
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npm run compile -- -p tsconfig.test.json && PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx mocha --enable-source-maps ./test/*.mjs --require ./test/before.mjs --timeout=24000 --check-leaks`
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx gts lint lib/completion.ts lib/completion-templates.ts`
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx eslint test/completion.mjs`