### PR TITLE
docs: document command deprecated and middlewares

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -184,6 +184,11 @@ simply needs to export:
 * `exports.builder`: object declaring the options the command accepts, or a function accepting and returning a yargs instance
 * `exports.handler`: a function which will be passed the parsed argv.
 * `exports.deprecated`: a boolean (or string) to show deprecation notice.
+* `exports.middlewares`: an array of middleware functions applied only to this command.
+
+The same keys (`command`, `aliases`, `describe`/`desc`/`description`, `builder`,
+`handler`, `deprecated`, `middlewares`) can be passed to `.command({ ... })`
+instead of loading a module. See the [`.command()` API](./api.md#command).
 
 ```js
 // my-module.js

--- a/docs/api.md
+++ b/docs/api.md
@@ -264,8 +264,8 @@ to include the command; any falsy value to exclude/skip it.
 `exclude`: Block list certain modules. Either a regex or callback can be provided. Return `true` from the callback to skip the file.
 
 <a name="command"></a>
-.command(cmd, desc, [builder], [handler])
------------------------------------------
+.command(cmd, desc, [builder], [handler], [middlewares], [deprecated])
+----------------------------------------------------------------------
 .command(cmd, desc, [module])
 -----------------------------
 .command(module)
@@ -341,6 +341,53 @@ yargs()
   )
   .help()
   .parse(hideBin(process.argv))
+```
+
+You can also pass command-scoped middleware and mark a command as deprecated.
+When using positional arguments, provide an empty middleware array if you only
+need to set `deprecated`:
+
+```js
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+yargs()
+  .command('legacy', 'old command', {}, (argv) => {
+    console.log(argv)
+  }, [], true)
+  .help()
+  .parse(hideBin(process.argv))
+```
+
+The object form of `.command()` accepts the same fields (and is the recommended
+way to set them):
+
+* `command`: string (or array of strings) for the command and optional aliases
+* `aliases`: array of strings (or a single string) with additional aliases
+* `describe` / `desc` / `description`: description shown in help; use `false` for a hidden command
+* `builder`: options object, or a function that receives a `yargs` instance
+* `handler`: function executed with the parsed `argv`
+* `middlewares`: array of middleware functions for this command only (see [`.middleware()`](#middleware))
+* `deprecated`: boolean, or a string message, to show a `[deprecated]` notice in help
+
+```js
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+yargs()
+  .command({
+    command: 'legacy',
+    describe: 'old command',
+    deprecated: 'use modern instead',
+    handler: (argv) => {
+      console.log(argv)
+    }
+  })
+  .help()
+  .parse(hideBin(process.argv))
+```
+
+```
+Commands:
+  legacy  old command               [deprecated: use modern instead]
 ```
 
 ***Note:*** `.parse()` should only be used at the top level, not inside a command's builder function.


### PR DESCRIPTION
## Summary
- Document `.command()` positional `middlewares` and `deprecated` arguments in the API reference.
- Document the object-form fields (`deprecated`, `middlewares`, and related keys) with a short example.
- Note the same module exports keys in the advanced commands guide.

Fixes #2246.

## Test plan
- [ ] Confirm the new API examples match existing behavior (`deprecated: true` / string message in help).
- [ ] Skim docs/api.md and docs/advanced.md for wording consistency with nearby sections.