### PR TITLE
fix: resolve show-hidden key via camelCase when strip-dashed is enabled

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -610,9 +610,12 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   }
 
   function filterHiddenOptions(key: string) {
+    const showHiddenOpt = yargs.getOptions().showHiddenOpt;
+    const argv = (yargs.parsed as DetailedArguments).argv;
     return (
       yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
-      (yargs.parsed as DetailedArguments).argv[yargs.getOptions().showHiddenOpt]
+      argv[showHiddenOpt] ||
+      argv[shim.Parser.camelCase(showHiddenOpt)]
     );
   }
 

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -4470,6 +4470,35 @@ describe('usage tests', () => {
           '  --custom-show-hidden  Show hidden options                            [boolean]',
         ]);
     });
+    // Refs: https://github.com/yargs/yargs/issues/2356
+    it('--help should display hidden options with --show-hidden when strip-dashed is enabled', () => {
+      const r = checkOutput(() =>
+        yargs('--help --show-hidden')
+          .options({
+            foo: {
+              describe: 'FOO',
+            },
+            bar: {},
+            baz: {
+              describe: 'BAZ',
+              hidden: true,
+            },
+          })
+          .parserConfiguration({'strip-dashed': true})
+          .parse()
+      );
+
+      r.logs[0]
+        .split('\n')
+        .should.deep.equal([
+          'Options:',
+          '  --help     Show help                                                 [boolean]',
+          '  --version  Show version number                                       [boolean]',
+          '  --foo      FOO',
+          '  --bar',
+          '  --baz      BAZ',
+        ]);
+    });
   });
 
   describe('help message caching', () => {


### PR DESCRIPTION
## Problem

When `parserConfiguration({ 'strip-dashed': true })` is set, `--show-hidden` silently does nothing. Hidden options do not appear in `--help` output even when `--show-hidden` is explicitly passed.

Minimal repro (from #2356):

```js
yargs(['--help', '--show-hidden'])
  .showHidden('show-hidden', 'Show hidden options')
  .option('foo', { describe: 'bar', type: 'string', hidden: true })
  .parserConfiguration({ 'strip-dashed': true })
  .parse();
// --foo never appears
```

## Root cause

`filterHiddenOptions` in `lib/usage.ts` checks `argv[showHiddenOpt]` where `showHiddenOpt` is the raw option name (e.g. `"show-hidden"`). With `strip-dashed: true`, yargs-parser removes dashed keys from parsed argv and only keeps camelCase variants (`"showHidden"`), so the lookup always returns `undefined`.

## Fix

After the direct lookup fails, also check `argv[shim.Parser.camelCase(showHiddenOpt)]`. The `camelCase` helper is already part of the `Parser` interface exposed on the shim. When `strip-dashed` is off the first lookup hits as before; when it is on the camelCase lookup finds the value.

Change is limited to three lines inside `filterHiddenOptions` in `lib/usage.ts`.

## Test

Added a regression test in `test/usage.mjs` inside the existing `hidden options` describe block:

```
✔ --help should display hidden options with --show-hidden when strip-dashed is enabled
```

Full suite: **821 passing, 0 failures**.

Fixes #2356