### PR TITLE
fix: apply coerce on every parse of a reused instance

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -70,6 +70,13 @@ export class GlobalMiddleware {
   reset() {
     this.globalMiddleware = this.globalMiddleware.filter(m => m.global);
   }
+  // Reset the "applied" guard on mutating (coerce) middleware so they run
+  // again on the next top-level parse of a reused yargs instance.
+  resetApplied() {
+    for (const m of this.globalMiddleware) {
+      if (m.mutates) m.applied = false;
+    }
+  }
 }
 
 export function commandMiddlewareFactory(

--- a/lib/yargs-factory.ts
+++ b/lib/yargs-factory.ts
@@ -2024,6 +2024,7 @@ export class YargsInstance {
     // need to clear the cached help message from the previous parse:
     if (commandIndex === 0) {
       this.#usage.clearCachedHelpMessage();
+      this.#globalMiddleware.resetApplied();
     }
 
     try {

--- a/test/middleware.mjs
+++ b/test/middleware.mjs
@@ -859,4 +859,23 @@ describe('middleware', () => {
       );
     });
   });
+
+  describe('coerce on a reused instance', () => {
+    it('applies coerce on every parse of the same instance', () => {
+      let callCount = 0;
+      const y = yargs().coerce('bar', v => {
+        callCount++;
+        return 'C(' + v + ')';
+      });
+
+      const r1 = y.parse('--bar one');
+      const r2 = y.parse('--bar two');
+      const r3 = y.parse('--bar three');
+
+      r1.bar.should.equal('C(one)');
+      r2.bar.should.equal('C(two)');
+      r3.bar.should.equal('C(three)');
+      callCount.should.equal(3);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

A yargs instance is documented as reusable: you can call `.parse()` on the same instance multiple times. But when an option has a `coerce` function, the coercion only runs on the **first** `parse()`. Every parse after that returns the raw, un-coerced value.

```js
const y = yargs().coerce('bar', v => 'C(' + v + ')');

y.parse('--bar one').bar;   // 'C(one)'   correct
y.parse('--bar two').bar;   // 'two'      BUG: coerce skipped
y.parse('--bar three').bar; // 'three'    BUG: coerce skipped
```

## Root cause

Coerce is implemented as a "mutating" middleware. To avoid running it twice within a single parse (the nested-command case fixed in #1966), the middleware sets an `applied` flag the first time it runs and short-circuits on subsequent runs:

```ts
if (middleware.mutates) {
  if (middleware.applied) return acc;
  middleware.applied = true;
  ...
}
```

The flag was never reset between top-level `parse()` calls, so on the second parse the middleware saw `applied === true` and skipped coercion.

## Fix

Add `GlobalMiddleware.resetApplied()`, which clears the `applied` flag on mutating middleware, and call it at the start of a top-level parse only (`commandIndex === 0`) alongside the existing cached-help-message clearing.

Because the reset happens only at the top level, the `applied` guard is still active while a single parse walks into nested commands. The double-coerce fix from #1966 stays intact (verified: that test still passes).

## Test

Added a regression test in `test/middleware.mjs` that parses one instance three times with different `--bar` values and asserts coerce produces the coerced value every time and the coerce function is called exactly 3 times.

Verified red/green: the test fails on the current tree (second parse returns `'two'` instead of `'C(two)'`) and passes with the fix. Full suite stays green (828 passing), including the #1966 nested-command double-coerce test.
