### PR TITLE
fix: replace every $1 in demandCommand min/max messages

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -44,7 +44,7 @@ export function validation(
             demandedCommands._.minMsg
               ? demandedCommands._.minMsg
                   .replace(/\$0/g, _s.toString())
-                  .replace(/\$1/, demandedCommands._.min.toString())
+                  .replace(/\$1/g, demandedCommands._.min.toString())
               : null
           );
         } else {
@@ -65,7 +65,7 @@ export function validation(
             demandedCommands._.maxMsg
               ? demandedCommands._.maxMsg
                   .replace(/\$0/g, _s.toString())
-                  .replace(/\$1/, demandedCommands._.max.toString())
+                  .replace(/\$1/g, demandedCommands._.max.toString())
               : null
           );
         } else {

--- a/test/validation.mjs
+++ b/test/validation.mjs
@@ -1226,6 +1226,16 @@ describe('validation tests', () => {
         .parse();
     });
 
+    it('replaces every $0 and $1 in a custom message', done => {
+      yargs('-a 10 marsupial mammal bro')
+        .demandCommand(1, 2, '', 'got $0 ($0), max $1 ($1)')
+        .fail(msg => {
+          msg.should.equal('got 3 (3), max 2 (2)');
+          return done();
+        })
+        .parse();
+    });
+
     it('defaults to demanding 1 command', done => {
       yargs('-a 10')
         .demandCommand()


### PR DESCRIPTION
The custom `minMsg`/`maxMsg` templating in `demandCommand` replaces `$0` with a global regex but `$1` without one, so only the first `$1` in a message is substituted and any later `$1` is left as a literal.

The docs say otherwise (docs/api.md): "every instance of `$1` will be replaced with the expected value". So the `$1` replace should be global to match `$0` and the documented behavior.

Before, with `'got $0 ($0), max $1 ($1)'`:
```
got 3 (3), max 2 ($1)
```
After:
```
got 3 (3), max 2 (2)
```

Changed both the min and max branches in `lib/validation.ts` and added a test covering repeated tokens. Full suite passes locally.