### PR TITLE
fix: complete negated boolean options

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -124,7 +124,7 @@ export class Completion implements CompletionInstance {
 
       Object.keys(options.key).forEach(key => {
         const negable =
-          !!options.configuration['boolean-negation'] &&
+          options.configuration['boolean-negation'] !== false &&
           options.boolean.includes(key);
         const isPositionalKey = positionalKeys.includes(key);
 
@@ -134,12 +134,7 @@ export class Completion implements CompletionInstance {
           !options.hiddenOptions.includes(key) &&
           !this.argsContainKey(args, key, negable)
         ) {
-          this.completeOptionKey(
-            key,
-            completions,
-            current,
-            negable && !!options.default[key]
-          );
+          this.completeOptionKey(key, completions, current, negable);
         }
       });
     }

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -94,20 +94,18 @@ describe('Completion', () => {
           r.logs.should.not.include('-1');
         });
 
-        it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+        it('completes boolean options with no- prefix flags by default', () => {
           const r = checkOutput(
             () =>
-              yargs([...firstArguments, './completion', ''])
-                .options({
-                  foo: {describe: 'foo flag', type: 'boolean', default: true},
-                  bar: {describe: 'bar flag', type: 'boolean'},
-                })
-                .parserConfiguration({'boolean-negation': true}).argv
+              yargs([...firstArguments, './completion', '']).options({
+                foo: {describe: 'foo flag', type: 'boolean', default: true},
+                bar: {describe: 'bar flag', type: 'boolean'},
+              }).argv
           );
 
           r.logs.should.include('--no-foo');
           r.logs.should.include('--foo');
-          r.logs.should.not.include('--no-bar');
+          r.logs.should.include('--no-bar');
           r.logs.should.include('--bar');
         });
 
@@ -133,21 +131,19 @@ describe('Completion', () => {
           r.logs.should.not.include('--foo');
           r.logs.should.not.include('--no-bar');
           r.logs.should.not.include('--bar');
+          r.logs.should.include('--no-baz');
           r.logs.should.include('--baz');
         });
 
-        it('ignores no- prefix flags when boolean-negation is not set', () => {
+        it('ignores no- prefix flags when boolean-negation is disabled', () => {
           const r = checkOutput(
             () =>
-              yargs([
-                ...firstArguments,
-                './completion',
-                '--no-bar',
-                '',
-              ]).options({
-                foo: {describe: 'foo flag', type: 'boolean', default: true},
-                bar: {describe: 'bar flag', type: 'boolean'},
-              }).argv
+              yargs([...firstArguments, './completion', '--no-bar', ''])
+                .options({
+                  foo: {describe: 'foo flag', type: 'boolean', default: true},
+                  bar: {describe: 'bar flag', type: 'boolean'},
+                })
+                .parserConfiguration({'boolean-negation': false}).argv
           );
 
           r.logs.should.not.include('--no-foo');
@@ -192,6 +188,7 @@ describe('Completion', () => {
           r.logs
             .sort()
             .should.deep.eq([
+              '--no-somebool',
               '--no-somebool2',
               '--somebool',
               '--somebool2',
@@ -878,9 +875,10 @@ describe('Completion', () => {
             .completion().argv
       );
 
-      r.logs.should.have.length(2);
+      r.logs.should.have.length(3);
       r.logs.should.include('--bar');
       r.logs.should.include('--help');
+      r.logs.should.include('--no-help');
     });
 
     it('does not complete hidden options for command', () => {
@@ -905,10 +903,11 @@ describe('Completion', () => {
             .completion().argv
       );
 
-      r.logs.should.have.length(2);
+      r.logs.should.have.length(3);
       r.logs.should.include('--bar');
       r.logs.should.not.include('--buz');
       r.logs.should.include('--help');
+      r.logs.should.include('--no-help');
     });
 
     describe('generateCompletionScript()', () => {
@@ -1046,9 +1045,10 @@ describe('Completion', () => {
             .completion().argv
       );
 
-      r.logs.should.have.length(2);
+      r.logs.should.have.length(3);
       r.logs.should.include('--bar:bar option');
       r.logs.should.include('--help:Show help');
+      r.logs.should.include('--no-help:Show help');
     });
 
     it('completes options and aliases with the same description', () => {
@@ -1135,7 +1135,7 @@ describe('Completion', () => {
       r.logs.should.include('--foo:bar');
     });
 
-    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+    it('completes boolean options with no- prefix flags', () => {
       process.env.SHELL = '/bin/zsh';
 
       const r = checkOutput(
@@ -1150,10 +1150,13 @@ describe('Completion', () => {
 
       r.logs.should.eql([
         '--help:Show help',
+        '--no-help:Show help',
         '--version:Show version number',
+        '--no-version:Show version number',
         '--foo:foo flag',
         '--no-foo:foo flag',
         '--bar:bar flag',
+        '--no-bar:bar flag',
       ]);
     });
   });
@@ -1229,9 +1232,10 @@ describe('Completion', () => {
             .completion().argv
       );
 
-      r.logs.should.have.length(2);
+      r.logs.should.have.length(3);
       r.logs.should.include('--bar\tbar option');
       r.logs.should.include('--help\tShow help');
+      r.logs.should.include('--no-help\tShow help');
     });
 
     it('completes options and aliases with the same description', () => {
@@ -1318,7 +1322,7 @@ describe('Completion', () => {
       r.logs.should.include('--foo\tbar');
     });
 
-    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+    it('completes boolean options with no- prefix flags', () => {
       process.env.SHELL = '/usr/bin/fish';
 
       const r = checkOutput(
@@ -1333,10 +1337,13 @@ describe('Completion', () => {
 
       r.logs.should.eql([
         '--help\tShow help',
+        '--no-help\tShow help',
         '--version\tShow version number',
+        '--no-version\tShow version number',
         '--foo\tfoo flag',
         '--no-foo\tfoo flag',
         '--bar\tbar flag',
+        '--no-bar\tbar flag',
       ]);
     });
 


### PR DESCRIPTION
## Summary
  - generate positive and negated completions for boolean options
  - respect explicitly disabled boolean negation
  - add Bash, Zsh, and Fish regression coverage

  Fixes #2254

  ## Testing
  - npm test