### PR TITLE
fix: complete negated boolean options by default

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -115,13 +115,17 @@ export class Completion implements CompletionInstance {
       !this.previousArgHasChoices(args)
     ) {
       const options = this.yargs.getOptions();
+      const descriptions = this.usage.getDescriptions();
       const positionalKeys =
         this.yargs.getGroups()[this.usage.getPositionalGroupName()] || [];
 
       Object.keys(options.key).forEach(key => {
         const negable =
-          !!options.configuration['boolean-negation'] &&
-          options.boolean.includes(key);
+          options.configuration['boolean-negation'] !== false &&
+          options.boolean.includes(key) &&
+          descriptions[key] !== this.usage.deferY18nLookup('Show help') &&
+          descriptions[key] !==
+            this.usage.deferY18nLookup('Show version number');
         const isPositionalKey = positionalKeys.includes(key);
 
         // If the key is not positional and its aliases aren't in 'args', add the key to 'completions'
@@ -130,12 +134,7 @@ export class Completion implements CompletionInstance {
           !options.hiddenOptions.includes(key) &&
           !this.argsContainKey(args, key, negable)
         ) {
-          this.completeOptionKey(
-            key,
-            completions,
-            current,
-            negable && !!options.default[key]
-          );
+          this.completeOptionKey(key, completions, current, negable);
         }
       });
     }

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -94,20 +94,18 @@ describe('Completion', () => {
           r.logs.should.not.include('-1');
         });
 
-        it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+        it('completes with no- prefix flags when boolean-negation is enabled by default', () => {
           const r = checkOutput(
             () =>
-              yargs([...firstArguments, './completion', ''])
-                .options({
-                  foo: {describe: 'foo flag', type: 'boolean', default: true},
-                  bar: {describe: 'bar flag', type: 'boolean'},
-                })
-                .parserConfiguration({'boolean-negation': true}).argv
+              yargs([...firstArguments, './completion', '']).options({
+                foo: {describe: 'foo flag', type: 'boolean', default: true},
+                bar: {describe: 'bar flag', type: 'boolean'},
+              }).argv
           );
 
           r.logs.should.include('--no-foo');
           r.logs.should.include('--foo');
-          r.logs.should.not.include('--no-bar');
+          r.logs.should.include('--no-bar');
           r.logs.should.include('--bar');
         });
 
@@ -136,18 +134,15 @@ describe('Completion', () => {
           r.logs.should.include('--baz');
         });
 
-        it('ignores no- prefix flags when boolean-negation is not set', () => {
+        it('ignores no- prefix flags when boolean-negation is disabled', () => {
           const r = checkOutput(
             () =>
-              yargs([
-                ...firstArguments,
-                './completion',
-                '--no-bar',
-                '',
-              ]).options({
-                foo: {describe: 'foo flag', type: 'boolean', default: true},
-                bar: {describe: 'bar flag', type: 'boolean'},
-              }).argv
+              yargs([...firstArguments, './completion', '--no-bar', ''])
+                .options({
+                  foo: {describe: 'foo flag', type: 'boolean', default: true},
+                  bar: {describe: 'bar flag', type: 'boolean'},
+                })
+                .parserConfiguration({'boolean-negation': false}).argv
           );
 
           r.logs.should.not.include('--no-foo');
@@ -192,6 +187,7 @@ describe('Completion', () => {
           r.logs
             .sort()
             .should.deep.eq([
+              '--no-somebool',
               '--no-somebool2',
               '--somebool',
               '--somebool2',
@@ -1135,17 +1131,15 @@ describe('Completion', () => {
       r.logs.should.include('--foo:bar');
     });
 
-    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+    it('completes with no- prefix flags when boolean-negation is enabled by default', () => {
       process.env.SHELL = '/bin/zsh';
 
       const r = checkOutput(
         () =>
-          yargs(['./completion', '--get-yargs-completions', '--'])
-            .options({
-              foo: {describe: 'foo flag', type: 'boolean', default: true},
-              bar: {describe: 'bar flag', type: 'boolean'},
-            })
-            .parserConfiguration({'boolean-negation': true}).argv
+          yargs(['./completion', '--get-yargs-completions', '--']).options({
+            foo: {describe: 'foo flag', type: 'boolean', default: true},
+            bar: {describe: 'bar flag', type: 'boolean'},
+          }).argv
       );
 
       r.logs.should.eql([
@@ -1154,6 +1148,7 @@ describe('Completion', () => {
         '--foo:foo flag',
         '--no-foo:foo flag',
         '--bar:bar flag',
+        '--no-bar:bar flag',
       ]);
     });
   });


### PR DESCRIPTION
Complete `--no-*` forms for boolean options whenever boolean negation is enabled, matching the parser default. This also removes the previous requirement that the option have a truthy default before its negated form appears in completion results.

Default `--help` and `--version` completions remain unchanged, so completion does not suggest `--no-help` or `--no-version`.

fixes #2254

Tests:
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npm run compile -- -p tsconfig.test.json && PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx mocha --enable-source-maps ./test/*.mjs --require ./test/before.mjs --timeout=24000 --check-leaks`
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx gts lint lib/completion.ts`
- `PATH=/Users/neo/.nvm/versions/node/v24.8.0/bin:$PATH npx eslint test/completion.mjs`