### PR TITLE
fix: handle halted args for command positionals

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -552,6 +552,16 @@ export class CommandInstance {
     const optional = commandHandler.optional.slice(0);
     const positionalMap: Dictionary<string[]> = {};
 
+    if (
+      yargs.getOptions().configuration['halt-at-non-option'] &&
+      argv._.length === 0 &&
+      Array.isArray(argv['--']) &&
+      argv['--'].length > 0
+    ) {
+      argv._ = argv['--'].slice();
+      delete argv['--'];
+    }
+
     this.validation.positionalCount(demanded.length, argv._.length);
 
     while (demanded.length) {

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -559,7 +559,9 @@ export class CommandInstance {
       argv['--'].length > 0
     ) {
       argv._ = argv['--'].slice();
-      delete argv['--'];
+      if (!yargs.getOptions().configuration['populate--']) {
+        delete argv['--'];
+      }
     }
 
     this.validation.positionalCount(demanded.length, argv._.length);

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -208,6 +208,35 @@ describe('Command', () => {
       called.should.equal(true);
     });
 
+    // see: https://github.com/yargs/yargs/issues/2423
+    it('counts halt-at-non-option arguments for default command positionals', () => {
+      let called = false;
+      const argv = yargs('my-host ls')
+        .usage(
+          '$0 <host> [cmd...]',
+          'Run command via ssh',
+          yargs =>
+            yargs
+              .positional('host', {type: 'string', demandOption: true})
+              .positional('cmd', {array: true, type: 'string'})
+              .option('verbose', {type: 'boolean', alias: 'v', count: true}),
+          argv2 => {
+            argv2.host.should.equal('my-host');
+            argv2.cmd.should.eql(['ls']);
+            called = true;
+          }
+        )
+        .strict()
+        .parserConfiguration({
+          'halt-at-non-option': true,
+        })
+        .parse();
+
+      argv.host.should.equal('my-host');
+      argv.cmd.should.eql(['ls']);
+      called.should.equal(true);
+    });
+
     // Addresses: https://github.com/yargs/yargs/issues/1637
     it('does not overwrite options in argv if variadic', () => {
       yargs()

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -237,6 +237,36 @@ describe('Command', () => {
       called.should.equal(true);
     });
 
+    it('preserves populate-- while counting halt-at-non-option default command positionals', () => {
+      let called = false;
+      const argv = yargs('my-host ls')
+        .usage(
+          '$0 <host> [cmd...]',
+          'Run command via ssh',
+          yargs =>
+            yargs
+              .positional('host', {type: 'string', demandOption: true})
+              .positional('cmd', {array: true, type: 'string'}),
+          argv2 => {
+            argv2.host.should.equal('my-host');
+            argv2.cmd.should.eql(['ls']);
+            argv2['--'].should.eql(['my-host', 'ls']);
+            called = true;
+          }
+        )
+        .strict()
+        .parserConfiguration({
+          'halt-at-non-option': true,
+          'populate--': true,
+        })
+        .parse();
+
+      argv.host.should.equal('my-host');
+      argv.cmd.should.eql(['ls']);
+      argv['--'].should.eql(['my-host', 'ls']);
+      called.should.equal(true);
+    });
+
     // Addresses: https://github.com/yargs/yargs/issues/1637
     it('does not overwrite options in argv if variadic', () => {
       yargs()


### PR DESCRIPTION
Fixes #2423.

When `halt-at-non-option` is enabled, yargs-parser stores the halted positional arguments under `--`. Command positional population currently validates and consumes only `argv._`, so default commands such as `$0 <host> [cmd...]` can fail with “got 0” even though the requested positionals were parsed under `--`.

This updates command positional population to use the halted `--` arguments when `halt-at-non-option` left `argv._` empty, then clears `--` after those values are consumed as command positionals. Existing explicit `--` / `populate--` behavior remains covered by the existing command tests.

The small type-definition formatting changes are from the repo's current Prettier version during `npm test` / `gts lint`.

Verification:

- `npx mocha --enable-source-maps ./test/command.mjs --require ./test/before.mjs --grep "halt-at-non-option arguments" --timeout=24000 --check-leaks`
- `npx mocha --enable-source-maps ./test/command.mjs --require ./test/before.mjs --timeout=24000 --check-leaks`
- `npm test`
