### PR TITLE
fix: complete negated boolean options

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -123,23 +123,21 @@ export class Completion implements CompletionInstance {
         this.yargs.getGroups()[this.usage.getPositionalGroupName()] || [];
 
       Object.keys(options.key).forEach(key => {
-        const negable =
-          !!options.configuration['boolean-negation'] &&
-          options.boolean.includes(key);
+        const booleanNegation = options.configuration['boolean-negation'];
+        const canNegate =
+          booleanNegation !== false && options.boolean.includes(key);
+        const completeNegated =
+          canNegate &&
+          (booleanNegation === true || current.startsWith('--no-'));
         const isPositionalKey = positionalKeys.includes(key);
 
         // If the key is not positional and its aliases aren't in 'args', add the key to 'completions'
         if (
           !isPositionalKey &&
           !options.hiddenOptions.includes(key) &&
-          !this.argsContainKey(args, key, negable)
+          !this.argsContainKey(args, key, canNegate)
         ) {
-          this.completeOptionKey(
-            key,
-            completions,
-            current,
-            negable && !!options.default[key]
-          );
+          this.completeOptionKey(key, completions, current, completeNegated);
         }
       });
     }
@@ -290,7 +288,9 @@ export class Completion implements CompletionInstance {
     const dashes =
       !startsByTwoDashes(current) && isShortOption(key) ? '-' : '--';
 
-    completions.push(dashes + keyWithDesc);
+    if (!current.startsWith('--no-')) {
+      completions.push(dashes + keyWithDesc);
+    }
     if (negable) {
       completions.push(dashes + 'no-' + keyWithDesc);
     }

--- a/test/completion.mjs
+++ b/test/completion.mjs
@@ -94,21 +94,32 @@ describe('Completion', () => {
           r.logs.should.not.include('-1');
         });
 
-        it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
-          const r = checkOutput(
+        it('completes no- prefix flags after the prefix by default', () => {
+          const regular = checkOutput(
             () =>
-              yargs([...firstArguments, './completion', ''])
-                .options({
-                  foo: {describe: 'foo flag', type: 'boolean', default: true},
-                  bar: {describe: 'bar flag', type: 'boolean'},
-                })
-                .parserConfiguration({'boolean-negation': true}).argv
+              yargs([...firstArguments, './completion', '--']).options({
+                foo: {describe: 'foo flag', type: 'boolean', default: true},
+                bar: {describe: 'bar flag', type: 'boolean'},
+              }).argv
           );
 
-          r.logs.should.include('--no-foo');
-          r.logs.should.include('--foo');
-          r.logs.should.not.include('--no-bar');
-          r.logs.should.include('--bar');
+          regular.logs.should.include('--foo');
+          regular.logs.should.include('--bar');
+          regular.logs.should.not.include('--no-foo');
+          regular.logs.should.not.include('--no-bar');
+
+          const negated = checkOutput(
+            () =>
+              yargs([...firstArguments, './completion', '--no-']).options({
+                foo: {describe: 'foo flag', type: 'boolean', default: true},
+                bar: {describe: 'bar flag', type: 'boolean'},
+              }).argv
+          );
+
+          negated.logs.should.include('--no-foo');
+          negated.logs.should.include('--no-bar');
+          negated.logs.should.not.include('--foo');
+          negated.logs.should.not.include('--bar');
         });
 
         it('avoids repeating flags whose negated counterparts are already included', () => {
@@ -133,21 +144,19 @@ describe('Completion', () => {
           r.logs.should.not.include('--foo');
           r.logs.should.not.include('--no-bar');
           r.logs.should.not.include('--bar');
+          r.logs.should.include('--no-baz');
           r.logs.should.include('--baz');
         });
 
-        it('ignores no- prefix flags when boolean-negation is not set', () => {
+        it('ignores no- prefix flags when boolean-negation is disabled', () => {
           const r = checkOutput(
             () =>
-              yargs([
-                ...firstArguments,
-                './completion',
-                '--no-bar',
-                '',
-              ]).options({
-                foo: {describe: 'foo flag', type: 'boolean', default: true},
-                bar: {describe: 'bar flag', type: 'boolean'},
-              }).argv
+              yargs([...firstArguments, './completion', '--no-bar', ''])
+                .options({
+                  foo: {describe: 'foo flag', type: 'boolean', default: true},
+                  bar: {describe: 'bar flag', type: 'boolean'},
+                })
+                .parserConfiguration({'boolean-negation': false}).argv
           );
 
           r.logs.should.not.include('--no-foo');
@@ -192,6 +201,7 @@ describe('Completion', () => {
           r.logs
             .sort()
             .should.deep.eq([
+              '--no-somebool',
               '--no-somebool2',
               '--somebool',
               '--somebool2',
@@ -1135,7 +1145,7 @@ describe('Completion', () => {
       r.logs.should.include('--foo:bar');
     });
 
-    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+    it('completes boolean options with no- prefix flags', () => {
       process.env.SHELL = '/bin/zsh';
 
       const r = checkOutput(
@@ -1150,10 +1160,13 @@ describe('Completion', () => {
 
       r.logs.should.eql([
         '--help:Show help',
+        '--no-help:Show help',
         '--version:Show version number',
+        '--no-version:Show version number',
         '--foo:foo flag',
         '--no-foo:foo flag',
         '--bar:bar flag',
+        '--no-bar:bar flag',
       ]);
     });
   });
@@ -1318,7 +1331,7 @@ describe('Completion', () => {
       r.logs.should.include('--foo\tbar');
     });
 
-    it('completes with no- prefix flags defaulting to true when boolean-negation is set', () => {
+    it('completes boolean options with no- prefix flags', () => {
       process.env.SHELL = '/usr/bin/fish';
 
       const r = checkOutput(
@@ -1333,10 +1346,13 @@ describe('Completion', () => {
 
       r.logs.should.eql([
         '--help\tShow help',
+        '--no-help\tShow help',
         '--version\tShow version number',
+        '--no-version\tShow version number',
         '--foo\tfoo flag',
         '--no-foo\tfoo flag',
         '--bar\tbar flag',
+        '--no-bar\tbar flag',
       ]);
     });
 


### PR DESCRIPTION
Fixes #2254

  By default, offer negated boolean completions once the current completion prefix starts with `--no-`, without adding every `--no-*` variant to the normal option list.

  Explicit `boolean-negation: true` remains an opt-in to the full positive/negative list, while `false` disables negated completions. Adds coverage for the default, enabled, and disabled behavior across Bash, Zsh, and
  Fish.