### PR TITLE
fix: do not surface hidden options in implications error (#2540)

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -349,12 +349,22 @@ export function validation(
 
   self.implications = function implications(argv) {
     const implyFail: string[] = [];
+    const options = yargs.getOptions();
 
     Object.keys(implied).forEach(key => {
       const origKey = key;
       (implied[key] || []).forEach(value => {
-        let key = origKey;
         const origValue = value;
+        // Hidden options are internal and must not be surfaced in
+        // user-facing validation errors (see #2540).
+        if (
+          options.hiddenOptions.includes(origKey) ||
+          (typeof origValue === 'string' &&
+            options.hiddenOptions.includes(origValue))
+        ) {
+          return;
+        }
+        let key = origKey;
         key = keyExists(argv, key);
         value = keyExists(argv, value);
 

--- a/test/validation.mjs
+++ b/test/validation.mjs
@@ -262,6 +262,21 @@ describe('validation tests', () => {
         })
         .parse();
     });
+    it('does not surface hidden options in implications error (#2540)', done => {
+      let leaked = false;
+      yargs(['--remote-debugging-port', '9222'])
+        .option('hidden-debug', {type: 'boolean', hidden: true})
+        .option('remote-debugging-port', {hidden: true})
+        .implies('remote-debugging-port', 'hidden-debug')
+        .fail(msg => {
+          if (/hidden-debug|remote-debugging-port/.test(msg)) leaked = true;
+        })
+        .parse();
+      // The implication involves only hidden options, so no user-facing
+      // error should be raised and the hidden names must not leak.
+      expect(leaked).to.equal(false);
+      done();
+    });
   });
 
   describe('conflicts', () => {


### PR DESCRIPTION
## Summary
`yargs.implications()` (used by `.implies()`) currently includes the names of **hidden** options in its "Implications failed" error. Hidden options are marked `hidden: true` precisely so they stay out of user-facing output (help, completion), so leaking their names in a validation error is a bug. Reported in #2540.

## Reproduction
```js
yargs(['--remote-debugging-port', '9222'])
  .option('hidden-debug', {type: 'boolean', hidden: true})
  .option('remote-debugging-port', {hidden: true})
  .implies('remote-debugging-port', 'hidden-debug')
  .parse();
```
Before this change, the failure message was:
```
Implications failed:
 remote-debugging-port -> hidden-debug
```
disclosing both internal option names.

## Fix
In `lib/validation.ts`, `self.implications()` now skips any implication where either the key or the value is a hidden option, using the same `yargs.getOptions().hiddenOptions` source of truth that help and completion already use. Hidden options are internal, so they should not produce (or appear in) user-facing validation errors.

## Test
Added a regression test in `test/validation.mjs` asserting that an implication involving only hidden options does not surface their names (and raises no error).

`npm test` passes — 833 passing, lint clean.
