### PR TITLE
docs: fix broken links in api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1342,7 +1342,7 @@ Valid `opt` keys include:
 - `demandOption`: boolean or string, demand the option be given, with optional error message, see [`demandOption()`](#demandOption)
 - `deprecate`/`deprecated`: boolean or string, mark option as deprecated, see [`deprecateOption()`](#deprecateOption)
 - `desc`/`describe`/`description`: string, the option description for help content, see [`describe()`](#describe)
-- `global`: boolean, indicate that this key should not be [reset](#reset) when a command is invoked, see [`global()`](#global)
+- `global`: boolean, indicate that this key should not be [reset](#global) when a command is invoked, see [`global()`](#global)
 - `group`: string, when displaying usage instructions place the option under an alternative group heading, see [`group()`](#group)
 - `hidden`: don't display option in help output.
 - `implies`: string or array of strings, require certain keys to be set, see [`implies()`](#implies)
@@ -1747,7 +1747,7 @@ present script similar to how `$0` works in bash or perl.
 
 If the optional `desc`/`builder`/`handler` are provided, `.usage()`
 acts an an alias for [`.command()`](#command). This allows you to use
-`.usage()` to configure the [default command](/docs/advanced.md#default-commands) that will be run as an entry-point to your application and allows you
+`.usage()` to configure the [default command](https://github.com/yargs/yargs/blob/main/docs/advanced.md#default-commands) that will be run as an entry-point to your application and allows you
 to provide configuration for the positional arguments accepted by your program:
 
 ```js


### PR DESCRIPTION
Two links in `docs/api.md` are broken on the rendered docs site.

1. The `.usage()` section linked the default command docs as `/docs/advanced.md#default-commands`. yargs.js.org serves HTML, not the raw `.md` file, so that link 404s. Switched it to the same `blob/main` GitHub URL already used for this exact target earlier in the file (the `### Default Commands` heading in `advanced.md`). Fixes #1989.

2. In the `opt` keys list, the `global` entry linked `[reset](#reset)`. There is no `#reset` anchor (the old `.reset()` method was removed long ago), so the link goes nowhere. Repointed it to `#global`, which is the `.global()` section the same sentence already references.

Docs only, no code changes.
