### PR TITLE
fix: resolve show-hidden option lookup when strip-dashed is enabled

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -610,9 +610,12 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   }
 
   function filterHiddenOptions(key: string) {
+    const showHiddenOpt = yargs.getOptions().showHiddenOpt;
+    const argv = (yargs.parsed as DetailedArguments).argv;
     return (
       yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
-      (yargs.parsed as DetailedArguments).argv[yargs.getOptions().showHiddenOpt]
+      argv[showHiddenOpt] ||
+      argv[shim.Parser.camelCase(showHiddenOpt)]
     );
   }
 

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -4470,6 +4470,36 @@ describe('usage tests', () => {
           '  --custom-show-hidden  Show hidden options                            [boolean]',
         ]);
     });
+    it('--show-hidden should display hidden options when strip-dashed is enabled', () => {
+      const r = checkOutput(() =>
+        yargs('--help --show-hidden')
+          .options({
+            foo: {
+              describe: 'FOO',
+            },
+            bar: {},
+            baz: {
+              describe: 'BAZ',
+              hidden: true,
+            },
+          })
+          .showHidden('show-hidden', 'Show hidden options')
+          .parserConfiguration({'strip-dashed': true})
+          .parse()
+      );
+
+      r.logs[0]
+        .split('\n')
+        .should.deep.equal([
+          'Options:',
+          '  --help         Show help                                             [boolean]',
+          '  --version      Show version number                                   [boolean]',
+          '  --foo          FOO',
+          '  --bar',
+          '  --baz          BAZ',
+          '  --show-hidden  Show hidden options                                   [boolean]',
+        ]);
+    });
   });
 
   describe('help message caching', () => {


### PR DESCRIPTION
## Problem

When `parserConfiguration({ 'strip-dashed': true })` is set, calling `--show-hidden` (or any custom name with dashes) in the CLI has no effect: hidden options are not displayed even though `--show-hidden` is explicitly passed.

Minimal reproduction from #2356:

```js
const yargs = require('yargs');

yargs(['--help', '--show-hidden'])
  .showHidden('show-hidden', 'Show hidden options')
  .options({ foo: { describe: 'bar', type: 'string', hidden: true } })
  .parserConfiguration({ 'strip-dashed': true })
  .parse();
// Expected: --foo appears in help output
// Actual:   --foo is hidden despite --show-hidden being passed
```

## Root cause

`filterHiddenOptions` in `lib/usage.ts` checks `argv[showHiddenOpt]` to determine if hidden options should be shown. When `strip-dashed` is enabled, yargs converts dashed option names to camelCase in the parsed `argv` object. So `argv['show-hidden']` is `undefined`, while `argv['showHidden']` is `true`. The lookup always returns undefined, so hidden options are never revealed.

## Fix

Check both the original option name and its camelCase equivalent in argv:

```ts
function filterHiddenOptions(key: string) {
  const showHiddenOpt = yargs.getOptions().showHiddenOpt;
  const argv = (yargs.parsed as DetailedArguments).argv;
  return (
    yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
    argv[showHiddenOpt] ||
    argv[shim.Parser.camelCase(showHiddenOpt)]
  );
}
```

## Testing

A new test case was added to `test/usage.mjs` covering `--show-hidden` with `strip-dashed` enabled. All 821 existing tests continue to pass.

Fixes #2356