### PR TITLE
fix: reveal hidden options with --show-hidden when strip-dashed is set

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -609,9 +609,14 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   }
 
   function filterHiddenOptions(key: string) {
+    const argv = (yargs.parsed as DetailedArguments).argv;
+    const showHiddenOpt = yargs.getOptions().showHiddenOpt;
+    // With `strip-dashed`, the dashed key is removed from argv, so also check
+    // the camel-cased form to detect whether --show-hidden was passed.
     return (
       yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
-      (yargs.parsed as DetailedArguments).argv[yargs.getOptions().showHiddenOpt]
+      argv[showHiddenOpt] ||
+      argv[shim.Parser.camelCase(showHiddenOpt)]
     );
   }
 

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -4376,6 +4376,22 @@ describe('usage tests', () => {
           '  --baz      BAZ',
         ]);
     });
+    // See https://github.com/yargs/yargs/issues/2356
+    it('--help should display hidden options with --show-hidden even when strip-dashed is set', () => {
+      const r = checkOutput(() =>
+        yargs('--help --show-hidden')
+          .options({
+            foo: {
+              describe: 'FOO',
+              hidden: true,
+            },
+          })
+          .parserConfiguration({'strip-dashed': true})
+          .parse()
+      );
+
+      r.logs[0].should.match(/--foo\s+FOO/);
+    });
     it('--help should display all groups (including ones with only hidden options) with --show-hidden', () => {
       const r = checkOutput(
         () =>


### PR DESCRIPTION
Fixes #2356.

`filterHiddenOptions` decided whether to reveal hidden options by reading `argv[showHiddenOpt]` — i.e. the dashed key (`show-hidden`). With `parserConfiguration({'strip-dashed': true})`, the dashed key is stripped from `argv` and only the camel-cased `showHidden` remains, so the lookup missed and `--help --show-hidden` no longer revealed hidden options.

This also checks the camel-cased form via `shim.Parser.camelCase(showHiddenOpt)`, so it works whether or not `strip-dashed` (or `camel-case-expansion`) is set.

Added a regression test in `test/usage.mjs`. Full `usage.mjs` suite (214) and `npm run check` (gts + eslint) pass.