### PR TITLE
(Sry for ai, it just tried to fix something) 
fix(completion): sanitize scriptName for shell identifiers

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -350,11 +350,12 @@ export class Completion implements CompletionInstance {
       ? templates.completionZshTemplate
       : templates.completionShTemplate;
     const name = this.shim.path.basename($0);
+    const sanitizedName = name.replace(/[^a-zA-Z0-9_-]/g, '_');
 
     // add ./ to applications not yet installed as bin.
     if ($0.match(/\.js$/)) $0 = `./${$0}`;
 
-    script = script.replace(/{{app_name}}/g, name);
+    script = script.replace(/{{app_name}}/g, sanitizedName);
     script = script.replace(/{{completion_command}}/g, cmd);
     return script.replace(/{{app_path}}/g, $0);
   }


### PR DESCRIPTION
## Description

Fixes #2387

## Problem

When `scriptName()` contains a space (e.g. `scriptName("yarn whatever")`), the generated bash/zsh completion script produces invalid shell identifiers:

```bash
# Before (broken):
_yarn whatever_yargs_completions()    # <- space in function name
complete ... _yarn whatever_yargs_completions yarn whatever
```

## Fix

Sanitize the `app_name` used in shell function names and `complete` declarations by replacing characters that are not alphanumeric, underscore, or hyphen with underscores.

The `app_path` (used for actually invoking the application) remains unchanged, so `yarn whatever --get-yargs-completions` still works correctly.

```bash
# After (fixed):
_yarn_whatever_yargs_completions()    # <- space replaced with underscore
complete ... _yarn_whatever_yargs_completions yarn whatever
```

This is a one-line regex replacement in `generateCompletionScript()`.