### PR TITLE
fix: show-hidden displays hidden options when strip-dashed is enabled

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -609,9 +609,12 @@ export function usage(yargs: YargsInstance, shim: PlatformShim) {
   }
 
   function filterHiddenOptions(key: string) {
+    if (yargs.getOptions().hiddenOptions.indexOf(key) < 0) return true;
+    const argv = (yargs.parsed as DetailedArguments).argv;
+    const showHiddenOpt = yargs.getOptions().showHiddenOpt;
     return (
-      yargs.getOptions().hiddenOptions.indexOf(key) < 0 ||
-      (yargs.parsed as DetailedArguments).argv[yargs.getOptions().showHiddenOpt]
+      argv[showHiddenOpt] ||
+      argv[shim.Parser.camelCase(showHiddenOpt)]
     );
   }
 

--- a/test/usage.mjs
+++ b/test/usage.mjs
@@ -4470,6 +4470,31 @@ describe('usage tests', () => {
           '  --custom-show-hidden  Show hidden options                            [boolean]',
         ]);
     });
+
+    it('--help --show-hidden should display hidden options when strip-dashed is enabled', () => {
+      const r = checkOutput(() =>
+        yargs('--help --show-hidden')
+          .options({
+            foo: {
+              describe: 'FOO',
+              hidden: true,
+            },
+          })
+          .showHidden('show-hidden', 'Show hidden options')
+          .parserConfiguration({'strip-dashed': true})
+          .parse()
+      );
+
+      r.logs[0]
+        .split('\n')
+        .should.deep.equal([
+          'Options:',
+          '  --help         Show help                                             [boolean]',
+          '  --version      Show version number                                   [boolean]',
+          '  --foo          FOO',
+          '  --show-hidden  Show hidden options                                   [boolean]',
+        ]);
+    });
   });
 
   describe('help message caching', () => {


### PR DESCRIPTION
Fixes #2356

## Problem

When `strip-dashed` parser configuration is enabled, `--show-hidden` does not reveal hidden options in `--help` output.

## Reproduction

```js
const yargs = require('yargs');
yargs()
  .help('help', 'help')
  .showHidden('show-hidden', 'Show hidden options')
  .options({ foo: { describe: 'bar', type: 'string', hidden: true } })
  .parserConfiguration({ 'strip-dashed': true })
  .parse(['--help', '--show-hidden']);
// Expected: --foo appears in output
// Actual: --foo is missing
```

## Root Cause

`filterHiddenOptions` in `lib/usage.ts` checks `argv[showHiddenOpt]` using the original kebab-case key (e.g. `show-hidden`). When `strip-dashed` is enabled, yargs-parser stores parsed values under camelCase keys (`showHidden`), so the lookup always returns `undefined`.

## Fix

Also check `argv[shim.Parser.camelCase(showHiddenOpt)]` so the flag is found regardless of `strip-dashed` configuration. This is the same pattern used in `lib/validation.ts` for conflict checking with `strip-dashed`.

## Compatibility

Minimal, non-breaking change. Only affects the `filterHiddenOptions` lookup path. All 833 existing tests pass. Lint (`gts lint`) has a pre-existing failure on Node v24 due to `@babel/eslint-parser` compatibility — unrelated to this change.

## Validation

- New regression test: `--help --show-hidden should display hidden options when strip-dashed is enabled`
- Full test suite: 833 passing

Note: yargs uses Conventional Commits and has a CLA requirement.