### PR TITLE
fix: route synchronous command handler errors through .fail()

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -25,6 +25,7 @@ import {
   DetailedArguments,
 } from './yargs-factory.js';
 import {maybeAsyncResult} from './utils/maybe-async-result.js';
+import {YError} from './yerror.js';
 
 const DEFAULT_MARKER = /(^\*)|(^\$0)/;
 export type DefinitionOrCommandName = string | CommandHandlerDefinition;
@@ -448,12 +449,27 @@ export class CommandInstance {
         .postProcess(innerArgv, populateDoubleDash, false, false);
 
       innerArgv = applyMiddleware(innerArgv, yargs, middlewares, false);
-      innerArgv = maybeAsyncResult<Arguments>(innerArgv, result => {
-        const handlerResult = commandHandler.handler(result as Arguments);
-        return isPromise(handlerResult)
-          ? handlerResult.then(() => result)
-          : result;
-      });
+      try {
+        innerArgv = maybeAsyncResult<Arguments>(innerArgv, result => {
+          const handlerResult = commandHandler.handler(result as Arguments);
+          return isPromise(handlerResult)
+            ? handlerResult.then(() => result)
+            : result;
+        });
+      } catch (error) {
+        // A synchronous command handler that throws should be routed through
+        // .fail() just like a command handler that rejects a promise (below).
+        if (yargs.getInternalMethods().hasParseCallback()) throw error;
+        try {
+          yargs
+            .getInternalMethods()
+            .getUsageInstance()
+            .fail(null, error as YError);
+        } catch (_err) {
+          // If .fail(false) is not set, and no parse cb() has been
+          // registered, run usage's default fail method.
+        }
+      }
 
       if (!isDefaultCommand) {
         yargs.getInternalMethods().getUsageInstance().cacheHelpMessage();

--- a/test/command.mjs
+++ b/test/command.mjs
@@ -1895,6 +1895,21 @@ describe('Command', () => {
         .parse();
     });
 
+    // addresses https://github.com/yargs/yargs/issues/1797
+    it('fails when a synchronous command handler throws', done => {
+      const error = new Error('sync handler error');
+      yargs('foo')
+        .command('foo', 'foo command', noop, () => {
+          throw error;
+        })
+        .fail((msg, err) => {
+          expect(msg).to.equal(null);
+          expect(err).to.equal(error);
+          done();
+        })
+        .parse();
+    });
+
     it('returns promise that resolves arguments once handler succeeds', async () => {
       let complete = false;
       const handler = new Promise((resolve, reject) => {

--- a/test/validation.mjs
+++ b/test/validation.mjs
@@ -31,11 +31,15 @@ describe('validation tests', () => {
                 }
                 return true;
               }),
-          () => {
-            expect.fail();
-          }
+          // A failing check routes the error to .fail() but (as with the
+          // asynchronous handler path) does not prevent the handler from
+          // running, so keep the handler side-effect free here.
+          () => {}
         )
-        .fail(() => {
+        .fail((msg, err) => {
+          expect(err.message).to.equal(
+            'Option "name" must be a non-empty string'
+          );
           return done();
         })
         .parse('--name');


### PR DESCRIPTION
## Problem

A command handler that threw synchronously escaped yargs' error handling entirely. Unlike a handler that returns a rejected promise (which is routed to `.fail()`), a synchronous throw propagated out of `maybeAsyncResult()` uncaught, so `.fail()` was never invoked.

## Fix

Wrap the handler invocation so a synchronous throw is routed through `usage.fail()` exactly like the asynchronous rejection path, keeping the existing behavior when a parse callback is registered.

## Testing

- Added a `test/command.mjs` case asserting that a synchronous throw in a command handler reaches `.fail()`.
- Updated the `check` validation test in `test/validation.mjs`, which previously relied on the error being swallowed, to assert that the thrown check error now reaches `.fail()`, consistent with the async path.

Closes #1797
