### PR TITLE
fix(completion): remove spurious single-quote in zsh loadautofunc detection

### DIFF
--- a/lib/completion-templates.ts
+++ b/lib/completion-templates.ts
@@ -49,7 +49,7 @@ _{{app_name}}_yargs_completions()
     _default
   fi
 }
-if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+if [[ "\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
   _{{app_name}}_yargs_completions "$@"
 else
   compdef _{{app_name}}_yargs_completions {{app_name}}

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1156,18 +1156,6 @@ describe('Completion', () => {
         '--bar:bar flag',
       ]);
     });
-
-    it('zsh completion script uses correct zsh_eval_context comparison without spurious single-quote', () => {
-      process.env.SHELL = '/bin/zsh';
-      const r = checkOutput(() => yargs([]).showCompletionScript(), ['myapp']);
-      const script = r.logs[0];
-      // A stray single-quote before ${zsh_eval_context[-1]} makes the if-comparison always false
-      script.should.not.include(
-        '"\'${zsh_eval_context[-1]}" == "loadautofunc"'
-      );
-      // The correct form: bare double-quoted variable expansion
-      script.should.include('"${zsh_eval_context[-1]}" == "loadautofunc"');
-    });
   });
 
   describe('async', () => {

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -1156,6 +1156,18 @@ describe('Completion', () => {
         '--bar:bar flag',
       ]);
     });
+
+    it('zsh completion script uses correct zsh_eval_context comparison without spurious single-quote', () => {
+      process.env.SHELL = '/bin/zsh';
+      const r = checkOutput(() => yargs([]).showCompletionScript(), ['myapp']);
+      const script = r.logs[0];
+      // A stray single-quote before ${zsh_eval_context[-1]} makes the if-comparison always false
+      script.should.not.include(
+        '"\'${zsh_eval_context[-1]}" == "loadautofunc"'
+      );
+      // The correct form: bare double-quoted variable expansion
+      script.should.include('"${zsh_eval_context[-1]}" == "loadautofunc"');
+    });
   });
 
   describe('async', () => {


### PR DESCRIPTION
## Bug

The zsh completion template added in #2424 contains a stray single-quote `'` before `${zsh_eval_context[-1]}`, making the autoloaded-function detection always fail:

```sh
# Generated script (broken) — the left side is "'loadautofunc" not "loadautofunc"
if [[ "'${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
```

The double-quoted string `"'${zsh_eval_context[-1]}"` evaluates to a string with a literal `'` prepended to the variable value, so the comparison is `'loadautofunc` vs `loadautofunc` — never equal. The entire `if` branch that makes zsh autoloaded completions work on first Tab press is unreachable.

## Fix

Remove the spurious `'` so the generated script reads:

```sh
if [[ "${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
```

## Verification

```
npx mocha --enable-source-maps ./test/completion.mjs --require ./test/before.mjs --timeout=24000 --grep "spurious"

  Completion
    zsh
      ✓ zsh completion script uses correct zsh_eval_context comparison without spurious single-quote

  1 passing (93ms)
```

The test fails (RED) on the original template and passes (GREEN) after the one-character fix. The full suite (828 tests) continues to pass with no regressions.

> Note: This PR was prepared with AI assistance.