### PR TITLE
ci: publish with npm provenance

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write # to create release commit (google-github-actions/release-please-action)
       pull-requests: write # to create release PR (google-github-actions/release-please-action)
+      id-token: write # to publish with npm provenance
 
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +44,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Hi, and thanks for yargs.

yargs publishes from GitHub Actions already, so npm provenance is available for the cost of a flag — but the published tarballs carry none. The registry metadata has no `attestations` block:

```
$ curl -s https://registry.npmjs.org/yargs | jq '.versions[."dist-tags".latest].dist.attestations'
null
```

At roughly 234M downloads a week, yargs is a package almost nobody installs on purpose — it arrives underneath CLIs people already trust. Provenance is what lets a consumer check that the tarball was built by this workflow, from this repo, at that commit, rather than uploaded by someone holding an npm token.

The change is two lines:

```yaml
    permissions:
      contents: write # to create release commit (google-github-actions/release-please-action)
      pull-requests: write # to create release PR (google-github-actions/release-please-action)
      id-token: write # to publish with npm provenance
...
      - run: npm publish --provenance
```

`id-token: write` is additive — the existing two permissions are unchanged, and your `permissions: {}` default at the top stays as it is. Node 22 ships npm 10, so the CLI already supports `--provenance`.

**One thing I genuinely cannot verify from outside, and it is the reason to look before merging.** The publish step sets:

```yaml
          registry-url: 'https://external-dot-oss-automation.appspot.com/'
```

Provenance attestations are generated by the npm CLI and submitted alongside the publish, so this depends on that proxy passing the attestation through to npmjs.org rather than only forwarding the tarball. I have no way to test that from here. If it does not pass it through, the publish would likely fail rather than silently skip — which is better than the alternative, but still worth knowing before a release rides on it. You will know how that proxy behaves far better than I do, and if it is a problem this PR is simply the wrong shape and I am happy for it to be closed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I checked the registry metadata and the workflow myself.
