### PR TITLE
fix: do not cap command help column at half wrap() when no command has a description

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -519,6 +519,13 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   ) {
     let width = 0;
 
+    // the half-width cap below only makes sense when there is a right-hand
+    // (description) column to reserve space for. The array form carries that
+    // column in v[1]; the dict form (e.g. options) is rendered with separate
+    // descriptions, so always treat it as having a right-hand column.
+    const hasRightColumn =
+      !Array.isArray(table) || table.some(v => getText(v[1] ?? '') !== '');
+
     // table might be of the form [leftColumn],
     // or {key: leftColumn}
     if (!Array.isArray(table)) {
@@ -536,9 +543,10 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
       );
     });
 
-    // if we've enabled 'wrap' we should limit
-    // the max-width of the left-column.
-    if (theWrap)
+    // if we've enabled 'wrap' we should limit the max-width of the
+    // left-column, but only when there is a right-hand column to make
+    // room for; otherwise the left column may use the full width.
+    if (theWrap && hasRightColumn)
       width = Math.min(width, parseInt((theWrap * 0.5).toString(), 10));
 
     return width;

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -2282,6 +2282,31 @@ describe('usage tests', () => {
         ]);
     });
 
+    // See https://github.com/yargs/yargs/issues/2204
+    it('does not wrap command column at half of wrap() when no command has a description', () => {
+      const longCommand = 'deploy <region> <environment> <service-name>';
+
+      const help = checkOutput(() =>
+        yargs('--help').command(longCommand).wrap(80).parse()
+      );
+
+      // The command is 50 columns wide and fits comfortably within wrap(80);
+      // because there are no descriptions, the left column should be allowed
+      // to use the full width rather than being capped at half of wrap().
+      help.logs[0]
+        .split('\n')
+        .should.deep.equal([
+          'usage [command]',
+          '',
+          'Commands:',
+          '  usage deploy <region> <environment> <service-name>',
+          '',
+          'Options:',
+          '  --help     Show help                                                 [boolean]',
+          '  --version  Show version number                                       [boolean]',
+        ]);
+    });
+
     it('resets groups for a command handler, respecting order', () => {
       const r = checkOutput(() =>
         yargs(['upload', '-h'])


### PR DESCRIPTION
## Summary

Fixes #2204.

When rendering `--help`, the left-hand column of each help table is capped at half of the configured `wrap()` width so the right-hand description column has room. For the **Commands** table this cap was applied **even when none of the commands had a description**, so a long command usage string would wrap onto a second line at half width despite the full terminal width being free.

### Before
```
$ app --help   # .wrap(80), command has no description
Commands:
  app deploy <region> <environment>
  <service-name-x>
```

### After
```
$ app --help   # .wrap(80), command has no description
Commands:
  app deploy <region> <environment> <service-name-x>
```

## Root cause

`maxWidth()` in `lib/usage.ts` unconditionally ran:

```js
if (theWrap)
  width = Math.min(width, parseInt((theWrap * 0.5).toString(), 10));
```

The `* 0.5` cap only exists to leave room for a right-hand description column. The Commands table can have no descriptions at all, in which case there is no second column and the cap needlessly truncates the available width.

## Fix

`maxWidth()` now applies the half-width cap only when the table actually has a right-hand (description) column with content:

- The **array form** (Commands, Examples) carries its description in `v[1]`; the cap is skipped when every row's description is empty.
- The **dict form** (Options) is rendered with descriptions looked up separately, so it is always treated as having a right-hand column — its behaviour is unchanged.

This leaves Options/Examples rendering and the descriptioned-command layout untouched, and only restores the full width for the previously-broken case.

## Testing

- Added a regression test in `test/usage.mjs` (`does not wrap command column at half of wrap() when no command has a description`). It fails on `main` and passes with this change.
- Full suite green: `828 passing` (`npx mocha ./test/*.mjs --require ./test/before.mjs`).
- No new lint findings introduced by this change.


---
_Generated by [Claude Code](https://claude.ai/code)_